### PR TITLE
enhancement: align out message buffer size with max read size

### DIFF
--- a/vendor/github.com/jacobsa/fuse/connection.go
+++ b/vendor/github.com/jacobsa/fuse/connection.go
@@ -155,7 +155,7 @@ func (c *Connection) Init() (err error) {
 
 	// Respond to the init op.
 	initOp.Library = c.protocol
-	initOp.MaxReadahead = maxReadahead
+	initOp.MaxReadahead = buffer.MaxReadSize
 	initOp.MaxWrite = buffer.MaxWriteSize
 
 	initOp.Flags = 0

--- a/vendor/github.com/jacobsa/fuse/internal/buffer/out_message_linux.go
+++ b/vendor/github.com/jacobsa/fuse/internal/buffer/out_message_linux.go
@@ -18,4 +18,4 @@ package buffer
 // calculating the size of out messages.
 //
 // For 4 KiB pages, this is 128 KiB (cf. https://goo.gl/HOiEYo)
-const MaxReadSize = 1 << 19
+const MaxReadSize = 1 << 18


### PR DESCRIPTION
Set out message buffer size to max read size, since we won't be needing
such a big buffer if it is larger than max read size.

Signed-off-by: Shuoran Liu <shuoranliu@gmail.com>