### PR TITLE
Change packet attr and if dp create failed,check all host if the host is alive

### DIFF
--- a/datanode/wrap_operator.go
+++ b/datanode/wrap_operator.go
@@ -477,6 +477,7 @@ func (s *DataNode) handleExtentRepaiReadPacket(p *repl.Packet, connect net.Conn,
 		}
 		reply.Size = uint32(currReadSize)
 		reply.ResultCode = proto.OpOk
+		reply.Opcode=p.Opcode
 		p.ResultCode = proto.OpOk
 		if err = reply.WriteToConn(connect); err != nil {
 			return

--- a/datanode/wrap_operator.go
+++ b/datanode/wrap_operator.go
@@ -525,6 +525,12 @@ func (s *DataNode) handlePacketToReadTinyDelete(p *repl.Packet, connect *net.TCP
 	var (
 		err error
 	)
+	defer func() {
+		if err != nil {
+			p.PackErrorBody(ActionStreamReadTinyDeleteRecord, err.Error())
+			p.WriteToConn(connect)
+		}
+	}()
 	partition := p.Object.(*DataPartition)
 	store := partition.ExtentStore()
 	localTinyDeleteFileSize := store.LoadTinyDeleteFileOffset()
@@ -542,21 +548,11 @@ func (s *DataNode) handlePacketToReadTinyDelete(p *repl.Packet, connect *net.TCP
 		reply.ExtentOffset = offset
 		reply.CRC, err = store.ReadTinyDeleteRecords(offset, int64(currReadSize), reply.Data)
 		if err != nil {
-			reply.PackErrorBody(ActionStreamReadTinyDeleteRecord, err.Error())
-			if err = reply.WriteToConn(connect); err != nil {
-				err = fmt.Errorf(reply.LogMessage(ActionStreamReadTinyDeleteRecord, connect.RemoteAddr().String(),
-					reply.StartT, err))
-				log.LogErrorf(err.Error())
-			}
 			return
 		}
 		reply.Size = uint32(currReadSize)
 		reply.ResultCode = proto.OpOk
 		if err = reply.WriteToConn(connect); err != nil {
-			err = fmt.Errorf(reply.LogMessage(ActionStreamReadTinyDeleteRecord, connect.RemoteAddr().String(),
-				reply.StartT, err))
-			p.PackErrorBody(ActionStreamReadTinyDeleteRecord, err.Error())
-			log.LogErrorf(err.Error())
 			return
 		}
 		needReplySize -= int64(currReadSize)

--- a/datanode/wrap_operator.go
+++ b/datanode/wrap_operator.go
@@ -548,6 +548,8 @@ func (s *DataNode) handlePacketToReadTinyDelete(p *repl.Packet, connect *net.TCP
 		reply.ExtentOffset = offset
 		reply.CRC, err = store.ReadTinyDeleteRecords(offset, int64(currReadSize), reply.Data)
 		if err != nil {
+			err=fmt.Errorf(ActionStreamReadTinyDeleteRecord+"localTinyDeleteRecordSize(%v) offset(%v)" +
+				" currReadSize(%v) err(%v)",localTinyDeleteFileSize,offset,currReadSize,err)
 			return
 		}
 		reply.Size = uint32(currReadSize)

--- a/datanode/wrap_operator.go
+++ b/datanode/wrap_operator.go
@@ -548,7 +548,7 @@ func (s *DataNode) handlePacketToReadTinyDelete(p *repl.Packet, connect *net.TCP
 		reply.ExtentOffset = offset
 		reply.CRC, err = store.ReadTinyDeleteRecords(offset, int64(currReadSize), reply.Data)
 		if err != nil {
-			err=fmt.Errorf(ActionStreamReadTinyDeleteRecord+"localTinyDeleteRecordSize(%v) offset(%v)" +
+			err=fmt.Errorf(ActionStreamReadTinyDeleteRecord+" localTinyDeleteRecordSize(%v) offset(%v)" +
 				" currReadSize(%v) err(%v)",localTinyDeleteFileSize,offset,currReadSize,err)
 			return
 		}

--- a/datanode/wrap_operator.go
+++ b/datanode/wrap_operator.go
@@ -477,7 +477,7 @@ func (s *DataNode) handleExtentRepaiReadPacket(p *repl.Packet, connect net.Conn,
 		}
 		reply.Size = uint32(currReadSize)
 		reply.ResultCode = proto.OpOk
-		reply.Opcode=p.Opcode
+		reply.Opcode = p.Opcode
 		p.ResultCode = proto.OpOk
 		if err = reply.WriteToConn(connect); err != nil {
 			return
@@ -549,8 +549,8 @@ func (s *DataNode) handlePacketToReadTinyDelete(p *repl.Packet, connect *net.TCP
 		reply.ExtentOffset = offset
 		reply.CRC, err = store.ReadTinyDeleteRecords(offset, int64(currReadSize), reply.Data)
 		if err != nil {
-			err=fmt.Errorf(ActionStreamReadTinyDeleteRecord+" localTinyDeleteRecordSize(%v) offset(%v)" +
-				" currReadSize(%v) err(%v)",localTinyDeleteFileSize,offset,currReadSize,err)
+			err = fmt.Errorf(ActionStreamReadTinyDeleteRecord+" localTinyDeleteRecordSize(%v) offset(%v)"+
+				" currReadSize(%v) err(%v)", localTinyDeleteFileSize, offset, currReadSize, err)
 			return
 		}
 		reply.Size = uint32(currReadSize)

--- a/datanode/wrap_post.go
+++ b/datanode/wrap_post.go
@@ -46,7 +46,7 @@ func (s *DataNode) releaseExtent(p *repl.Packet) {
 	if p == nil || !storage.IsTinyExtent(p.ExtentID) || p.ExtentID <= 0 || atomic.LoadInt32(&p.IsReleased) == IsReleased {
 		return
 	}
-	if !p.IsTinyExtentType()|| !p.IsLeaderPacket() || !p.IsWriteOperation()|| !p.IsForwardPkt() {
+	if !p.IsTinyExtentType() || !p.IsLeaderPacket() || !p.IsWriteOperation() || !p.IsForwardPkt() {
 		return
 	}
 	if p.Object == nil {

--- a/datanode/wrap_post.go
+++ b/datanode/wrap_post.go
@@ -15,7 +15,6 @@
 package datanode
 
 import (
-	"github.com/chubaofs/chubaofs/proto"
 	"github.com/chubaofs/chubaofs/repl"
 	"github.com/chubaofs/chubaofs/storage"
 	"sync/atomic"
@@ -25,7 +24,7 @@ func (s *DataNode) Post(p *repl.Packet) error {
 	if p.IsMasterCommand() {
 		p.NeedReply = true
 	}
-	if isReadExtentOperation(p) {
+	if p.IsReadOperation() {
 		p.NeedReply = false
 	}
 	s.cleanupPkt(p)
@@ -37,7 +36,7 @@ func (s *DataNode) cleanupPkt(p *repl.Packet) {
 	if p.IsMasterCommand() {
 		return
 	}
-	if !isLeaderPacket(p) {
+	if !p.IsLeaderPacket() {
 		return
 	}
 	s.releaseExtent(p)
@@ -47,7 +46,7 @@ func (s *DataNode) releaseExtent(p *repl.Packet) {
 	if p == nil || !storage.IsTinyExtent(p.ExtentID) || p.ExtentID <= 0 || atomic.LoadInt32(&p.IsReleased) == IsReleased {
 		return
 	}
-	if p.ExtentType != proto.TinyExtentType || !isLeaderPacket(p) || !isWriteOperation(p) || !p.IsForwardPkt() {
+	if !p.IsTinyExtentType()|| !p.IsLeaderPacket() || !p.IsWriteOperation()|| !p.IsForwardPkt() {
 		return
 	}
 	if p.Object == nil {

--- a/master/data_partition.go
+++ b/master/data_partition.go
@@ -28,14 +28,14 @@ import (
 
 // DataPartition represents the structure of storing the file contents.
 type DataPartition struct {
-	PartitionID             uint64
-	LastLoadedTime          int64
-	ReplicaNum              uint8
-	Status                  int8
-	isRecover               bool
-	Replicas                []*DataReplica
-	Hosts                   []string // host addresses
-	Peers                   []proto.Peer
+	PartitionID    uint64
+	LastLoadedTime int64
+	ReplicaNum     uint8
+	Status         int8
+	isRecover      bool
+	Replicas       []*DataReplica
+	Hosts          []string // host addresses
+	Peers          []proto.Peer
 	sync.RWMutex
 	total                   uint64
 	used                    uint64
@@ -310,7 +310,7 @@ func (partition *DataPartition) getFileCount() {
 	}
 
 	for _, replica := range partition.Replicas {
-		msg = fmt.Sprintf(getFileCountOnDataReplica + "partitionID:%v  replicaAddr:%v  FileCount:%v  "+
+		msg = fmt.Sprintf(getFileCountOnDataReplica+"partitionID:%v  replicaAddr:%v  FileCount:%v  "+
 			"NodeIsActive:%v  replicaIsActive:%v  .replicaStatusOnNode:%v ", partition.PartitionID, replica.Addr, replica.FileCount,
 			replica.getReplicaNode().isActive, replica.isActive(defaultDataPartitionTimeOutSec), replica.Status)
 		log.LogInfo(msg)

--- a/repl/packet.go
+++ b/repl/packet.go
@@ -269,8 +269,6 @@ func (p *Packet) ReadFull(c net.Conn, readSize int) (err error) {
 	return
 }
 
-
-
 func (p *Packet) ReadFromConnFromCli(c net.Conn, deadlineTime time.Duration) (err error) {
 	if deadlineTime != proto.NoReadDeadlineTime {
 		c.SetReadDeadline(time.Now().Add(deadlineTime * time.Second))
@@ -305,7 +303,6 @@ func (p *Packet) ReadFromConnFromCli(c net.Conn, deadlineTime time.Duration) (er
 	return p.ReadFull(c, int(size))
 }
 
-
 // A leader packet is the packet send to the leader and does not require packet forwarding.
 func (p *Packet) IsLeaderPacket() (ok bool) {
 	if p.IsForwardPkt() && (p.IsWriteOperation() || p.IsCreateExtentOperation() || p.IsMarkDeleteExtentOperation()) {
@@ -315,8 +312,8 @@ func (p *Packet) IsLeaderPacket() (ok bool) {
 	return
 }
 
-func (p *Packet)IsTinyExtentType()bool{
-	return p.ExtentType==proto.TinyExtentType
+func (p *Packet) IsTinyExtentType() bool {
+	return p.ExtentType == proto.TinyExtentType
 }
 
 func (p *Packet) IsWriteOperation() bool {
@@ -327,11 +324,10 @@ func (p *Packet) IsCreateExtentOperation() bool {
 	return p.Opcode == proto.OpCreateExtent
 }
 
-
 func (p *Packet) IsMarkDeleteExtentOperation() bool {
 	return p.Opcode == proto.OpMarkDelete
 }
 
 func (p *Packet) IsReadOperation() bool {
-	return p.Opcode == proto.OpStreamRead || p.Opcode == proto.OpRead || p.Opcode == proto.OpExtentRepairRead || p.Opcode==proto.OpReadTinyDelete
+	return p.Opcode == proto.OpStreamRead || p.Opcode == proto.OpRead || p.Opcode == proto.OpExtentRepairRead || p.Opcode == proto.OpReadTinyDelete
 }

--- a/sdk/data/stream/extent_handler.go
+++ b/sdk/data/stream/extent_handler.go
@@ -490,26 +490,13 @@ func (eh *ExtentHandler) allocateExtent() (err error) {
 			continue
 		}
 
+		extID = 0
 		if eh.storeMode == proto.NormalExtentType {
-			if extID, err = eh.createExtent(dp, exclude); err != nil {
-				log.LogWarnf("allocateExtent: failed to create extent, eh(%v) err(%v)", eh, err)
-				continue
-			}
-		} else {
-			extID = 0
+			extID, err = eh.createExtent(dp, exclude)
 		}
-
-		if err!=nil {
-			//check the partition all host has live
-			for i:=0;i<len(dp.Hosts);i++{
-				host:=dp.Hosts[i]
-				if conn, err = StreamConnPool.DailTimeOut(host,proto.ReadDeadlineTime); err != nil {
-					exclude[host] = struct{}{}
-					log.LogWarnf("allocateExtent: failed to create connection, eh(%v) err(%v) dp(%v)", eh, err, dp)
-					continue
-				}
-				StreamConnPool.PutConnect(conn,false)
-			}
+		if err != nil {
+			log.LogWarnf("allocateExtent: failed to create extent, eh(%v) err(%v)", eh, err)
+			dp.CheckAllHostsIsAvail(exclude)
 			continue
 		}
 

--- a/sdk/data/stream/extent_handler.go
+++ b/sdk/data/stream/extent_handler.go
@@ -499,6 +499,20 @@ func (eh *ExtentHandler) allocateExtent() (err error) {
 			extID = 0
 		}
 
+		if err!=nil {
+			//check the partition all host has live
+			for i:=0;i<len(dp.Hosts);i++{
+				host:=dp.Hosts[i]
+				if conn, err = StreamConnPool.DailTimeOut(host,proto.ReadDeadlineTime); err != nil {
+					exclude[host] = struct{}{}
+					log.LogWarnf("allocateExtent: failed to create connection, eh(%v) err(%v) dp(%v)", eh, err, dp)
+					continue
+				}
+				StreamConnPool.PutConnect(conn,false)
+			}
+			continue
+		}
+
 		if conn, err = StreamConnPool.GetConnect(dp.Hosts[0]); err != nil {
 			exclude[dp.Hosts[0]] = struct{}{}
 			log.LogWarnf("allocateExtent: failed to create connection, eh(%v) err(%v) dp(%v)", eh, err, dp)

--- a/storage/extent_store.go
+++ b/storage/extent_store.go
@@ -647,7 +647,12 @@ func (s *ExtentStore) NextTinyDeleteFileOffset() (offset int64) {
 }
 
 func (s *ExtentStore) LoadTinyDeleteFileOffset() (offset int64) {
-	return atomic.LoadInt64(&s.baseTinyDeleteOffset)
+	finfo,err:=s.tinyExtentDeleteFp.Stat()
+	if err!=nil {
+		return atomic.LoadInt64(&s.baseTinyDeleteOffset)
+	}
+	offset=finfo.Size()
+	return
 }
 
 func (s *ExtentStore) getExtentKey(extent uint64) string {

--- a/storage/extent_store.go
+++ b/storage/extent_store.go
@@ -647,11 +647,11 @@ func (s *ExtentStore) NextTinyDeleteFileOffset() (offset int64) {
 }
 
 func (s *ExtentStore) LoadTinyDeleteFileOffset() (offset int64) {
-	finfo,err:=s.tinyExtentDeleteFp.Stat()
-	if err!=nil {
+	finfo, err := s.tinyExtentDeleteFp.Stat()
+	if err != nil {
 		return atomic.LoadInt64(&s.baseTinyDeleteOffset)
 	}
-	offset=finfo.Size()
+	offset = finfo.Size()
 	return
 }
 

--- a/util/conn_pool.go
+++ b/util/conn_pool.go
@@ -44,10 +44,9 @@ func NewConnectPool() (cp *ConnectPool) {
 	return cp
 }
 
-
-func (cp *ConnectPool)DailTimeOut(target string,timeout time.Duration)(c *net.TCPConn,err error){
+func DailTimeOut(target string, timeout time.Duration) (c *net.TCPConn, err error) {
 	var connect net.Conn
-	connect, err = net.DialTimeout("tcp", target,timeout)
+	connect, err = net.DialTimeout("tcp", target, timeout)
 	if err == nil {
 		conn := connect.(*net.TCPConn)
 		conn.SetKeepAlive(true)

--- a/util/conn_pool.go
+++ b/util/conn_pool.go
@@ -44,6 +44,19 @@ func NewConnectPool() (cp *ConnectPool) {
 	return cp
 }
 
+
+func (cp *ConnectPool)DailTimeOut(target string,timeout time.Duration)(c *net.TCPConn,err error){
+	var connect net.Conn
+	connect, err = net.DialTimeout("tcp", target,timeout)
+	if err == nil {
+		conn := connect.(*net.TCPConn)
+		conn.SetKeepAlive(true)
+		conn.SetNoDelay(true)
+		c = conn
+	}
+	return
+}
+
 func (cp *ConnectPool) GetConnect(targetAddr string) (c *net.TCPConn, err error) {
 	cp.RLock()
 	pool, ok := cp.pools[targetAddr]

--- a/util/ump/ump.go
+++ b/util/ump/ump.go
@@ -56,7 +56,7 @@ var (
 	}}
 )
 
-func InitUmp(module, dataDir string)(err error) {
+func InitUmp(module, dataDir string) (err error) {
 	runtime.GOMAXPROCS(runtime.NumCPU())
 	if err := initLogName(module, dataDir); err != nil {
 		return err

--- a/util/ump/ump_async_log.go
+++ b/util/ump/ump_async_log.go
@@ -15,12 +15,12 @@
 package ump
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"net"
 	"os"
 	"strings"
-	"bytes"
 )
 
 type FunctionTp struct {
@@ -67,13 +67,13 @@ var (
 )
 
 type LogWrite struct {
-	logCh     chan interface{}
-	logName   string
-	logSize   int64
-	seq       int
-	logSufixx string
-	logFp     *os.File
-	sigCh     chan bool
+	logCh       chan interface{}
+	logName     string
+	logSize     int64
+	seq         int
+	logSufixx   string
+	logFp       *os.File
+	sigCh       chan bool
 	bf          *bytes.Buffer
 	jsonEncoder *json.Encoder
 }


### PR DESCRIPTION
1. rename the isReadOperator to packet.isReadOperator
2. rename the isLeaderPacket to packet.isLeaderPacket
3. rename the isWriteOperation to packet.IsWriteOperation
4. rename the isCreateExtentOperation to packet.IsCreateExtentOperation
5. rename the isMarkDeleteExtentOperation to packet.IsMarkDeleteExtentOperation
6. change the handlePacketToReadTinyDelete func error log
7. fix bug: when read tinyDeleteFile return eof error  …
8. fix bug: when create dataPartition failed,exclude the dp hosts

Signed-off-by: awzhgw guowl18702995996@gmail.com