### PR TITLE
Fix: then client cannnot mount (if dp only has 10) and add disk error condition

### DIFF
--- a/datanode/server.go
+++ b/datanode/server.go
@@ -431,7 +431,7 @@ func (s *DataNode) incDiskErrCnt(partitionID uint64, err error, flag uint8) {
 }
 
 func IsDiskErr(errMsg string) bool {
-	if strings.Contains(errMsg, syscall.EIO.Error()) {
+	if strings.Contains(errMsg, syscall.EIO.Error()) || strings.Contains(errMsg,syscall.EROFS.Error()) {
 		return true
 	}
 

--- a/sdk/data/wrapper/wrapper.go
+++ b/sdk/data/wrapper/wrapper.go
@@ -36,6 +36,7 @@ var (
 
 var (
 	LocalIP string
+	MinWriteAbleDataPartitionCnt=10
 )
 
 type DataPartitionView struct {
@@ -140,7 +141,7 @@ func (w *Wrapper) updateDataPartition() error {
 		}
 	}
 
-	if len(rwPartitionGroups) > 10 {
+	if len(rwPartitionGroups) >= MinWriteAbleDataPartitionCnt {
 		w.rwPartition = rwPartitionGroups
 		w.localLeaderPartitions = localLeaderPartitionGroups
 	} else {


### PR DESCRIPTION
1.if master only create DataPartitionCnt is 10,then cannnot mount 
2.Increase the judgment condition of disk error,add syscall.EROFS
Signed-off-by: awzhgw <guowl18702995996@gmail.com>