### PR TITLE
fix: client gets stale file size if streamer is auto evicted

### DIFF
--- a/clientv2/fs/dir.go
+++ b/clientv2/fs/dir.go
@@ -196,7 +196,7 @@ func (s *Super) LookUpInode(ctx context.Context, op *fuseops.LookUpInodeOp) erro
 	fillChildEntry(&op.Entry, inode)
 
 	if inode.mode.IsRegular() {
-		fileSize, gen := s.ec.FileSize(ino)
+		fileSize, gen := s.fileSize(ino)
 		log.LogDebugf("LookUpInode: Get filesize, op(%v) fileSize(%v) gen(%v) inode.gen(%v)", desc, fileSize, gen, inode.gen)
 		if gen >= inode.gen {
 			op.Entry.Attributes.Size = uint64(fileSize)

--- a/clientv2/fs/misc.go
+++ b/clientv2/fs/misc.go
@@ -39,7 +39,7 @@ func (s *Super) GetInodeAttributes(ctx context.Context, op *fuseops.GetInodeAttr
 	op.AttributesExpiration = time.Now().Add(AttrValidDuration)
 
 	if inode.mode.IsRegular() {
-		fileSize, gen := s.ec.FileSize(ino)
+		fileSize, gen := s.fileSize(ino)
 		log.LogDebugf("GetInodeAttributes: op(%v) fileSize(%v) gen(%v) inode.gen(%v)", desc, fileSize, gen, inode.gen)
 		if gen >= inode.gen {
 			op.Attributes.Size = uint64(fileSize)
@@ -92,7 +92,7 @@ func (s *Super) SetInodeAttributes(ctx context.Context, op *fuseops.SetInodeAttr
 	}
 
 	if inode.mode.IsRegular() {
-		fileSize, gen := s.ec.FileSize(ino)
+		fileSize, gen := s.fileSize(ino)
 		log.LogDebugf("SetInodeAttributes: Get filesize, op(%v) fileSize(%v) gen(%v) inode.gen(%v)", desc, fileSize, gen, inode.gen)
 		if gen >= inode.gen {
 			op.Attributes.Size = uint64(fileSize)

--- a/sdk/data/stream/extent_client.go
+++ b/sdk/data/stream/extent_client.go
@@ -151,12 +151,14 @@ func (client *ExtentClient) RefreshExtentsCache(inode uint64) error {
 }
 
 // FileSize returns the file size.
-func (client *ExtentClient) FileSize(inode uint64) (size int, gen uint64) {
+func (client *ExtentClient) FileSize(inode uint64) (size int, gen uint64, valid bool) {
 	s := client.GetStreamer(inode)
 	if s == nil {
 		return
 	}
-	return s.extents.Size()
+	valid = true
+	size, gen = s.extents.Size()
+	return
 }
 
 // SetFileSize set the file size.


### PR DESCRIPTION
If streamer is auto evicted, then extent client FileSize() will return a
generation of 0 and there is a chance for GetAttr system call to get
stale file size. So in such case, client should not trust inode cache
and send an iget request to metanode explicitly.

Signed-off-by: Shuoran Liu <shuoranliu@gmail.com>