### PR TITLE
fix: exclude dir inode in the orphan list

### DIFF
--- a/client/fs/dir.go
+++ b/client/fs/dir.go
@@ -149,7 +149,7 @@ func (d *Dir) Remove(ctx context.Context, req *fuse.RemoveRequest) error {
 
 	d.super.ic.Delete(d.inode.ino)
 
-	if info != nil && info.Nlink == 0 {
+	if info != nil && info.Nlink == 0 && !proto.IsDir(info.Mode) {
 		d.super.orphan.Put(info.Inode)
 		log.LogDebugf("Remove: add to orphan inode list, ino(%v)", info.Inode)
 	}


### PR DESCRIPTION
Directory inode should not be added to the orphan list, since it does
not need to be evicted.

Signed-off-by: Shuoran Liu <shuoranliu@gmail.com>