### PR TITLE
fix: fuse directIO read size can exceeds buffer size

### DIFF
--- a/vendor/github.com/jacobsa/fuse/mount_linux.go
+++ b/vendor/github.com/jacobsa/fuse/mount_linux.go
@@ -6,7 +6,10 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"strconv"
 	"syscall"
+
+	"github.com/jacobsa/fuse/internal/buffer"
 )
 
 // Begin the process of mounting at the given directory, returning a connection
@@ -36,6 +39,8 @@ func mount(
 
 	// Start fusermount, passing it a buffer in which to write stderr.
 	var stderr bytes.Buffer
+
+	cfg.Options["max_read"] = strconv.Itoa(buffer.MaxReadSize)
 
 	cmd := exec.Command(
 		"fusermount",


### PR DESCRIPTION
Since jacobasa fuse package uses a fixed-size memory pool for out
messages, it is important to tell fuse kernel module what the maximum
read size is. Otherwise, a large read will cause a panic.

However, max readahead size can only affect buffered read. The kernel
might still send a large directIO read in spite of the max readahead
size. We need to specify "max_read" option during mount.

Signed-off-by: Shuoran Liu <shuoranliu@gmail.com>