### PR TITLE
fix: redirect stderr to an output file in daemon

### DIFF
--- a/client/fuse.go
+++ b/client/fuse.go
@@ -125,6 +125,11 @@ func main() {
 	}()
 	syslog.SetOutput(outputFile)
 
+	if err = syscall.Dup2(int(outputFile.Fd()), int(os.Stderr.Fd())); err != nil {
+		daemonize.SignalOutcome(err)
+		os.Exit(1)
+	}
+
 	registerInterceptedSignal(opt.MountPoint)
 
 	fsConn, super, err := mount(opt)

--- a/clientv2/main.go
+++ b/clientv2/main.go
@@ -126,6 +126,11 @@ func main() {
 	}()
 	syslog.SetOutput(outputFile)
 
+	if err = syscall.Dup2(int(outputFile.Fd()), int(os.Stderr.Fd())); err != nil {
+		daemonize.SignalOutcome(err)
+		os.Exit(1)
+	}
+
 	registerInterceptedSignal(opt.MountPoint)
 
 	mfs, err := mount(opt)


### PR DESCRIPTION
Since the client is started as a daemon, it is necessary to redirect
stderr to an output file to capture panic messages.

Signed-off-by: Shuoran Liu <shuoranliu@gmail.com>