### PR TITLE
Fix: Datanode Repair time out and if tinyExtentRepair execlude Write

### DIFF
--- a/datanode/const.go
+++ b/datanode/const.go
@@ -99,8 +99,8 @@ const (
 )
 
 const (
-	EmptyResponse               = 'E'
-	EmptyPacketLength           = 9
-	MaxSyncTinyDeleteBufferSize = 2400000
-	MaxFullSyncTinyDeleteTime   = 3600 * 24
+	EmptyResponse                      = 'E'
+	TinyExtentRepairReadResponseArgLen = 17
+	MaxSyncTinyDeleteBufferSize        = 2400000
+	MaxFullSyncTinyDeleteTime          = 3600 * 24
 )

--- a/datanode/const.go
+++ b/datanode/const.go
@@ -89,10 +89,6 @@ const (
 	StreamRead = false
 )
 
-const (
-	NotUpdateSize = false
-	UpdateSize    = true
-)
 
 const (
 	BufferWrite = false

--- a/datanode/data_partition_repair.go
+++ b/datanode/data_partition_repair.go
@@ -533,7 +533,7 @@ func (dp *DataPartition) streamRepairExtent(remoteExtentInfo *storage.ExtentInfo
 				break
 			}
 		} else {
-			err = store.Write(uint64(localExtentInfo.FileID), int64(currFixOffset), int64(reply.Size), reply.Data, reply.CRC, UpdateSize, BufferWrite)
+			err = store.Write(uint64(localExtentInfo.FileID), int64(currFixOffset), int64(reply.Size), reply.Data, reply.CRC, storage.AppendWriteType, BufferWrite)
 		}
 
 		// write to the local extent file

--- a/datanode/disk.go
+++ b/datanode/disk.go
@@ -66,7 +66,7 @@ func NewDisk(path string, restSize uint64, maxErrCnt int, space *SpaceManager) (
 	d.Path = path
 	d.ReservedSpace = restSize
 	d.MaxErrCnt = maxErrCnt
-	d.RejectWrite=false
+	d.RejectWrite = false
 	d.space = space
 	d.partitionMap = make(map[uint64]*DataPartition)
 	d.computeUsage()
@@ -123,10 +123,10 @@ func (d *Disk) computeUsage() (err error) {
 	if unallocated < 0 {
 		unallocated = 0
 	}
-	if d.Available<=0{
-		d.RejectWrite=true
-	}else {
-		d.RejectWrite=false
+	if d.Available <= 0 {
+		d.RejectWrite = true
+	} else {
+		d.RejectWrite = false
 	}
 	d.Unallocated = uint64(unallocated)
 

--- a/datanode/partition.go
+++ b/datanode/partition.go
@@ -111,7 +111,7 @@ type DataPartition struct {
 	snapshotMutex                 sync.RWMutex
 	intervalToUpdatePartitionSize int64
 	loadExtentHeaderStatus        int
-	FullSyncTinyDeleteTime int64
+	FullSyncTinyDeleteTime        int64
 }
 
 func CreateDataPartition(dpCfg *dataPartitionCfg, disk *Disk, request *proto.CreateDataPartitionRequest) (dp *DataPartition, err error) {
@@ -303,7 +303,7 @@ func (dp *DataPartition) Disk() *Disk {
 	return dp.disk
 }
 
-func (dp *DataPartition) IsRejectWrite() bool{
+func (dp *DataPartition) IsRejectWrite() bool {
 	return dp.Disk().RejectWrite
 }
 
@@ -351,11 +351,11 @@ func (dp *DataPartition) PersistMetadata(dataPartitionCreateType int) (err error
 	sort.Sort(sp)
 
 	md := &DataPartitionMetadata{
-		VolumeID:                dp.config.VolName,
-		PartitionID:             dp.config.PartitionID,
-		PartitionSize:           dp.config.PartitionSize,
-		Peers:                   dp.config.Peers,
-		Hosts:                   dp.config.Hosts,
+		VolumeID:      dp.config.VolName,
+		PartitionID:   dp.config.PartitionID,
+		PartitionSize: dp.config.PartitionSize,
+		Peers:         dp.config.Peers,
+		Hosts:         dp.config.Hosts,
 		DataPartitionCreateType: dataPartitionCreateType,
 		CreateTime:              time.Now().Format(TimeLayout),
 	}

--- a/datanode/partition_op_by_raft.go
+++ b/datanode/partition_op_by_raft.go
@@ -225,8 +225,8 @@ func (dp *DataPartition) ApplyRandomWrite(command []byte, raftApplyID uint64) (r
 			resp = proto.OpDiskErr
 		}
 	}()
-	if dp.IsRejectWrite(){
-		err=fmt.Errorf("partition(%v) disk(%v) err(%v)",dp.partitionID,dp.Disk().Path,syscall.ENOSPC)
+	if dp.IsRejectWrite() {
+		err = fmt.Errorf("partition(%v) disk(%v) err(%v)", dp.partitionID, dp.Disk().Path, syscall.ENOSPC)
 		return
 	}
 

--- a/datanode/partition_op_by_raft.go
+++ b/datanode/partition_op_by_raft.go
@@ -237,7 +237,7 @@ func (dp *DataPartition) ApplyRandomWrite(command []byte, raftApplyID uint64) (r
 	log.LogDebugf("[ApplyRandomWrite] ApplyID(%v) Partition(%v)_Extent(%v)_ExtentOffset(%v)_Size(%v)",
 		raftApplyID, dp.partitionID, opItem.extentID, opItem.offset, opItem.size)
 	for i := 0; i < 20; i++ {
-		err = dp.ExtentStore().Write(opItem.extentID, opItem.offset, opItem.size, opItem.data, opItem.crc, NotUpdateSize, opItem.opcode == proto.OpSyncRandomWrite)
+		err = dp.ExtentStore().Write(opItem.extentID, opItem.offset, opItem.size, opItem.data, opItem.crc, storage.RandomWriteType, opItem.opcode == proto.OpSyncRandomWrite)
 		if dp.checkIsDiskError(err) {
 			return
 		}

--- a/datanode/wrap_operator.go
+++ b/datanode/wrap_operator.go
@@ -371,7 +371,7 @@ func (s *DataNode) handleWritePacket(p *repl.Packet) {
 	}
 	store := partition.ExtentStore()
 	if p.Size <= util.BlockSize {
-		err = store.Write(p.ExtentID, p.ExtentOffset, int64(p.Size), p.Data, p.CRC, UpdateSize, p.Opcode == proto.OpSyncWrite)
+		err = store.Write(p.ExtentID, p.ExtentOffset, int64(p.Size), p.Data, p.CRC, storage.AppendWriteType, p.IsSyncWrite())
 		partition.checkIsDiskError(err)
 	} else {
 		size := p.Size
@@ -383,7 +383,7 @@ func (s *DataNode) handleWritePacket(p *repl.Packet) {
 			currSize := util.Min(int(size), util.BlockSize)
 			data := p.Data[offset : offset+currSize]
 			crc := crc32.ChecksumIEEE(data)
-			err = store.Write(p.ExtentID, p.ExtentOffset+int64(offset), int64(currSize), data, crc, UpdateSize, p.Opcode == proto.OpSyncWrite)
+			err = store.Write(p.ExtentID, p.ExtentOffset+int64(offset), int64(currSize), data, crc, storage.AppendWriteType, p.IsSyncWrite())
 			partition.checkIsDiskError(err)
 			if err != nil {
 				break

--- a/repl/packet.go
+++ b/repl/packet.go
@@ -395,3 +395,11 @@ func (p *Packet) IsMarkDeleteExtentOperation() bool {
 func (p *Packet) IsReadOperation() bool {
 	return p.Opcode == proto.OpStreamRead || p.Opcode == proto.OpRead || p.Opcode == proto.OpExtentRepairRead || p.Opcode == proto.OpReadTinyDeleteRecord || p.Opcode == proto.OpTinyExtentRepairRead
 }
+
+func (p *Packet) IsRandomWrite() bool {
+	return p.Opcode == proto.OpRandomWrite || p.Opcode == proto.OpSyncRandomWrite
+}
+
+func (p *Packet) IsSyncWrite() bool {
+	return p.Opcode == proto.OpSyncWrite || p.Opcode == proto.OpSyncRandomWrite
+}

--- a/storage/extent_store.go
+++ b/storage/extent_store.go
@@ -50,6 +50,8 @@ const (
 	MinExtentID              = 1024
 	DeleteTinyRecordSize     = 24
 	UpdateCrcInterval        = 600
+	RandomWriteType          = 2
+	AppendWriteType          = 1
 )
 
 var (
@@ -284,7 +286,7 @@ func (s *ExtentStore) initBaseFileID() (err error) {
 }
 
 // Write writes the given extent to the disk.
-func (s *ExtentStore) Write(extentID uint64, offset, size int64, data []byte, crc uint32, isUpdateSize bool, isSync bool) (err error) {
+func (s *ExtentStore) Write(extentID uint64, offset, size int64, data []byte, crc uint32, writeType int, isSync bool) (err error) {
 	var (
 		e  *Extent
 		ei *ExtentInfo
@@ -299,7 +301,7 @@ func (s *ExtentStore) Write(extentID uint64, offset, size int64, data []byte, cr
 	if err = s.checkOffsetAndSize(extentID, offset, size); err != nil {
 		return err
 	}
-	err = e.Write(data, offset, size, crc, isUpdateSize, isSync, s.PersistenceBlockCrc, ei)
+	err = e.Write(data, offset, size, crc, writeType, isSync, s.PersistenceBlockCrc, ei)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fix: Datanode Repair time out and  tinyExtentRepair flow execlude Write flow