### PR TITLE
refactor: change metaPartition verification method

### DIFF
--- a/master/const.go
+++ b/master/const.go
@@ -47,8 +47,6 @@ const (
 	dataNodeOfflineErr            = "dataNodeOfflineErr "
 	diskOfflineErr                = "diskOfflineErr "
 	handleDataPartitionOfflineErr = "handleDataPartitionOffLineErr "
-
-	getFileCountOnDataReplica = "getFileCountOnDataReplica "
 )
 
 const (
@@ -79,6 +77,7 @@ const (
 	EmptyCrcValue                         uint32 = 4045511210
 	DefaultRackName                              = "default"
 	retrySendSyncTaskInternal                    = 3 * time.Second
+	defaultRangeOfCountDifferencesAllowed        = 50
 )
 
 const (

--- a/master/mocktest/meta_server.go
+++ b/master/mocktest/meta_server.go
@@ -296,8 +296,8 @@ func (mms *MockMetaServer) handleLoadMetaPartition(conn net.Conn, p *proto.Packe
 		PartitionID: req.PartitionID,
 		DoCompare:   true,
 		ApplyID:     100,
-		InodeSign:   123456,
-		DentrySign:  123456,
+		InodeCount:  123456,
+		DentryCount: 123456,
 	}
 	data, err = json.Marshal(resp)
 	if err != nil {

--- a/metanode/manager_op.go
+++ b/metanode/manager_op.go
@@ -599,7 +599,7 @@ func (m *metadataManager) opLoadMetaPartition(conn net.Conn, p *Packet,
 	decode.UseNumber()
 	if err = decode.Decode(adminTask); err != nil {
 		p.PacketErrorWithBody(proto.OpErr, nil)
-		p.WriteToConn(conn)
+		m.respondToClient(conn, p)
 		return
 	}
 	mp, err := m.getPartition(req.PartitionID)
@@ -609,8 +609,11 @@ func (m *metadataManager) opLoadMetaPartition(conn net.Conn, p *Packet,
 		return
 	}
 	if err = mp.LoadSnapshotSign(p); err != nil {
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
 		log.LogErrorf("%s [opLoadMetaPartition] req[%v], "+
 			"response marshal[%v]", remoteAddr, req, err.Error())
+		m.respondToClient(conn, p)
+		return
 	}
 	m.respondToClient(conn, p)
 	log.LogInfof("%s [opLoadMetaPartition] req[%v], response status[%s], "+

--- a/proto/admin_proto.go
+++ b/proto/admin_proto.go
@@ -311,8 +311,8 @@ type MetaPartitionLoadResponse struct {
 	PartitionID uint64
 	DoCompare   bool
 	ApplyID     uint64
-	InodeSign   uint32
-	DentrySign  uint32
+	InodeCount  int
+	DentryCount int
 	Addr        string
 }
 


### PR DESCRIPTION
When metanode receives loadmetapartition command, it returns applyid and inodeCnt and dentryCnt as Check consistency between  metaPartition replicas
Signed-off-by: awzhgw <guowl18702995996@gmail.com>