### PR TITLE
feature: support read from raft follower instead of just leader  …

### DIFF
--- a/datanode/partition_raftfsm.go
+++ b/datanode/partition_raftfsm.go
@@ -20,7 +20,6 @@ import (
 	"sync/atomic"
 
 	"github.com/chubaofs/chubaofs/proto"
-	"github.com/chubaofs/chubaofs/util/exporter"
 	"github.com/chubaofs/chubaofs/util/log"
 	"github.com/tiglabs/raft"
 	raftproto "github.com/tiglabs/raft/proto"
@@ -96,9 +95,6 @@ func (dp *DataPartition) HandleFatalEvent(err *raft.FatalError) {
 
 // HandleLeaderChange notifies the application when the raft leader has changed.
 func (dp *DataPartition) HandleLeaderChange(leader uint64) {
-	exporter.Warning(fmt.Sprintf("LeaderChange: partition=%d, "+
-		"newLeader=%d", dp.config.PartitionID, leader))
-
 	if dp.config.NodeID == leader {
 		dp.isRaftLeader = true
 	}

--- a/datanode/wrap_operator.go
+++ b/datanode/wrap_operator.go
@@ -72,7 +72,7 @@ func (s *DataNode) OperatePacket(p *repl.Packet, c *net.TCPConn) (err error) {
 	case proto.OpStreamRead:
 		s.handleStreamReadPacket(p, c, StreamRead)
 	case proto.OpStreamFollowerRead:
-		s.handleExtentRepaiReadPacket(p, c, RepairRead)
+		s.handleExtentRepaiReadPacket(p, c, StreamRead)
 	case proto.OpExtentRepairRead:
 		s.handleExtentRepaiReadPacket(p, c, RepairRead)
 	case proto.OpTinyExtentRepairRead:

--- a/master/api_service_test.go
+++ b/master/api_service_test.go
@@ -272,6 +272,24 @@ func TestUpdateVol(t *testing.T) {
 	reqURL := fmt.Sprintf("%v%v?name=%v&capacity=%v&authKey=%v",
 		hostAddr, proto.AdminUpdateVol, commonVol.Name, capacity, buildAuthKey("cfs"))
 	process(reqURL, t)
+	vol, err := server.cluster.getVol(commonVolName)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if vol.FollowerRead != false {
+		t.Errorf("expect FollowerRead is false, but is %v", vol.FollowerRead)
+		return
+	}
+
+	reqURL = fmt.Sprintf("%v%v?name=%v&capacity=%v&authKey=%v&followerRead=true",
+		hostAddr, proto.AdminUpdateVol, commonVol.Name, capacity, buildAuthKey("cfs"))
+	process(reqURL, t)
+	if vol.FollowerRead != true {
+		t.Errorf("expect FollowerRead is true, but is %v", vol.FollowerRead)
+		return
+	}
+
 }
 func buildAuthKey(owner string) string {
 	h := md5.New()

--- a/master/api_service_test.go
+++ b/master/api_service_test.go
@@ -94,7 +94,7 @@ func createDefaultMasterServerForTest() *Server {
 	time.Sleep(5 * time.Second)
 	testServer.cluster.scheduleToUpdateStatInfo()
 	fmt.Printf("nodeSet len[%v]\n", len(testServer.cluster.t.nodeSetMap))
-	testServer.cluster.createVol(commonVolName, "cfs", 3, 3, 100,defaultReplicaNum)
+	testServer.cluster.createVol(commonVolName, "cfs", 3, 3, 100, defaultReplicaNum, false)
 	vol, err := testServer.cluster.getVol(commonVolName)
 	if err != nil {
 		panic(err)

--- a/master/cluster.go
+++ b/master/cluster.go
@@ -966,7 +966,7 @@ errHandler:
 
 // Create a new volume.
 // By default we create 3 meta partitions and 10 data partitions during initialization.
-func (c *Cluster) createVol(name, owner string, mpCount, size, capacity, dpReplicaNum int) (vol *Vol, err error) {
+func (c *Cluster) createVol(name, owner string, mpCount, size, capacity, dpReplicaNum int,followerRead bool) (vol *Vol, err error) {
 	var (
 		dataPartitionSize       uint64
 		readWriteDataPartitions int
@@ -976,7 +976,7 @@ func (c *Cluster) createVol(name, owner string, mpCount, size, capacity, dpRepli
 	} else {
 		dataPartitionSize = uint64(size) * util.GB
 	}
-	if vol, err = c.doCreateVol(name, owner, dataPartitionSize, uint64(capacity), dpReplicaNum); err != nil {
+	if vol, err = c.doCreateVol(name, owner, dataPartitionSize, uint64(capacity), dpReplicaNum,followerRead); err != nil {
 		goto errHandler
 	}
 	if err = vol.initMetaPartitions(c, mpCount); err != nil {
@@ -1004,7 +1004,7 @@ errHandler:
 	return
 }
 
-func (c *Cluster) doCreateVol(name, owner string, dpSize, capacity uint64, dpReplicaNum int) (vol *Vol, err error) {
+func (c *Cluster) doCreateVol(name, owner string, dpSize, capacity uint64, dpReplicaNum int,followerRead bool) (vol *Vol, err error) {
 	var id uint64
 	c.createVolMutex.Lock()
 	defer c.createVolMutex.Unlock()
@@ -1016,7 +1016,7 @@ func (c *Cluster) doCreateVol(name, owner string, dpSize, capacity uint64, dpRep
 	if err != nil {
 		goto errHandler
 	}
-	vol = newVol(id, name, owner, dpSize, capacity, uint8(dpReplicaNum), defaultReplicaNum)
+	vol = newVol(id, name, owner, dpSize, capacity, uint8(dpReplicaNum), defaultReplicaNum,followerRead)
 	if err = c.syncAddVol(vol); err != nil {
 		goto errHandler
 	}

--- a/master/cluster_test.go
+++ b/master/cluster_test.go
@@ -19,7 +19,7 @@ func buildPanicVol() *Vol {
 	if err != nil {
 		return nil
 	}
-	vol := newVol(id, commonVol.Name, commonVol.Owner, commonVol.dataPartitionSize, commonVol.Capacity, defaultReplicaNum, defaultReplicaNum)
+	vol := newVol(id, commonVol.Name, commonVol.Owner, commonVol.dataPartitionSize, commonVol.Capacity, defaultReplicaNum, defaultReplicaNum,false)
 	vol.dataPartitions = nil
 	return vol
 }

--- a/master/const.go
+++ b/master/const.go
@@ -32,6 +32,7 @@ const (
 	volOwnerKey           = "owner"
 	volAuthKey            = "authKey"
 	replicaNumKey         = "replicaNum"
+	followerReadKey       = "followerRead"
 )
 
 const (

--- a/master/metadata_fsm_op.go
+++ b/master/metadata_fsm_op.go
@@ -114,6 +114,7 @@ type volValue struct {
 	DataPartitionSize uint64
 	Capacity          uint64
 	Owner             string
+	FollowerRead      bool
 }
 
 func newVolValue(vol *Vol) (vv *volValue) {
@@ -126,6 +127,7 @@ func newVolValue(vol *Vol) (vv *volValue) {
 		DataPartitionSize: vol.dataPartitionSize,
 		Capacity:          vol.Capacity,
 		Owner:             vol.Owner,
+		FollowerRead:      vol.FollowerRead,
 	}
 	return
 }
@@ -520,7 +522,7 @@ func (c *Cluster) loadVols() (err error) {
 			err = fmt.Errorf("action[loadVols],value:%v,unmarshal err:%v", string(value), err)
 			return err
 		}
-		vol := newVol(vv.ID, vv.Name, vv.Owner, vv.DataPartitionSize, vv.Capacity, vv.DpReplicaNum, vv.ReplicaNum)
+		vol := newVol(vv.ID, vv.Name, vv.Owner, vv.DataPartitionSize, vv.Capacity, vv.DpReplicaNum, vv.ReplicaNum, vv.FollowerRead)
 		vol.Status = vv.Status
 		c.putVol(vol)
 		log.LogInfof("action[loadVols],vol[%v]", vol.Name)

--- a/master/vol_test.go
+++ b/master/vol_test.go
@@ -171,7 +171,7 @@ func markDeleteVol(name string, t *testing.T) {
 
 func TestVolReduceReplicaNum(t *testing.T) {
 	volName := "reduce-replica-num"
-	vol, err := server.cluster.createVol(volName, volName, 3, util.DefaultDataPartitionSize, 100, defaultReplicaNum,false)
+	vol, err := server.cluster.createVol(volName, volName, 3, util.DefaultDataPartitionSize, 100, defaultReplicaNum, false)
 	if err != nil {
 		t.Error(err)
 		return
@@ -210,7 +210,7 @@ func TestVolReduceReplicaNum(t *testing.T) {
 func TestConcurrentReadWriteDataPartitionMap(t *testing.T) {
 	name := "TestConcurrentReadWriteDataPartitionMap"
 	var volID uint64 = 1
-	vol := newVol(volID, name, name, util.DefaultDataPartitionSize, 100, defaultReplicaNum, defaultReplicaNum)
+	vol := newVol(volID, name, name, util.DefaultDataPartitionSize, 100, defaultReplicaNum, defaultReplicaNum, false)
 	//unavaliable mp
 	mp1 := newMetaPartition(1, 1, defaultMaxMetaPartitionInodeID, 3, name, volID)
 	vol.addMetaPartition(mp1)

--- a/master/vol_test.go
+++ b/master/vol_test.go
@@ -171,7 +171,7 @@ func markDeleteVol(name string, t *testing.T) {
 
 func TestVolReduceReplicaNum(t *testing.T) {
 	volName := "reduce-replica-num"
-	vol, err := server.cluster.createVol(volName, volName, 3, util.DefaultDataPartitionSize, 100, defaultReplicaNum)
+	vol, err := server.cluster.createVol(volName, volName, 3, util.DefaultDataPartitionSize, 100, defaultReplicaNum,false)
 	if err != nil {
 		t.Error(err)
 		return

--- a/proto/admin_proto.go
+++ b/proto/admin_proto.go
@@ -308,6 +308,7 @@ type DataPartitionResponse struct {
 	ReplicaNum  uint8
 	Hosts       []string
 	LeaderAddr  string
+	Epoch       uint64
 }
 
 // DataPartitionsView defines the view of a data partition

--- a/proto/admin_proto.go
+++ b/proto/admin_proto.go
@@ -335,13 +335,15 @@ type MetaPartitionView struct {
 type VolView struct {
 	Name           string
 	Status         uint8
+	FollowerRead   bool
 	MetaPartitions []*MetaPartitionView
 	DataPartitions []*DataPartitionResponse
 }
 
-func NewVolView(name string, status uint8) (view *VolView) {
+func NewVolView(name string, status uint8, followerRead bool) (view *VolView) {
 	view = new(VolView)
 	view.Name = name
+	view.FollowerRead = followerRead
 	view.Status = status
 	view.MetaPartitions = make([]*MetaPartitionView, 0)
 	view.DataPartitions = make([]*DataPartitionResponse, 0)
@@ -370,4 +372,5 @@ type SimpleVolView struct {
 	RwDpCnt      int
 	MpCnt        int
 	DpCnt        int
+	FollowerRead bool
 }

--- a/proto/packet.go
+++ b/proto/packet.go
@@ -44,14 +44,15 @@ const (
 
 // Operations
 const (
-	ProtoMagic         uint8 = 0xFF
-	OpInitResultCode   uint8 = 0x00
-	OpCreateExtent     uint8 = 0x01
-	OpMarkDelete       uint8 = 0x02
-	OpWrite            uint8 = 0x03
-	OpRead             uint8 = 0x04
-	OpStreamRead       uint8 = 0x05
-	OpGetAllWatermarks uint8 = 0x07
+	ProtoMagic           uint8 = 0xFF
+	OpInitResultCode     uint8 = 0x00
+	OpCreateExtent       uint8 = 0x01
+	OpMarkDelete         uint8 = 0x02
+	OpWrite              uint8 = 0x03
+	OpRead               uint8 = 0x04
+	OpStreamRead         uint8 = 0x05
+	OpStreamFollowerRead uint8 = 0x06
+	OpGetAllWatermarks   uint8 = 0x07
 
 	OpNotifyReplicasToRepair         uint8 = 0x08
 	OpExtentRepairRead               uint8 = 0x09
@@ -211,6 +212,8 @@ func (p *Packet) GetOpMsg() (m string) {
 		m = "Read"
 	case OpStreamRead:
 		m = "OpStreamRead"
+	case OpStreamFollowerRead:
+		m = "OpStreamFollowerRead"
 	case OpGetAllWatermarks:
 		m = "OpGetAllWatermarks"
 	case OpNotifyReplicasToRepair:
@@ -480,7 +483,7 @@ func (p *Packet) ReadFromConn(c net.Conn, timeoutSec int) (err error) {
 		return
 	}
 	size := p.Size
-	if (p.Opcode == OpRead || p.Opcode == OpStreamRead || p.Opcode == OpExtentRepairRead) && p.ResultCode == OpInitResultCode {
+	if (p.Opcode == OpRead || p.Opcode == OpStreamRead || p.Opcode == OpExtentRepairRead || p.Opcode== OpStreamFollowerRead) && p.ResultCode == OpInitResultCode {
 		size = 0
 	}
 	p.Data = make([]byte, size)

--- a/repl/packet.go
+++ b/repl/packet.go
@@ -393,7 +393,9 @@ func (p *Packet) IsMarkDeleteExtentOperation() bool {
 }
 
 func (p *Packet) IsReadOperation() bool {
-	return p.Opcode == proto.OpStreamRead || p.Opcode == proto.OpRead || p.Opcode == proto.OpExtentRepairRead || p.Opcode == proto.OpReadTinyDeleteRecord || p.Opcode == proto.OpTinyExtentRepairRead
+	return p.Opcode == proto.OpStreamRead || p.Opcode == proto.OpRead ||
+		p.Opcode == proto.OpExtentRepairRead || p.Opcode == proto.OpReadTinyDeleteRecord ||
+			p.Opcode == proto.OpTinyExtentRepairRead || p.Opcode==proto.OpStreamFollowerRead
 }
 
 func (p *Packet) IsRandomWrite() bool {

--- a/sdk/data/stream/extent_client.go
+++ b/sdk/data/stream/extent_client.go
@@ -54,6 +54,7 @@ type ExtentClient struct {
 	appendExtentKey AppendExtentKeyFunc
 	getExtents      GetExtentsFunc
 	truncate        TruncateFunc
+	followerRead    bool
 }
 
 // NewExtentClient returns a new extent client.
@@ -78,6 +79,7 @@ retry:
 	client.appendExtentKey = appendExtentKey
 	client.getExtents = getExtents
 	client.truncate = truncate
+	client.followerRead = gDataWrapper.FollowerRead()
 
 	// Init request pools
 	openRequestPool = &sync.Pool{New: func() interface{} {

--- a/sdk/data/stream/extent_reader.go
+++ b/sdk/data/stream/extent_reader.go
@@ -27,17 +27,19 @@ import (
 
 // ExtentReader defines the struct of the extent reader.
 type ExtentReader struct {
-	inode uint64
-	key   *proto.ExtentKey
-	dp    *wrapper.DataPartition
+	inode        uint64
+	key          *proto.ExtentKey
+	dp           *wrapper.DataPartition
+	followerRead bool
 }
 
 // NewExtentReader returns a new extent reader.
-func NewExtentReader(inode uint64, key *proto.ExtentKey, dp *wrapper.DataPartition) *ExtentReader {
+func NewExtentReader(inode uint64, key *proto.ExtentKey, dp *wrapper.DataPartition, followerRead bool) *ExtentReader {
 	return &ExtentReader{
-		inode: inode,
-		key:   key,
-		dp:    dp,
+		inode:        inode,
+		key:          key,
+		dp:           dp,
+		followerRead: followerRead,
 	}
 }
 
@@ -52,8 +54,8 @@ func (reader *ExtentReader) Read(req *ExtentRequest) (readBytes int, err error) 
 	offset := req.FileOffset - int(reader.key.FileOffset) + int(reader.key.ExtentOffset)
 	size := req.Size
 
-	reqPacket := NewReadPacket(reader.key, offset, size, reader.inode, req.FileOffset)
-	sc := NewStreamConn(reader.dp)
+	reqPacket := NewReadPacket(reader.key, offset, size, reader.inode, req.FileOffset, reader.followerRead)
+	sc := NewStreamConn(reader.dp, reader.followerRead)
 
 	log.LogDebugf("ExtentReader Read enter: size(%v) req(%v) reqPacket(%v)", size, req, reqPacket)
 

--- a/sdk/data/stream/packet.go
+++ b/sdk/data/stream/packet.go
@@ -75,14 +75,18 @@ func NewOverwritePacket(dp *wrapper.DataPartition, extentID uint64, extentOffset
 }
 
 // NewReadPacket returns a new read packet.
-func NewReadPacket(key *proto.ExtentKey, extentOffset, size int, inode uint64, fileOffset int) *Packet {
+func NewReadPacket(key *proto.ExtentKey, extentOffset, size int, inode uint64, fileOffset int, followerRead bool) *Packet {
 	p := new(Packet)
 	p.ExtentID = key.ExtentId
 	p.PartitionID = key.PartitionId
 	p.Magic = proto.ProtoMagic
 	p.ExtentOffset = int64(extentOffset)
 	p.Size = uint32(size)
-	p.Opcode = proto.OpStreamRead
+	if followerRead {
+		p.Opcode = proto.OpStreamFollowerRead
+	} else {
+		p.Opcode = proto.OpStreamRead
+	}
 	p.ExtentType = proto.NormalExtentType
 	p.ReqID = proto.GenerateRequestID()
 	p.RemainingFollowers = 0

--- a/sdk/data/stream/stream_reader.go
+++ b/sdk/data/stream/stream_reader.go
@@ -77,7 +77,7 @@ func (s *Streamer) GetExtentReader(ek *proto.ExtentKey) (*ExtentReader, error) {
 	if err != nil {
 		return nil, err
 	}
-	reader := NewExtentReader(s.inode, ek, partition)
+	reader := NewExtentReader(s.inode, ek, partition, s.client.followerRead)
 	return reader, nil
 }
 

--- a/sdk/data/stream/stream_writer.go
+++ b/sdk/data/stream/stream_writer.go
@@ -316,7 +316,7 @@ func (s *Streamer) doOverwrite(req *ExtentRequest, direct bool) (total int, err 
 		return
 	}
 
-	sc := NewStreamConn(dp)
+	sc := NewStreamConn(dp, false)
 
 	for total < size {
 		reqPacket := NewOverwritePacket(dp, req.ExtentKey.ExtentId, offset-ekFileOffset+total+ekExtOffset, s.inode, offset)

--- a/sdk/data/wrapper/wrapper.go
+++ b/sdk/data/wrapper/wrapper.go
@@ -35,8 +35,8 @@ var (
 )
 
 var (
-	LocalIP string
-	MinWriteAbleDataPartitionCnt=10
+	LocalIP                      string
+	MinWriteAbleDataPartitionCnt = 10
 )
 
 type DataPartitionView struct {
@@ -70,6 +70,10 @@ func NewDataPartitionWrapper(volName, masterHosts string) (w *Wrapper, err error
 		err = errors.Trace(err, "NewDataPartitionWrapper:")
 		return
 	}
+	if err = w.getSimpleVolView(); err != nil {
+		err = errors.Trace(err, "NewDataPartitionWrapper:")
+		return
+	}
 	if err = w.updateDataPartition(); err != nil {
 		err = errors.Trace(err, "NewDataPartitionWrapper:")
 		return
@@ -83,11 +87,7 @@ func (w *Wrapper) FollowerRead() bool {
 }
 
 func (w *Wrapper) updateClusterInfo() error {
-	masterHelper := util.NewMasterHelper()
-	for _, ip := range w.masters {
-		masterHelper.AddNode(ip)
-	}
-	body, err := masterHelper.Request(http.MethodPost, proto.AdminGetIP, nil, nil)
+	body, err := MasterHelper.Request(http.MethodPost, proto.AdminGetIP, nil, nil)
 	if err != nil {
 		log.LogWarnf("UpdateClusterInfo request: err(%v)", err)
 		return err
@@ -105,11 +105,9 @@ func (w *Wrapper) updateClusterInfo() error {
 }
 
 func (w *Wrapper) getSimpleVolView() error {
-	masterHelper := util.NewMasterHelper()
-	for _, ip := range w.masters {
-		masterHelper.AddNode(ip)
-	}
-	body, err := masterHelper.Request(http.MethodPost, proto.AdminGetVol, nil, nil)
+	paras := make(map[string]string, 0)
+	paras["name"] = w.volName
+	body, err := MasterHelper.Request(http.MethodPost, proto.AdminGetVol, paras, nil)
 	if err != nil {
 		log.LogWarnf("getSimpleVolView request: err(%v)", err)
 		return err

--- a/sdk/data/wrapper/wrapper.go
+++ b/sdk/data/wrapper/wrapper.go
@@ -52,6 +52,7 @@ type Wrapper struct {
 	partitions            map[uint64]*DataPartition
 	rwPartition           []*DataPartition
 	localLeaderPartitions []*DataPartition
+	followerRead          bool
 }
 
 // NewDataPartitionWrapper returns a new data partition wrapper.
@@ -77,10 +78,10 @@ func NewDataPartitionWrapper(volName, masterHosts string) (w *Wrapper, err error
 	return
 }
 
-// GetClusterName returns the cluster name of the wrapper.
-func (w *Wrapper) GetClusterName() string {
-	return w.clusterName
+func (w *Wrapper) FollowerRead() bool {
+	return w.followerRead
 }
+
 func (w *Wrapper) updateClusterInfo() error {
 	masterHelper := util.NewMasterHelper()
 	for _, ip := range w.masters {
@@ -100,6 +101,27 @@ func (w *Wrapper) updateClusterInfo() error {
 	log.LogInfof("ClusterInfo: %v", *info)
 	w.clusterName = info.Cluster
 	LocalIP = info.Ip
+	return nil
+}
+
+func (w *Wrapper) getSimpleVolView() error {
+	masterHelper := util.NewMasterHelper()
+	for _, ip := range w.masters {
+		masterHelper.AddNode(ip)
+	}
+	body, err := masterHelper.Request(http.MethodPost, proto.AdminGetVol, nil, nil)
+	if err != nil {
+		log.LogWarnf("getSimpleVolView request: err(%v)", err)
+		return err
+	}
+
+	view := new(proto.SimpleVolView)
+	if err = json.Unmarshal(body, view); err != nil {
+		log.LogWarnf("getSimpleVolView unmarshal: err(%v)", err)
+		return err
+	}
+	w.followerRead = view.FollowerRead
+	log.LogInfof("SimpleVolView: %v", *view)
 	return nil
 }
 


### PR DESCRIPTION
1.If volume is created with "followerRead" specified, read requests can be oriented to raft followers as well as leader.
2.Refactor: leader change not warning on raft  …


