### PR TITLE
feature: introduce keepcache mount option

### DIFF
--- a/client/fs/dir.go
+++ b/client/fs/dir.go
@@ -93,6 +93,10 @@ func (d *Dir) Create(ctx context.Context, req *fuse.CreateRequest, resp *fuse.Cr
 	d.super.nodeCache[inode.ino] = child
 	d.super.fslock.Unlock()
 
+	if d.super.keepCache {
+		resp.Flags |= fuse.OpenKeepCache
+	}
+
 	elapsed := time.Since(start)
 	log.LogDebugf("TRACE Create: parent(%v) req(%v) resp(%v) ino(%v) (%v)ns", d.inode.ino, req, resp, inode.ino, elapsed.Nanoseconds())
 	return child, child, nil

--- a/client/fs/file.go
+++ b/client/fs/file.go
@@ -116,6 +116,10 @@ func (f *File) Open(ctx context.Context, req *fuse.OpenRequest, resp *fuse.OpenR
 
 	f.super.ec.OpenStream(ino)
 
+	if f.super.keepCache {
+		resp.Flags |= fuse.OpenKeepCache
+	}
+
 	elapsed := time.Since(start)
 	log.LogDebugf("TRACE Open: ino(%v) req(%v) resp(%v) (%v)ns", ino, req, resp, elapsed.Nanoseconds())
 	return f, nil

--- a/client/fs/super.go
+++ b/client/fs/super.go
@@ -45,6 +45,7 @@ type MountOption struct {
 	UmpDatadir    string
 	Rdonly        bool
 	WriteCache    bool
+	KeepCache     bool
 }
 
 // Super defines the struct of a super block.
@@ -57,6 +58,7 @@ type Super struct {
 	ec          *stream.ExtentClient
 	orphan      *OrphanInodeList
 	enSyncWrite bool
+	keepCache   bool
 
 	nodeCache map[uint64]fs.Node
 	fslock    sync.Mutex
@@ -97,6 +99,7 @@ func NewSuper(opt *MountOption) (s *Super, err error) {
 	if opt.EnSyncWrite > 0 {
 		s.enSyncWrite = true
 	}
+	s.keepCache = opt.KeepCache
 	s.ic = NewInodeCache(inodeExpiration, MaxInodeCache)
 	s.orphan = NewOrphanInodeList()
 	s.nodeCache = make(map[uint64]fs.Node)

--- a/client/fuse.go
+++ b/client/fuse.go
@@ -247,6 +247,7 @@ func parseMountOption(cfg *config.Config) (*cfs.MountOption, error) {
 	opt.UmpDatadir = cfg.GetString(proto.WarnLogDir)
 	opt.Rdonly = cfg.GetBool(proto.Rdonly)
 	opt.WriteCache = cfg.GetBool(proto.WriteCache)
+	opt.KeepCache = cfg.GetBool(proto.KeepCache)
 
 	if opt.MountPoint == "" || opt.Volname == "" || opt.Owner == "" || opt.Master == "" {
 		return nil, errors.New(fmt.Sprintf("invalid config file: lack of mandatory fields, mountPoint(%v), volName(%v), owner(%v), masterAddr(%v)", opt.MountPoint, opt.Volname, opt.Owner, opt.Master))

--- a/clientv2/fs/file.go
+++ b/clientv2/fs/file.go
@@ -31,6 +31,7 @@ func (s *Super) OpenFile(ctx context.Context, op *fuseops.OpenFileOp) error {
 
 	s.ec.OpenStream(ino)
 	op.Handle = s.hc.Assign(ino)
+	op.KeepPageCache = s.keepCache
 
 	log.LogDebugf("TRACE Open: op(%v) handle(%v)", desc, op.Handle)
 	return nil

--- a/clientv2/fs/super.go
+++ b/clientv2/fs/super.go
@@ -45,6 +45,7 @@ type MountOption struct {
 	UmpDatadir    string
 	Rdonly        bool
 	WriteCache    bool
+	KeepCache     bool
 }
 
 type Super struct {
@@ -57,6 +58,7 @@ type Super struct {
 	ec          *stream.ExtentClient
 	orphan      *OrphanInodeList
 	enSyncWrite bool
+	keepCache   bool
 }
 
 var (
@@ -91,6 +93,7 @@ func NewSuper(opt *MountOption) (s *Super, err error) {
 	if opt.EnSyncWrite > 0 {
 		s.enSyncWrite = true
 	}
+	s.keepCache = opt.KeepCache
 	s.hc = NewHandleCache()
 	s.ic = NewInodeCache(inodeExpiration, MaxInodeCache)
 	s.orphan = NewOrphanInodeList()

--- a/clientv2/main.go
+++ b/clientv2/main.go
@@ -240,6 +240,7 @@ func parseMountOption(cfg *config.Config) (*cfs.MountOption, error) {
 	opt.UmpDatadir = cfg.GetString(proto.WarnLogDir)
 	opt.Rdonly = cfg.GetBool(proto.Rdonly)
 	opt.WriteCache = cfg.GetBool(proto.WriteCache)
+	opt.KeepCache = cfg.GetBool(proto.KeepCache)
 
 	if opt.MountPoint == "" || opt.Volname == "" || opt.Owner == "" || opt.Master == "" {
 		return nil, errors.New(fmt.Sprintf("invalid config file: lack of mandatory fields, mountPoint(%v), volName(%v), owner(%v), masterAddr(%v)", opt.MountPoint, opt.Volname, opt.Owner, opt.Master))

--- a/proto/mount_options.go
+++ b/proto/mount_options.go
@@ -18,4 +18,5 @@ const (
 	AutoInvalData = "autoInvalData"
 	Rdonly        = "rdonly"
 	WriteCache    = "writecache"
+	KeepCache     = "keepcache"
 )


### PR DESCRIPTION
The "OpenKeepCache" flag tells the FUSE kernel to keep page cache
when opening an existing file to improve read performance, in exchange
of weaker data consistency among multiple nodes.

Signed-off-by: Shuoran Liu <shuoranliu@gmail.com>