### PR TITLE
metanode: fix create dentry exist error

### DIFF
--- a/metanode/partition_fsmop_dentry.go
+++ b/metanode/partition_fsmop_dentry.go
@@ -15,6 +15,8 @@
 package metanode
 
 import (
+	"strings"
+
 	"github.com/chubaofs/chubaofs/proto"
 )
 
@@ -51,13 +53,19 @@ func (mp *metaPartition) fsmCreateDentry(dentry *Dentry,
 		}
 	}
 	if item, ok := mp.dentryTree.ReplaceOrInsert(dentry, false); !ok {
-		status = proto.OpExistErr
 		//do not allow directories and files to overwrite each
 		// other when renaming
 		d := item.(*Dentry)
 		if dentry.Type != d.Type {
 			status = proto.OpArgMismatchErr
+			return
 		}
+
+		if dentry.ParentId == d.ParentId && strings.Compare(dentry.Name, d.Name) == 0 && dentry.Inode == d.Inode {
+			return
+		}
+
+		status = proto.OpExistErr
 	} else {
 		if !forceUpdate {
 			parIno.IncNLink()


### PR DESCRIPTION
In the following scenario,

-> client issues a create dentry request to metanode;
-> meta node receives the request and applies the raft log;
-> meta node gets killed before sending a response to client;
-> client get a EOF error and retries to the new raft leader;
-> the new meta raft leader send a dentry exist error to client;

This error happens if create dentry request is applied but metanode is
not managed to response to client.

So if the create dentry request has the same parent inode id, name and
inode id, then we can treat it as successful.

Signed-off-by: Shuoran Liu <shuoranliu@gmail.com>