### PR TITLE
fix: potential panic if send returns nil resp and no error

### DIFF
--- a/sdk/meta/conn.go
+++ b/sdk/meta/conn.go
@@ -73,6 +73,7 @@ func (mw *MetaWrapper) sendToMetaPartition(mp *MetaPartition, req *proto.Packet)
 
 	addr = mp.LeaderAddr
 	if addr == "" {
+		err = errors.New(fmt.Sprintf("sendToMetaPartition failed: leader addr empty, req(%v) mp(%v)", req, mp))
 		goto retry
 	}
 	mc, err = mw.getConn(mp.PartitionID, addr)
@@ -110,8 +111,8 @@ retry:
 	}
 
 out:
-	if err != nil {
-		return nil, errors.New(fmt.Sprintf("sendToMetaPartition faild: req(%v) mp(%v)", req, mp))
+	if err != nil || resp == nil {
+		return nil, errors.New(fmt.Sprintf("sendToMetaPartition failed: req(%v) mp(%v) err(%v) resp(%v)", req, mp, err, resp))
 	}
 	log.LogDebugf("sendToMetaPartition successful: req(%v) mc(%v) resp(%v)", req, mc, resp)
 	return resp, nil


### PR DESCRIPTION
It is unacceptable for sendToMetaPatition to return nil resp packet and
no error, which may lead to callers to panic.

Signed-off-by: Shuoran Liu <shuoranliu@gmail.com>