### PR TITLE
meta: update atime in inode get operation

### DIFF
--- a/metanode/partition_fsmop_inode.go
+++ b/metanode/partition_fsmop_inode.go
@@ -71,6 +71,11 @@ func (mp *metaPartition) getInode(ino *Inode) (resp *InodeResponse) {
 		resp.Status = proto.OpNotExistErr
 		return
 	}
+	/*
+	 * FIXME: not protected by lock yet, since nothing is depending on atime.
+	 * Shall add inode lock in the future.
+	 */
+	i.AccessTime = Now.GetCurrentTime().Unix()
 	resp.Msg = i
 	return
 }


### PR DESCRIPTION
Update atime in inode get operation, so that temporary file validation
can be extended.

A temporary file is defined as file which is created and removed
immediately by a process, and only the one who is holding the file
descriptor can manipulate the file. However, metanode has difficulties
telling whether a zero-nlink inode is orphan or some user is still holding
the fd. In order to eliminate dirty orphan inode, there is a mechanism to
evict expired zero-nlink inode.

This patch avoids the wrong eviction of read-only temporary files.

Signed-off-by: Shuoran Liu <shuoranliu@gmail.com>