### PR TITLE
Fix: dataPartition disk error ,not recvoery raft log on new datanode

### DIFF
--- a/datanode/const.go
+++ b/datanode/const.go
@@ -89,7 +89,6 @@ const (
 	StreamRead = false
 )
 
-
 const (
 	BufferWrite = false
 )

--- a/datanode/data_partition_repair.go
+++ b/datanode/data_partition_repair.go
@@ -144,7 +144,7 @@ func (dp *DataPartition) buildDataPartitionRepairTask(repairTasks []*DataPartiti
 	for index := 1; index < len(dp.replicas); index++ {
 		extents, err := dp.getRemoteExtentInfo(extentType, tinyExtents, dp.replicas[index])
 		if err != nil {
-			log.LogErrorf("buildDataPartitionRepairTask partitionID(%v) on (%v) err(%v)", dp.partitionID, dp.replicas[index], err)
+			log.LogErrorf("buildDataPartitionRepairTask PartitionID(%v) on (%v) err(%v)", dp.partitionID, dp.replicas[index], err)
 			continue
 		}
 		repairTasks[index] = NewDataPartitionRepairTask(extents, leaderTinyDeleteRecordFileSize, dp.replicas[index], dp.replicas[0])

--- a/datanode/disk.go
+++ b/datanode/disk.go
@@ -334,7 +334,7 @@ func (d *Disk) RestorePartition(visitor PartitionVisitor) {
 				filename, d.Path, err.Error())
 			continue
 		}
-		log.LogDebugf("acton[RestorePartition] disk(%v) path(%v) partitionID(%v) partitionSize(%v).",
+		log.LogDebugf("acton[RestorePartition] disk(%v) path(%v) PartitionID(%v) partitionSize(%v).",
 			d.Path, fileInfo.Name(), partitionID, partitionSize)
 		wg.Add(1)
 

--- a/datanode/partition.go
+++ b/datanode/partition.go
@@ -174,8 +174,7 @@ func LoadDataPartition(partitionDir string, disk *Disk) (dp *DataPartition, err 
 	if err = dp.LoadAppliedID(); err != nil {
 		log.LogErrorf("action[loadApplyIndex] %v", err)
 	}
-
-	log.LogInfof("Action(LoadDataPartition) partitionID(%v) meta(%v)", dp.partitionID, meta)
+	log.LogInfof("Action(LoadDataPartition) PartitionID(%v) meta(%v)", dp.partitionID, meta)
 	dp.DataPartitionCreateType = meta.DataPartitionCreateType
 	dp.lastTruncateID = meta.LastTruncateID
 	if meta.DataPartitionCreateType == proto.NormalCreateDataPartition {

--- a/datanode/partition_raftfsm.go
+++ b/datanode/partition_raftfsm.go
@@ -63,7 +63,8 @@ func (dp *DataPartition) ApplyMemberChange(confChange *raftproto.ConfChange, ind
 		return
 	}
 	if isUpdated {
-		if err = dp.PersistMetadata(proto.NormalCreateDataPartition); err != nil {
+		dp.DataPartitionCreateType = proto.NormalCreateDataPartition
+		if err = dp.PersistMetadata(); err != nil {
 			log.LogErrorf("action[ApplyMemberChange] dp(%v) PersistMetadata err(%v).", dp.partitionID, err)
 			return
 		}
@@ -75,14 +76,16 @@ func (dp *DataPartition) ApplyMemberChange(confChange *raftproto.ConfChange, ind
 // Note that the data in each data partition has already been saved on the disk. Therefore there is no need to take the
 // snapshot in this case.
 func (dp *DataPartition) Snapshot() (raftproto.Snapshot, error) {
-	applyID := dp.appliedID
-	snapIterator := NewItemIterator(applyID)
+	snapIterator := NewItemIterator(dp.lastTruncateID)
+	log.LogInfof("SendSnapShot PartitionID(%v) Snapshot lastTruncateID(%v) currentApplyID(%v) firstCommitID(%v)",
+		dp.partitionID, dp.lastTruncateID, dp.appliedID, dp.raftPartition.CommittedIndex())
 	return snapIterator, nil
 }
 
 // ApplySnapshot asks the raft leader for the snapshot data to recover the contents on the local disk.
 func (dp *DataPartition) ApplySnapshot(peers []raftproto.Peer, iterator raftproto.SnapIterator) (err error) {
 	// Never delete the raft log which hadn't applied, so snapshot no need.
+	log.LogInfof("PartitionID(%v) ApplySnapshot to (%v)", dp.partitionID, dp.raftPartition.CommittedIndex())
 	return
 }
 

--- a/datanode/server.go
+++ b/datanode/server.go
@@ -305,7 +305,7 @@ func (s *DataNode) register(cfg *config.Config) {
 
 			nodeID := strings.TrimSpace(string(data))
 			s.nodeID, err = strconv.ParseUint(nodeID, 10, 64)
-			log.LogDebug("[tempDebug] nodeID=%v", s.nodeID)
+			log.LogDebug("[tempDebug] nodeID(%v)", s.nodeID)
 			return
 		case <-s.stopC:
 			timer.Stop()

--- a/datanode/wrap_operator.go
+++ b/datanode/wrap_operator.go
@@ -261,7 +261,7 @@ func (s *DataNode) handlePacketToDeleteDataPartition(p *repl.Packet) {
 	data, _ := json.Marshal(task)
 	_, err = MasterHelper.Request("POST", proto.GetDataNodeTaskResponse, nil, data)
 	if err != nil {
-		err = errors.Trace(err, "delete DataPartition failed,partitionID(%v)", request.PartitionId)
+		err = errors.Trace(err, "delete DataPartition failed,PartitionID(%v)", request.PartitionId)
 		log.LogErrorf("action[handlePacketToDeleteDataPartition] err(%v).", err)
 	}
 	log.LogInfof(fmt.Sprintf("action[handlePacketToDeleteDataPartition] %v error(%v)", request.PartitionId, string(data)))
@@ -322,7 +322,7 @@ func (s *DataNode) asyncLoadDataPartition(task *proto.AdminTask) {
 	}
 	_, err = MasterHelper.Request("POST", proto.GetDataNodeTaskResponse, nil, data)
 	if err != nil {
-		err = errors.Trace(err, "load DataPartition failed,partitionID(%v)", request.PartitionId)
+		err = errors.Trace(err, "load DataPartition failed,PartitionID(%v)", request.PartitionId)
 		log.LogError(errors.Stack(err))
 	}
 }
@@ -709,7 +709,7 @@ func (s *DataNode) handleBroadcastMinAppliedID(p *repl.Packet) {
 	if minAppliedID > 0 {
 		partition.SetMinAppliedID(minAppliedID)
 	}
-	log.LogDebugf("[handleBroadcastMinAppliedID] partition=%v minAppliedID=%v", partition.partitionID, minAppliedID)
+	log.LogDebugf("[handleBroadcastMinAppliedID] partition(%v) minAppliedID(%v)", partition.partitionID, minAppliedID)
 	p.PacketOkReply()
 	return
 }
@@ -718,7 +718,7 @@ func (s *DataNode) handleBroadcastMinAppliedID(p *repl.Packet) {
 func (s *DataNode) handlePacketToGetAppliedID(p *repl.Packet) {
 	partition := p.Object.(*DataPartition)
 	appliedID := partition.GetAppliedID() //return current appliedID
-	log.LogDebugf("[handlePacketToGetAppliedID] partition=%v curAppId=%v",
+	log.LogDebugf("[handlePacketToGetAppliedID] partition(%v) curAppId(%v)",
 		partition.partitionID, appliedID)
 	buf := make([]byte, 8)
 	binary.BigEndian.PutUint64(buf, appliedID)

--- a/raftstore/partition.go
+++ b/raftstore/partition.go
@@ -63,6 +63,9 @@ type Partition interface {
 	// CommittedIndex returns the current index of the applied raft log in the raft store partition.
 	CommittedIndex() uint64
 
+	// FirstCommittedIndex returns the first committed index of raft log in the raft store partition.
+	FirstCommittedIndex() uint64
+
 	// Truncate raft log
 	Truncate(index uint64)
 }
@@ -130,6 +133,11 @@ func (p *partition) AppliedIndex() (applied uint64) {
 func (p *partition) CommittedIndex() (applied uint64) {
 	applied = p.raft.CommittedIndex(p.id)
 	return
+}
+
+// FirstCommittedIndex returns the first committed index of raft log in the raft store partition.
+func (p *partition) FirstCommittedIndex() uint64 {
+	return p.raft.FirstCommittedIndex(p.id)
 }
 
 // Submit submits command data to raft log.

--- a/storage/extent.go
+++ b/storage/extent.go
@@ -221,8 +221,10 @@ func (e *Extent) Write(data []byte, offset, size int64, crc uint32, writeType in
 	blockNo := offset / util.BlockSize
 	offsetInBlock := offset % util.BlockSize
 	defer func() {
-		e.dataSize = int64(math.Max(float64(e.dataSize), float64(offset+size)))
-		atomic.StoreInt64(&e.modifyTime, time.Now().Unix())
+		if IsAppendWrite(writeType) {
+			atomic.StoreInt64(&e.modifyTime, time.Now().Unix())
+			e.dataSize = int64(math.Max(float64(e.dataSize), float64(offset+size)))
+		}
 	}()
 	if isSync {
 		if err = e.file.Sync(); err != nil {

--- a/storage/extent_store.go
+++ b/storage/extent_store.go
@@ -909,4 +909,3 @@ func (s *ExtentStore) TinyExtentAvaliOffset(extentID uint64, offset int64) (newO
 
 	return
 }
-

--- a/vendor/github.com/tiglabs/raft/server.go
+++ b/vendor/github.com/tiglabs/raft/server.go
@@ -253,6 +253,17 @@ func (rs *RaftServer) CommittedIndex(id uint64) uint64 {
 	return 0
 }
 
+func (rs *RaftServer) FirstCommittedIndex(id uint64) uint64 {
+	rs.mu.RLock()
+	raft, ok := rs.rafts[id]
+	rs.mu.RUnlock()
+
+	if ok {
+		return raft.raftFsm.raftLog.firstIndex()
+	}
+	return 0
+}
+
 func (rs *RaftServer) TryToLeader(id uint64) (future *Future) {
 	rs.mu.RLock()
 	raft, ok := rs.rafts[id]


### PR DESCRIPTION
if dataPartition disk error ,master can new dataParittion on new Host, the snapshot recovery fininsh ,then start raftPartition, but not recovery raftLog