### PR TITLE
util: increase request timeout to master

### DIFF
--- a/util/master_helper.go
+++ b/util/master_helper.go
@@ -27,6 +27,10 @@ import (
 	"time"
 )
 
+const (
+	requestTimeout = 30 * time.Second
+)
+
 var (
 	ErrNoValidMaster = errors.New("no valid master")
 )
@@ -158,7 +162,7 @@ func (helper *masterHelper) prepareRequest() (addr string, nodes []string) {
 func (helper *masterHelper) httpRequest(method, url string, param map[string]string, reqData []byte) (resp *http.Response, err error) {
 	client := &http.Client{}
 	reader := bytes.NewReader(reqData)
-	client.Timeout = time.Second * 3
+	client.Timeout = requestTimeout
 	var req *http.Request
 	fullUrl := helper.mergeRequestUrl(url, param)
 	log.LogDebugf("action[httpRequest] method[%v] url[%v] reqBodyLen[%v].", method, fullUrl, len(reqData))


### PR DESCRIPTION
When the amount of partitions are very large, some requests to master
such as obtaining all partitions info may take several seconds to
complete. So increase timeout for now and will optimize master later.

Signed-off-by: Shuoran Liu <shuoranliu@gmail.com>