### PR TITLE
Refactor: master, datanode and metanode refactor dp or mp offline process

### DIFF
--- a/cmd/master/scripts/manage_dr_add.sh
+++ b/cmd/master/scripts/manage_dr_add.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+curl -v "http://127.0.0.1/dataReplica/add?id=96&addr=127.0.0.1:5000"

--- a/cmd/master/scripts/manage_dr_delete.sh
+++ b/cmd/master/scripts/manage_dr_delete.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+curl -v "http://127.0.0.1/dataReplica/delete?id=96&addr=127.0.0.1:5000"

--- a/cmd/master/scripts/manage_mr_add.sh
+++ b/cmd/master/scripts/manage_mr_add.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+curl -v "http://127.0.0.1/metaReplica/add?id=96&addr=127.0.0.1:9021"

--- a/cmd/master/scripts/manage_mr_delete.sh
+++ b/cmd/master/scripts/manage_mr_delete.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+curl -v "http://127.0.0.1/metaReplica/delete?id=96&addr=127.0.0.1:9021"

--- a/datanode/const.go
+++ b/datanode/const.go
@@ -52,15 +52,18 @@ const (
 
 // Action description
 const (
-	ActionNotifyFollowerToRepair     = "ActionNotifyFollowerRepair"
-	ActionStreamRead                 = "ActionStreamRead"
-	ActionGetDataPartitionMetrics    = "ActionGetDataPartitionMetrics"
-	ActionCreateExtent               = "ActionCreateExtent:"
-	ActionMarkDelete                 = "ActionMarkDelete:"
-	ActionGetAllExtentWatermarks     = "ActionGetAllExtentWatermarks:"
-	ActionWrite                      = "ActionWrite:"
-	ActionRepair                     = "ActionRepair:"
-	ActionDecommissionPartition      = "ActionDecommissionPartition"
+	ActionNotifyFollowerToRepair        = "ActionNotifyFollowerRepair"
+	ActionStreamRead                    = "ActionStreamRead"
+	ActionCreateExtent                  = "ActionCreateExtent:"
+	ActionMarkDelete                    = "ActionMarkDelete:"
+	ActionGetAllExtentWatermarks        = "ActionGetAllExtentWatermarks:"
+	ActionWrite                         = "ActionWrite:"
+	ActionRepair                        = "ActionRepair:"
+	ActionDecommissionPartition         = "ActionDecommissionPartition"
+	ActionAddDataPartitionRaftMember    = "ActionAddDataPartitionRaftMember"
+	ActionRemoveDataPartitionRaftMember = "ActionRemoveDataPartitionRaftMember"
+	ActionDataPartitionTryToLeader      = "ActionDataPartitionTryToLeader"
+
 	ActionCreateDataPartition        = "ActionCreateDataPartition"
 	ActionLoadDataPartition          = "ActionLoadDataPartition"
 	ActionDeleteDataPartition        = "ActionDeleteDataPartition"

--- a/master/admin_task_manager.go
+++ b/master/admin_task_manager.go
@@ -41,8 +41,8 @@ type AdminTaskManager struct {
 	targetAddr string
 	TaskMap    map[string]*proto.AdminTask
 	sync.RWMutex
-	exitCh   chan struct{}
-	connPool *util.ConnectPool
+	exitCh     chan struct{}
+	connPool   *util.ConnectPool
 }
 
 func newAdminTaskManager(targetAddr, clusterID string) (sender *AdminTaskManager) {
@@ -165,6 +165,7 @@ func (sender *AdminTaskManager) buildPacket(task *proto.AdminTask) (packet *prot
 	packet = proto.NewPacket()
 	packet.Opcode = task.OpCode
 	packet.ReqID = proto.GenerateRequestID()
+	packet.PartitionID = task.PartitionID
 	body, err := json.Marshal(task)
 	if err != nil {
 		return nil, err
@@ -191,9 +192,9 @@ func (sender *AdminTaskManager) sendAdminTask(task *proto.AdminTask, conn net.Co
 	return nil
 }
 
-func (sender *AdminTaskManager) syncSendAdminTask(task *proto.AdminTask) (response []byte, err error) {
+func (sender *AdminTaskManager) syncSendAdminTask(task *proto.AdminTask) (packet *proto.Packet, err error) {
 	log.LogInfof("action[syncSendAdminTask],task[%v]", task)
-	packet, err := sender.buildPacket(task)
+	packet, err = sender.buildPacket(task)
 	if err != nil {
 		return nil, errors.Trace(err, "action[syncSendAdminTask build packet failed,task:%v]", task.ID)
 	}
@@ -209,17 +210,17 @@ func (sender *AdminTaskManager) syncSendAdminTask(task *proto.AdminTask) (respon
 		}
 	}()
 	if err = packet.WriteToConn(conn); err != nil {
-		return nil, errors.Trace(err, "action[syncSendAdminTask],WriteToConn failed,task:%v", task.ID)
+		return nil, errors.Trace(err, "action[syncSendAdminTask],WriteToConn failed,task:%v,reqID[%v]", task.ID, packet.ReqID)
 	}
 	if err = packet.ReadFromConn(conn, proto.SyncSendTaskDeadlineTime); err != nil {
-		return nil, errors.Trace(err, "action[syncSendAdminTask],ReadFromConn failed task:%v", task.ID)
+		return nil, errors.Trace(err, "action[syncSendAdminTask],ReadFromConn failed task:%v,reqID[%v]", task.ID, packet.ReqID)
 	}
 	if packet.ResultCode != proto.OpOk {
-		err = fmt.Errorf(string(packet.Data))
-		log.LogErrorf("action[syncSendAdminTask],task:%v get response code[%v] err[%v],", task.ID, packet.ResultCode, err)
+		err = fmt.Errorf("result code[%v],msg[%v]", packet.ResultCode, string(packet.Data))
+		log.LogErrorf("action[syncSendAdminTask],task:%v,reqID[%v],err[%v],", task.ID, packet.ReqID, err)
 		return
 	}
-	return packet.Data, nil
+	return packet, nil
 }
 
 // DelTask deletes the to-be-deleted tasks.

--- a/master/cluster_test.go
+++ b/master/cluster_test.go
@@ -19,7 +19,7 @@ func buildPanicVol() *Vol {
 	if err != nil {
 		return nil
 	}
-	vol := newVol(id, commonVol.Name, commonVol.Owner, commonVol.dataPartitionSize, commonVol.Capacity, defaultReplicaNum, defaultReplicaNum,false)
+	vol := newVol(id, commonVol.Name, commonVol.Owner, commonVol.dataPartitionSize, commonVol.Capacity, defaultReplicaNum, defaultReplicaNum, false)
 	vol.dataPartitions = nil
 	return vol
 }

--- a/master/const.go
+++ b/master/const.go
@@ -14,7 +14,10 @@
 
 package master
 
-import "github.com/chubaofs/chubaofs/util"
+import (
+	"github.com/chubaofs/chubaofs/util"
+	"time"
+)
 
 // Keys in the request
 const (
@@ -68,12 +71,14 @@ const (
 	defaultNodeSetCapacity                       = 18
 	minNumOfRWDataPartitions                     = 10
 	intervalToCheckMissingReplica                = 600
+	intervalToWarnDataPartition                  = 600
 	intervalToLoadDataPartition                  = 12 * 60 * 60
 	defaultInitDataPartitionCnt                  = 10
 	volExpansionRatio                            = 0.1
 	maxNumberOfDataPartitionsForExpansion        = 100
 	EmptyCrcValue                         uint32 = 4045511210
 	DefaultRackName                              = "default"
+	retrySendSyncTaskInternal                    = 3 * time.Second
 )
 
 const (

--- a/master/data_partition_check.go
+++ b/master/data_partition_check.go
@@ -47,6 +47,10 @@ func (partition *DataPartition) checkStatus(clusterName string, needLog bool, dp
 		msg := fmt.Sprintf("action[extractStatus],partitionID:%v  replicaNum:%v  liveReplicas:%v   Status:%v  RocksDBHost:%v ",
 			partition.PartitionID, partition.ReplicaNum, len(liveReplicas), partition.Status, partition.Hosts)
 		log.LogInfo(msg)
+		if time.Now().Unix()-partition.lastWarnTime > intervalToWarnDataPartition {
+			Warn(clusterName, msg)
+			partition.lastWarnTime = time.Now().Unix()
+		}
 	}
 }
 
@@ -94,8 +98,7 @@ func (partition *DataPartition) checkMissingReplicas(clusterID, leaderAddr strin
 			msg := fmt.Sprintf("action[checkMissErr],clusterID[%v] paritionID:%v  on Node:%v  "+
 				"miss time > %v  lastRepostTime:%v   dnodeLastReportTime:%v  nodeisActive:%v So Migrate by manual",
 				clusterID, partition.PartitionID, replica.Addr, dataPartitionMissSec, replica.ReportTime, lastReportTime, isActive)
-			Warn(clusterID, msg)
-			msg = fmt.Sprintf("decommissionDataPartitionURL is http://%v/dataPartition/decommission?id=%v&addr=%v", leaderAddr, partition.PartitionID, replica.Addr)
+			msg = msg + fmt.Sprintf(" decommissionDataPartitionURL is http://%v/dataPartition/decommission?id=%v&addr=%v", leaderAddr, partition.PartitionID, replica.Addr)
 			Warn(clusterID, msg)
 		}
 	}
@@ -104,8 +107,7 @@ func (partition *DataPartition) checkMissingReplicas(clusterID, leaderAddr strin
 		if partition.hasMissingDataPartition(addr) == true && partition.needToAlarmMissingDataPartition(addr, dataPartitionWarnInterval) {
 			msg := fmt.Sprintf("action[checkMissErr],clusterID[%v] partitionID:%v  on Node:%v  "+
 				"miss time  > :%v  but server not exsit So Migrate", clusterID, partition.PartitionID, addr, dataPartitionMissSec)
-			Warn(clusterID, msg)
-			msg = fmt.Sprintf("decommissionDataPartitionURL is http://%v/dataPartition/decommission?id=%v&addr=%v", leaderAddr, partition.PartitionID, addr)
+			msg = msg + fmt.Sprintf(" decommissionDataPartitionURL is http://%v/dataPartition/decommission?id=%v&addr=%v", leaderAddr, partition.PartitionID, addr)
 			Warn(clusterID, msg)
 		}
 	}
@@ -157,8 +159,7 @@ func (partition *DataPartition) checkDiskError(clusterID, leaderAddr string) (di
 	for _, diskAddr := range diskErrorAddrs {
 		msg := fmt.Sprintf("action[%v],clusterID[%v],partitionID:%v  On :%v  Disk Error,So Remove it From RocksDBHost",
 			checkDataPartitionDiskErr, clusterID, partition.PartitionID, diskAddr)
-		Warn(clusterID, msg)
-		msg = fmt.Sprintf("decommissionDataPartitionURL is http://%v/dataPartition/decommission?id=%v&addr=%v", leaderAddr, partition.PartitionID, diskAddr)
+		msg = msg + fmt.Sprintf(" decommissionDataPartitionURL is http://%v/dataPartition/decommission?id=%v&addr=%v", leaderAddr, partition.PartitionID, diskAddr)
 		Warn(clusterID, msg)
 	}
 

--- a/master/http_server.go
+++ b/master/http_server.go
@@ -40,6 +40,8 @@ func (m *Server) handleFunctions() {
 	http.Handle(proto.AdminCreateDataPartition, m.handlerWithInterceptor())
 	http.Handle(proto.AdminLoadDataPartition, m.handlerWithInterceptor())
 	http.Handle(proto.AdminDecommissionDataPartition, m.handlerWithInterceptor())
+	http.Handle(proto.AdminAddDataReplica, m.handlerWithInterceptor())
+	http.Handle(proto.AdminDeleteDataReplica, m.handlerWithInterceptor())
 	http.Handle(proto.AdminCreateVol, m.handlerWithInterceptor())
 	http.Handle(proto.AdminGetVol, m.handlerWithInterceptor())
 	http.Handle(proto.AdminDeleteVol, m.handlerWithInterceptor())
@@ -54,6 +56,8 @@ func (m *Server) handleFunctions() {
 	http.Handle(proto.GetMetaNode, m.handlerWithInterceptor())
 	http.Handle(proto.AdminLoadMetaPartition, m.handlerWithInterceptor())
 	http.Handle(proto.AdminDecommissionMetaPartition, m.handlerWithInterceptor())
+	http.Handle(proto.AdminAddMetaReplica, m.handlerWithInterceptor())
+	http.Handle(proto.AdminDeleteMetaReplica, m.handlerWithInterceptor())
 	http.Handle(proto.ClientDataPartitions, m.handlerWithInterceptor())
 	http.Handle(proto.ClientVol, m.handlerWithInterceptor())
 	http.Handle(proto.ClientMetaPartitions, m.handlerWithInterceptor())
@@ -115,6 +119,10 @@ func (m *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		m.loadDataPartition(w, r)
 	case proto.AdminDecommissionDataPartition:
 		m.decommissionDataPartition(w, r)
+	case proto.AdminAddDataReplica:
+		m.addDataReplica(w, r)
+	case proto.AdminDeleteDataReplica:
+		m.deleteDataReplica(w, r)
 	case proto.AdminCreateVol:
 		m.createVol(w, r)
 	case proto.AdminGetVol:
@@ -130,7 +138,7 @@ func (m *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case proto.GetDataNode:
 		m.getDataNode(w, r)
 	case proto.DecommissionDataNode:
-		m.dataNodeOffline(w, r)
+		m.decommissionDataNode(w, r)
 	case proto.DecommissionDisk:
 		m.decommissionDisk(w, r)
 	case proto.GetDataNodeTaskResponse:
@@ -159,6 +167,10 @@ func (m *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		m.decommissionMetaPartition(w, r)
 	case proto.AdminCreateMP:
 		m.createMetaPartition(w, r)
+	case proto.AdminAddMetaReplica:
+		m.addMetaReplica(w, r)
+	case proto.AdminDeleteMetaReplica:
+		m.deleteMetaReplica(w, r)
 	case proto.AddRaftNode:
 		m.addRaftNode(w, r)
 	case proto.RemoveRaftNode:

--- a/master/mocktest/data_server.go
+++ b/master/mocktest/data_server.go
@@ -109,10 +109,26 @@ func (mds *MockDataServer) serveConn(rc net.Conn) {
 		fmt.Printf("data node [%v] load data partition,id[%v],err:%v\n", mds.TcpAddr, adminTask.ID, err)
 	case proto.OpDecommissionDataPartition:
 		err = mds.handleDecommissionDataPartition(conn, req, adminTask)
-		fmt.Printf("data node [%v] load data partition,id[%v],err:%v\n", mds.TcpAddr, adminTask.ID, err)
+		fmt.Printf("data node [%v] decommission data partition,id[%v],err:%v\n", mds.TcpAddr, adminTask.ID, err)
+	case proto.OpAddDataPartitionRaftMember:
+		err = mds.handleAddDataPartitionRaftMember(conn, req, adminTask)
+		fmt.Printf("data node [%v] add data partition raft member,id[%v],err:%v\n", mds.TcpAddr, adminTask.ID, err)
+	case proto.OpRemoveDataPartitionRaftMember:
+		err = mds.handleRemoveDataPartitionRaftMember(conn, req, adminTask)
+		fmt.Printf("data node [%v] remove data partition raft member,id[%v],err:%v\n", mds.TcpAddr, adminTask.ID, err)
 	default:
 		fmt.Printf("unknown code [%v]\n", req.Opcode)
 	}
+}
+
+func (mds *MockDataServer) handleAddDataPartitionRaftMember(conn net.Conn, p *proto.Packet, adminTask *proto.AdminTask) (err error) {
+	responseAckOKToMaster(conn, p, nil)
+	return
+}
+
+func (mds *MockDataServer) handleRemoveDataPartitionRaftMember(conn net.Conn, p *proto.Packet, adminTask *proto.AdminTask) (err error) {
+	responseAckOKToMaster(conn, p, nil)
+	return
 }
 
 func (mds *MockDataServer) handleDecommissionDataPartition(conn net.Conn, p *proto.Packet, adminTask *proto.AdminTask) (err error) {

--- a/master/mocktest/meta_server.go
+++ b/master/mocktest/meta_server.go
@@ -109,9 +109,25 @@ func (mms *MockMetaServer) serveConn(rc net.Conn) {
 	case proto.OpDecommissionMetaPartition:
 		err = mms.handleDecommissionMetaPartition(conn, req, adminTask)
 		fmt.Printf("meta node [%v] offline meta partition,err:%v\n", mms.TcpAddr, err)
+	case proto.OpAddMetaPartitionRaftMember:
+		err = mms.handleAddMetaPartitionRaftMember(conn, req, adminTask)
+		fmt.Printf("meta node [%v] add data partition raft member,id[%v],err:%v\n", mms.TcpAddr, adminTask.ID, err)
+	case proto.OpRemoveMetaPartitionRaftMember:
+		err = mms.handleRemoveMetaPartitionRaftMember(conn, req, adminTask)
+		fmt.Printf("meta node [%v] remove data partition raft member,id[%v],err:%v\n", mms.TcpAddr, adminTask.ID, err)
 	default:
 		fmt.Printf("unknown code [%v]\n", req.Opcode)
 	}
+}
+
+func (mms *MockMetaServer) handleAddMetaPartitionRaftMember(conn net.Conn, p *proto.Packet, adminTask *proto.AdminTask) (err error) {
+	responseAckOKToMaster(conn, p, nil)
+	return
+}
+
+func (mms *MockMetaServer) handleRemoveMetaPartitionRaftMember(conn net.Conn, p *proto.Packet, adminTask *proto.AdminTask) (err error) {
+	responseAckOKToMaster(conn, p, nil)
+	return
 }
 
 func (mms *MockMetaServer) handleCreateMetaPartition(conn net.Conn, p *proto.Packet, adminTask *proto.AdminTask) (err error) {

--- a/master/operate_util.go
+++ b/master/operate_util.go
@@ -56,6 +56,22 @@ func newOfflineDataPartitionRequest(ID uint64, removePeer, addPeer proto.Peer) (
 	return
 }
 
+func newAddDataPartitionRaftMemberRequest(ID uint64, addPeer proto.Peer) (req *proto.AddDataPartitionRaftMemberRequest) {
+	req = &proto.AddDataPartitionRaftMemberRequest{
+		PartitionId: ID,
+		AddPeer:     addPeer,
+	}
+	return
+}
+
+func newRemoveDataPartitionRaftMemberRequest(ID uint64, removePeer proto.Peer) (req *proto.RemoveDataPartitionRaftMemberRequest) {
+	req = &proto.RemoveDataPartitionRaftMemberRequest{
+		PartitionId: ID,
+		RemovePeer:  removePeer,
+	}
+	return
+}
+
 func newLoadDataPartitionMetricRequest(ID uint64) (req *proto.LoadDataPartitionRequest) {
 	req = &proto.LoadDataPartitionRequest{
 		PartitionId: ID,

--- a/master/topology_test.go
+++ b/master/topology_test.go
@@ -108,7 +108,7 @@ func TestAllocRacks(t *testing.T) {
 	}
 	cluster := new(Cluster)
 	cluster.t = topo
-	hosts, _, err := cluster.chooseTargetDataNodes(replicaNum)
+	hosts, _, err := cluster.chooseTargetDataNodes(nil, nil, nil, replicaNum)
 	if err != nil {
 		t.Error(err)
 		return

--- a/master/vol.go
+++ b/master/vol.go
@@ -226,7 +226,7 @@ func (vol *Vol) checkMetaPartitions(c *Cluster) {
 	mps := vol.cloneMetaPartitionMap()
 	for _, mp := range mps {
 
-		mp.checkStatus(true, int(vol.mpReplicaNum), maxPartitionID)
+		mp.checkStatus(c.Name, true, int(vol.mpReplicaNum), maxPartitionID)
 		mp.checkLeader()
 		mp.checkReplicaNum(c, vol.Name, vol.mpReplicaNum)
 		mp.checkEnd(c, maxPartitionID)
@@ -600,7 +600,7 @@ func (vol *Vol) doCreateMetaPartition(c *Cluster, start, end uint64) (mp *MetaPa
 		wg          sync.WaitGroup
 	)
 	errChannel := make(chan error, vol.mpReplicaNum)
-	if hosts, peers, err = c.chooseTargetMetaHosts(int(vol.mpReplicaNum)); err != nil {
+	if hosts, peers, err = c.chooseTargetMetaHosts(nil, nil, int(vol.mpReplicaNum)); err != nil {
 		return nil, errors.NewError(err)
 	}
 	log.LogInfof("target meta hosts:%v,peers:%v", hosts, peers)

--- a/master/vol_test.go
+++ b/master/vol_test.go
@@ -111,7 +111,7 @@ func checkMetaPartitionsWritableTest(vol *Vol, t *testing.T) {
 	maxPartitionID := vol.maxPartitionID()
 	maxMp := vol.MetaPartitions[maxPartitionID]
 	//after check meta partitions ,the status must be writable
-	maxMp.checkStatus(false, int(vol.mpReplicaNum), maxPartitionID)
+	maxMp.checkStatus(server.cluster.Name, false, int(vol.mpReplicaNum), maxPartitionID)
 	if maxMp.Status != proto.ReadWrite {
 		t.Errorf("expect partition status[%v],real status[%v]\n", proto.ReadWrite, maxMp.Status)
 		return

--- a/metanode/manager.go
+++ b/metanode/manager.go
@@ -114,6 +114,12 @@ func (m *metadataManager) HandleMetadataOperation(conn net.Conn, p *Packet,
 		err = m.opLoadMetaPartition(conn, p, remoteAddr)
 	case proto.OpDecommissionMetaPartition:
 		err = m.opDecommissionMetaPartition(conn, p, remoteAddr)
+	case proto.OpAddMetaPartitionRaftMember:
+		err = m.opAddMetaPartitionRaftMember(conn, p, remoteAddr)
+	case proto.OpRemoveMetaPartitionRaftMember:
+		err = m.opRemoveMetaPartitionRaftMember(conn, p, remoteAddr)
+	case proto.OpMetaPartitionTryToLeader:
+		err = m.opMetaPartitionTryToLeader(conn, p, remoteAddr)
 	case proto.OpMetaBatchInodeGet:
 		err = m.opMetaBatchInodeGet(conn, p, remoteAddr)
 	default:
@@ -253,7 +259,7 @@ func (m *metadataManager) loadPartitions() (err error) {
 					}
 					errload = nil
 				}
-				partition := NewMetaPartition(partitionConfig)
+				partition := NewMetaPartition(partitionConfig, m)
 				errload = m.attachPartition(id, partition)
 				if errload != nil {
 					log.LogErrorf("load partition id=%d failed: %s.",
@@ -317,7 +323,7 @@ func (m *metadataManager) createPartition(id uint64, volName string, start,
 		// TODO Unhandled errors
 		m.detachPartition(id)
 	}
-	partition := NewMetaPartition(mpc)
+	partition := NewMetaPartition(mpc, m)
 	if err = partition.PersistMetadata(); err != nil {
 		err = errors.NewErrorf("[createPartition]->%s", err.Error())
 		return

--- a/metanode/metanode.go
+++ b/metanode/metanode.go
@@ -195,12 +195,12 @@ func (m *MetaNode) parseConfig(cfg *config.Config) (err error) {
 	configTotalMem, _ = strconv.ParseUint(cfg.GetString(cfgTotalMem), 10, 64)
 
 	if configTotalMem == 0 {
-		return fmt.Errorf("bad totalMem config,Recommended to be configured as 80% of physical machine memory")
+		return fmt.Errorf("bad totalMem config,Recommended to be configured as 80 percent of physical machine memory")
 	}
 
 	total, _, err := util.GetMemInfo()
 	if err == nil && configTotalMem > total-util.GB {
-		return fmt.Errorf("bad totalMem config,Recommended to be configured as 80% of physical machine memory")
+		return fmt.Errorf("bad totalMem config,Recommended to be configured as 80 percent of physical machine memory")
 	}
 
 	if m.metadataDir == "" {

--- a/proto/admin_proto.go
+++ b/proto/admin_proto.go
@@ -22,6 +22,8 @@ const (
 	AdminLoadDataPartition         = "/dataPartition/load"
 	AdminCreateDataPartition       = "/dataPartition/create"
 	AdminDecommissionDataPartition = "/dataPartition/decommission"
+	AdminDeleteDataReplica         = "/dataReplica/delete"
+	AdminAddDataReplica            = "/dataReplica/add"
 	AdminDeleteVol                 = "/vol/delete"
 	AdminUpdateVol                 = "/vol/update"
 	AdminCreateVol                 = "/admin/createVol"
@@ -52,6 +54,8 @@ const (
 	GetMetaNode                    = "/metaNode/get"
 	AdminLoadMetaPartition         = "/metaPartition/load"
 	AdminDecommissionMetaPartition = "/metaPartition/decommission"
+	AdminAddMetaReplica            = "/metaReplica/add"
+	AdminDeleteMetaReplica         = "/metaReplica/delete"
 
 	// Operation response
 	GetMetaNodeTaskResponse = "/metaNode/response" // Method: 'POST', ContentType: 'application/json'
@@ -118,11 +122,28 @@ type DataPartitionDecommissionRequest struct {
 	AddPeer     Peer
 }
 
-// DataPartitionDecommissionResponse defines the response to the request of decommissioning a data partition.
-type DataPartitionDecommissionResponse struct {
-	Status      uint8
-	Result      string
+// AddDataPartitionRaftMemberRequest defines the request of add raftMember a data partition.
+type AddDataPartitionRaftMemberRequest struct {
 	PartitionId uint64
+	AddPeer     Peer
+}
+
+// RemoveDataPartitionRaftMemberRequest defines the request of add raftMember a data partition.
+type RemoveDataPartitionRaftMemberRequest struct {
+	PartitionId uint64
+	RemovePeer  Peer
+}
+
+// AddMetaPartitionRaftMemberRequest defines the request of add raftMember a meta partition.
+type AddMetaPartitionRaftMemberRequest struct {
+	PartitionId uint64
+	AddPeer     Peer
+}
+
+// RemoveMetaPartitionRaftMemberRequest defines the request of add raftMember a meta partition.
+type RemoveMetaPartitionRaftMemberRequest struct {
+	PartitionId uint64
+	RemovePeer  Peer
 }
 
 // LoadDataPartitionRequest defines the request of loading a data partition.

--- a/proto/admin_task.go
+++ b/proto/admin_task.go
@@ -32,6 +32,7 @@ const (
 // AdminTask defines the administration task.
 type AdminTask struct {
 	ID           string
+	PartitionID  uint64
 	OpCode       uint8
 	OperatorAddr string
 	Status       int8

--- a/repl/packet.go
+++ b/repl/packet.go
@@ -356,7 +356,10 @@ func (p *Packet) IsMasterCommand() bool {
 		proto.OpLoadDataPartition,
 		proto.OpCreateDataPartition,
 		proto.OpDeleteDataPartition,
-		proto.OpDecommissionDataPartition:
+		proto.OpDecommissionDataPartition,
+		proto.OpAddDataPartitionRaftMember,
+		proto.OpRemoveDataPartitionRaftMember,
+		proto.OpDataPartitionTryToLeader:
 		return true
 	}
 	return false
@@ -390,6 +393,10 @@ func (p *Packet) IsCreateExtentOperation() bool {
 
 func (p *Packet) IsMarkDeleteExtentOperation() bool {
 	return p.Opcode == proto.OpMarkDelete
+}
+
+func (p *Packet) IsBroadcastMinAppliedID()bool {
+	return p.Opcode==proto.OpBroadcastMinAppliedID
 }
 
 func (p *Packet) IsReadOperation() bool {

--- a/storage/extent_store.go
+++ b/storage/extent_store.go
@@ -50,6 +50,7 @@ const (
 	MinExtentID              = 1024
 	DeleteTinyRecordSize     = 24
 	UpdateCrcInterval        = 600
+	RepairInterval			=60
 	RandomWriteType          = 2
 	AppendWriteType          = 1
 )
@@ -77,7 +78,7 @@ var (
 	NormalExtentFilter = func() ExtentFilter {
 		now := time.Now()
 		return func(ei *ExtentInfo) bool {
-			return !IsTinyExtent(ei.FileID) && now.Unix()-ei.ModifyTime > UpdateCrcInterval && ei.IsDeleted == false && ei.Size > 0
+			return !IsTinyExtent(ei.FileID) && now.Unix()-ei.ModifyTime > RepairInterval && ei.IsDeleted == false && ei.Size > 0
 		}
 	}
 
@@ -595,6 +596,9 @@ func (s *ExtentStore) StoreSizeExtentID(maxExtentID uint64) (totalSize uint64) {
 	s.eiMutex.RUnlock()
 	for _, extentInfo := range extentInfos {
 		totalSize += extentInfo.Size
+		if extentInfo.Size>util.BlockSize*util.BlockCount{
+			log.LogErrorf("file(%v) size too much (%v)",s.dataPath,extentInfo)
+		}
 	}
 
 	return totalSize

--- a/vendor/github.com/tiglabs/raft/raft_fsm.go
+++ b/vendor/github.com/tiglabs/raft/raft_fsm.go
@@ -80,6 +80,12 @@ func newRaftFsm(config *Config, raftConfig *RaftConfig) (*raftFsm, error) {
 		r.replicas[p.ID] = newReplica(p, 0)
 	}
 	if !hs.IsEmpty() {
+		if raftConfig.Applied > r.raftLog.lastIndex() {
+			raftConfig.Applied = r.raftLog.lastIndex()
+		}
+		if hs.Commit > r.raftLog.lastIndex() {
+			hs.Commit = r.raftLog.lastIndex()
+		}
 		if err := r.loadState(hs); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
if the disk where the dataPartition/metaPartition is located is broken, or if a datanode/metanode is permanently broken, these dataPartition/metaPartitions need to be migrated to other nodes in the cluster.
New migration process:
1. master send OpRemoveRaftMemberDataPartition or OpRemoveRaftMemberMetaPartition command to  raftLeader for these partition groups， the raftLeader remove the bad peer from raftGroup 
2. master send OpAddRaftMemberDataPartition or OpAddRaftMemberMetaPartition command to  raftLeader for these partition groups， the raftLeader add  the new peer to raftGroup 
3. master send OpCreateDataPartition or OpCreateMetaPartition command to another datanode or metanode
4. master send OpDeleteDataPartition or OpDeleteMetaPartition command to bad node
5. change the dataPartition or metaPartition Members

Signed-off-by: awzhgw <guowl18702995996@gmail.com>