### PR TITLE
fix: metanode panic when deleting meta partition

### DIFF
--- a/metanode/partition.go
+++ b/metanode/partition.go
@@ -298,7 +298,6 @@ func (mp *metaPartition) stopRaft() {
 	if mp.raftPartition != nil {
 		// TODO Unhandled errors
 		mp.raftPartition.Stop()
-		mp.raftPartition = nil
 	}
 	return
 }


### PR DESCRIPTION
When deleting a meta partition, stopRaft() is invoked and raftPartition
is set to nil, then invoking DeleteRaft() would cause a panic. Actually
there is no need to set raftPartition to nil in stopRaft().

Signed-off-by: Shuoran Liu <shuoranliu@gmail.com>