### PR TITLE
enhancement: compatible with string when get bool config

### DIFF
--- a/util/config/config.go
+++ b/util/config/config.go
@@ -95,6 +95,11 @@ func (c *Config) GetBool(key string) bool {
 	if result, isBool := x.(bool); isBool {
 		return result
 	}
+	if result, isString := x.(string); isString {
+		if result == "true" {
+			return true
+		}
+	}
 	return false
 }
 


### PR DESCRIPTION
Right now certain client mount options require bool type inputs,
which have no double quotation marks, i.e. true instead of "true".
However, this is a little bit confusing, and some customers might
have used string type by mistake.

This commit can deal with a string-typed bool config such as "true".

Signed-off-by: Shuoran Liu <shuoranliu@gmail.com>