### PR TITLE
data sdk: use ip addressto rule out unavailadata partitions

### DIFF
--- a/sdk/data/wrapper/data_partition.go
+++ b/sdk/data/wrapper/data_partition.go
@@ -64,9 +64,9 @@ func (dp *DataPartition) GetAllAddrs() string {
 	return strings.Join(dp.Hosts[1:], proto.AddrSplit) + proto.AddrSplit
 }
 
-func isExcluded(partitionId uint64, excludes []uint64) bool {
-	for _, id := range excludes {
-		if id == partitionId {
+func isExcluded(dp *DataPartition, exclude map[string]struct{}) bool {
+	for _, host := range dp.Hosts {
+		if _, exist := exclude[host]; exist {
 			return true
 		}
 	}

--- a/sdk/data/wrapper/wrapper.go
+++ b/sdk/data/wrapper/wrapper.go
@@ -172,7 +172,7 @@ func (w *Wrapper) replaceOrInsertPartition(dp *DataPartition) {
 	}
 }
 
-func (w *Wrapper) getRandomDataPartition(partitions []*DataPartition, exclude []uint64) *DataPartition {
+func (w *Wrapper) getRandomDataPartition(partitions []*DataPartition, exclude map[string]struct{}) *DataPartition {
 	var dp *DataPartition
 
 	if len(partitions) == 0 {
@@ -182,19 +182,19 @@ func (w *Wrapper) getRandomDataPartition(partitions []*DataPartition, exclude []
 	rand.Seed(time.Now().UnixNano())
 	index := rand.Intn(len(partitions))
 	dp = partitions[index]
-	if !isExcluded(dp.PartitionID, exclude) {
+	if !isExcluded(dp, exclude) {
 		return dp
 	}
 
 	for _, dp = range partitions {
-		if !isExcluded(dp.PartitionID, exclude) {
+		if !isExcluded(dp, exclude) {
 			return dp
 		}
 	}
 	return nil
 }
 
-func (w *Wrapper) getLocalLeaderDataPartition(exclude []uint64) *DataPartition {
+func (w *Wrapper) getLocalLeaderDataPartition(exclude map[string]struct{}) *DataPartition {
 	w.RLock()
 	localLeaderPartitions := w.localLeaderPartitions
 	w.RUnlock()
@@ -202,7 +202,7 @@ func (w *Wrapper) getLocalLeaderDataPartition(exclude []uint64) *DataPartition {
 }
 
 // GetDataPartitionForWrite returns an available data partition for write.
-func (w *Wrapper) GetDataPartitionForWrite(exclude []uint64) (*DataPartition, error) {
+func (w *Wrapper) GetDataPartitionForWrite(exclude map[string]struct{}) (*DataPartition, error) {
 	dp := w.getLocalLeaderDataPartition(exclude)
 	if dp != nil {
 		return dp, nil


### PR DESCRIPTION
use ip address instead of partition id to rule out unavailable data partitions

In sequential write protocol, a write is considered successful only if
all of the partition members reply success. So using ip address instead
of partition id to rule out unavailable data partitions would be more
appropriate, i.e. any member in a data partition should not be in the
exclude list.

Signed-off-by: Shuoran Liu <shuoranliu@gmail.com>