### PR TITLE
metanode: skip corrupted file which records deleted extent

### DIFF
--- a/metanode/partition_delete_extents.go
+++ b/metanode/partition_delete_extents.go
@@ -183,8 +183,8 @@ func (mp *metaPartition) deleteExtentsFromList(fileList *list.List) {
 				errStr := fmt.Sprintf(
 					"[deleteExtentsFromList] partitionId=%d, %s file corrupted!",
 					mp.config.PartitionId, fileName)
-				log.LogErrorf(errStr)
-				panic(errStr)
+				log.LogErrorf(errStr) // FIXME
+				goto LOOP
 			}
 			buf = buf[:size]
 		}


### PR DESCRIPTION
Deleted extent is written to a local file without fsync, and might get
corrupted if the process is killed. Since this file does not affect
responses to users, just skip corrupted files for now.