### PR TITLE
data sdk: check amount of writable data partitions when mount

### DIFF
--- a/sdk/data/wrapper/wrapper.go
+++ b/sdk/data/wrapper/wrapper.go
@@ -143,10 +143,12 @@ func (w *Wrapper) updateDataPartition() error {
 	if len(rwPartitionGroups) > 0 {
 		w.rwPartition = rwPartitionGroups
 		w.localLeaderPartitions = localLeaderPartitionGroups
+	} else {
+		err = errors.New("updateDataPartition: no writable data partition")
 	}
 
 	log.LogInfof("updateDataPartition: end!")
-	return nil
+	return err
 }
 
 func (w *Wrapper) replaceOrInsertPartition(dp *DataPartition) {


### PR DESCRIPTION
If there is no writable data partition, updateDataPartition will return
an error which leads to mount fail.

Signed-off-by: Shuoran Liu <shuoranliu@gmail.com>