### PR TITLE
clientv2: add dentry cache

### DIFF
--- a/clientv2/fs/dcache.go
+++ b/clientv2/fs/dcache.go
@@ -1,0 +1,72 @@
+// Copyright 2018 The Chubao Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package fs
+
+import (
+	"sync"
+	"time"
+)
+
+// DentryCache defines the dentry cache.
+type DentryCache struct {
+	sync.Mutex
+	cache      map[string]uint64
+	expiration time.Time
+}
+
+// NewDentryCache returns a new dentry cache.
+func NewDentryCache() *DentryCache {
+	return &DentryCache{
+		cache:      make(map[string]uint64),
+		expiration: time.Now().Add(DentryValidDuration),
+	}
+}
+
+// Put puts an item into the cache.
+func (dc *DentryCache) Put(name string, ino uint64) {
+	if dc == nil {
+		return
+	}
+	dc.Lock()
+	defer dc.Unlock()
+	dc.cache[name] = ino
+	dc.expiration = time.Now().Add(DentryValidDuration)
+}
+
+// Get gets the item from the cache based on the given key.
+func (dc *DentryCache) Get(name string) (uint64, bool) {
+	if dc == nil {
+		return 0, false
+	}
+
+	dc.Lock()
+	defer dc.Unlock()
+	if dc.expiration.Before(time.Now()) {
+		dc.cache = make(map[string]uint64)
+		return 0, false
+	}
+	ino, ok := dc.cache[name]
+	return ino, ok
+}
+
+// Delete deletes the item based on the given key.
+func (dc *DentryCache) Delete(name string) {
+	if dc == nil {
+		return
+	}
+	dc.Lock()
+	defer dc.Unlock()
+	delete(dc.cache, name)
+}

--- a/clientv2/fs/dir.go
+++ b/clientv2/fs/dir.go
@@ -142,12 +142,21 @@ func (s *Super) LookUpInode(ctx context.Context, op *fuseops.LookUpInodeOp) erro
 
 	log.LogDebugf("TRACE enter %v: ", desc)
 
-	ino, _, err := s.mw.Lookup_ll(pino, op.Name)
+	pinode, err := s.InodeGet(pino)
 	if err != nil {
-		if err != fuse.ENOENT {
-			log.LogErrorf("%v: err(%v)", desc, err)
-		}
+		log.LogErrorf("%v: failed to get parent inode, err(%v)", desc, err)
 		return ParseError(err)
+	}
+
+	ino, ok := pinode.dcache.Get(op.Name)
+	if !ok {
+		ino, _, err = s.mw.Lookup_ll(pino, op.Name)
+		if err != nil {
+			if err != fuse.ENOENT {
+				log.LogErrorf("%v: err(%v)", desc, err)
+			}
+			return ParseError(err)
+		}
 	}
 
 	inode, err := s.InodeGet(ino)
@@ -167,6 +176,10 @@ func (s *Super) RmDir(ctx context.Context, op *fuseops.RmDirOp) error {
 	desc := fuse.OpDescription(op)
 
 	log.LogDebugf("TRACE enter %v:", desc)
+
+	if pinode, _ := s.InodeGet(pino); pinode != nil {
+		pinode.dcache.Delete(op.Name)
+	}
 
 	info, err := s.mw.Delete_ll(pino, op.Name, true)
 	if err != nil {
@@ -208,7 +221,7 @@ func (s *Super) OpenDir(ctx context.Context, op *fuseops.OpenDirOp) error {
 }
 
 func (s *Super) ReadDir(ctx context.Context, op *fuseops.ReadDirOp) error {
-	ino := uint64(op.Inode)
+	pino := uint64(op.Inode)
 	pos := int(op.Offset)
 	desc := fuse.OpDescription(op)
 
@@ -220,16 +233,23 @@ func (s *Super) ReadDir(ctx context.Context, op *fuseops.ReadDirOp) error {
 		return syscall.EBADF
 	}
 
+	pinode, err := s.InodeGet(pino)
+	if err != nil {
+		log.LogErrorf("%v: failed to get inode, err(%v)", desc, err)
+		return ParseError(err)
+	}
+
 	handle.lock.Lock()
 	defer handle.lock.Unlock()
 
 	if pos == 0 || handle.entries == nil {
-		children, err := s.mw.ReadDir_ll(ino)
+		children, err := s.mw.ReadDir_ll(pino)
 		if err != nil {
 			log.LogErrorf("%v: failed to readdir from metanode, err(%v)", desc, err)
 			return ParseError(err)
 		}
 		handle.entries = children
+		pinode.dcache = NewDentryCache()
 	}
 
 	if pos > len(handle.entries) {
@@ -254,6 +274,7 @@ func (s *Super) ReadDir(ctx context.Context, op *fuseops.ReadDirOp) error {
 		}
 		op.BytesRead += nbytes
 		inodes = append(inodes, child.Inode)
+		pinode.dcache.Put(child.Name, child.Inode)
 	}
 
 	if pos == 0 {
@@ -280,6 +301,10 @@ func (s *Super) Rename(ctx context.Context, op *fuseops.RenameOp) error {
 	desc := fuse.OpDescription(op)
 
 	log.LogDebugf("TRACE enter %v: ", desc)
+
+	if oldPinode, _ := s.InodeGet(oldPino); oldPinode != nil {
+		oldPinode.dcache.Delete(op.OldName)
+	}
 
 	err := s.mw.Rename_ll(oldPino, op.OldName, newPino, op.NewName)
 	if err != nil {

--- a/clientv2/fs/inode.go
+++ b/clientv2/fs/inode.go
@@ -46,6 +46,9 @@ type Inode struct {
 
 	// protected under the inode cache lock
 	expiration int64
+
+	// For directory inode only
+	dcache *DentryCache
 }
 
 // NewInode returns a new inode.


### PR DESCRIPTION
Add dentry cache to mitigate the LookUpInode request flood if there are
many dentries in a directory.

Signed-off-by: Shuoran Liu <shuoranliu@gmail.com>