### PR TITLE
enhancement: enable async read by default

### DIFF
--- a/vendor/github.com/jacobsa/fuse/connection.go
+++ b/vendor/github.com/jacobsa/fuse/connection.go
@@ -161,7 +161,7 @@ func (c *Connection) Init() (err error) {
 	initOp.Flags = 0
 
 	// Tell the kernel not to use pitifully small 4 KiB writes.
-	initOp.Flags |= fusekernel.InitBigWrites
+	initOp.Flags |= (fusekernel.InitBigWrites | fusekernel.InitAsyncRead)
 
 	// Enable writeback caching if the user hasn't asked us not to.
 	if !c.cfg.DisableWritebackCaching {


### PR DESCRIPTION
Enable FUSE async read feature by default, so that readahead can take
effect to improve sequential read performance.

Signed-off-by: Shuoran Liu <shuoranliu@gmail.com>