### PR TITLE
refactor: keep mount point in error stataus when client is killed

### DIFF
--- a/client/fuse.go
+++ b/client/fuse.go
@@ -223,8 +223,7 @@ func registerInterceptedSignal(mnt string) {
 	signal.Notify(sigC, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
 		sig := <-sigC
-		syslog.Printf("Umount due to a received signal (%v)\n", sig)
-		fuse.Unmount(mnt)
+		syslog.Printf("Killed due to a received signal (%v)\n", sig)
 	}()
 }
 

--- a/clientv2/main.go
+++ b/clientv2/main.go
@@ -216,8 +216,7 @@ func registerInterceptedSignal(mnt string) {
 	signal.Notify(sigC, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
 		sig := <-sigC
-		syslog.Printf("Umount due to a received signal (%v)\n", sig)
-		fuse.Unmount(mnt)
+		syslog.Printf("Killed due to a received signal (%v)\n", sig)
 	}()
 }
 


### PR DESCRIPTION
This commit will keep the mount point directory in error status when
client is killed, so the successive writes to this directory will not be
written to local disk. And the writer knows client is down as soon as
possible.

Signed-off-by: Shuoran Liu <shuoranliu@gmail.com>