### PR TITLE
refactor: remove unnecessary function in raftstore

### DIFF
--- a/raftstore/raftstore.go
+++ b/raftstore/raftstore.go
@@ -56,14 +56,12 @@ func (s *raftStore) RaftStatus(raftID uint64) (raftStatus *raft.Status) {
 
 // AddNodeWithPort add a new node with the given port.
 func (s *raftStore) AddNodeWithPort(nodeID uint64, addr string, heartbeat int, replicate int) {
-	if s.resolver != nil {
-		s.resolver.AddNodeWithPort(nodeID, addr, heartbeat, replicate)
-	}
+	s.resolver.AddNodeWithPort(nodeID, addr, heartbeat, replicate)
 }
 
 // DeleteNode deletes the node with the given ID in the raft store.
 func (s *raftStore) DeleteNode(nodeID uint64) {
-	DeleteNode(s.resolver, nodeID)
+	s.resolver.DeleteNode(nodeID)
 }
 
 // Stop stops the raft store server.

--- a/raftstore/resolver.go
+++ b/raftstore/resolver.go
@@ -110,10 +110,3 @@ func (r *nodeResolver) DeleteNode(nodeID uint64) {
 func NewNodeResolver() NodeResolver {
 	return &nodeResolver{}
 }
-
-// DeleteNode deletes the node address from the NodeManager if possible.
-func DeleteNode(manager NodeManager, nodeID uint64) {
-	if manager != nil {
-		manager.DeleteNode(nodeID)
-	}
-}


### PR DESCRIPTION
The interface NodeManager involves method DeleteNode, so there is no
need to define a DeleteNode function with NodeManager as an input
parameter. Note that the prerequisite is that raftStore.resolver is
guarenteed to be non-nil in NewRaftStore.

Signed-off-by: Shuoran Liu <shuoranliu@gmail.com>