### PR TITLE
Fix: use MaxInode and DentryCnt verify metaPartition

### DIFF
--- a/master/meta_partition_manager.go
+++ b/master/meta_partition_manager.go
@@ -88,9 +88,9 @@ func (mp *MetaPartition) isSameApplyID() bool {
 
 func (mp *MetaPartition) checkInodeCount(clusterID string) {
 	isEqual := true
-	inodeCount := mp.LoadResponse[0].InodeCount
+	maxInode := mp.LoadResponse[0].MaxInode
 	for _, loadResponse := range mp.LoadResponse {
-		diff := math.Abs(float64(loadResponse.InodeCount) - float64(inodeCount))
+		diff := math.Abs(float64(loadResponse.MaxInode) - float64(maxInode))
 		if diff > defaultRangeOfCountDifferencesAllowed {
 			isEqual = false
 		}
@@ -99,9 +99,9 @@ func (mp *MetaPartition) checkInodeCount(clusterID string) {
 	if !isEqual {
 		msg := fmt.Sprintf("inode count is not equal,vol[%v],mpID[%v],", mp.volName, mp.PartitionID)
 		for _, lr := range mp.LoadResponse {
-			inodeCountStr := strconv.Itoa(lr.InodeCount)
+			inodeCountStr := strconv.FormatUint(lr.MaxInode,10)
 			applyIDStr := strconv.FormatUint(uint64(lr.ApplyID), 10)
-			msg = msg + lr.Addr + " applyId[" + applyIDStr + "] inodeCount[" + inodeCountStr + "],"
+			msg = msg + lr.Addr + " applyId[" + applyIDStr + "] maxInode[" + inodeCountStr + "],"
 		}
 		Warn(clusterID, msg)
 	}
@@ -120,7 +120,7 @@ func (mp *MetaPartition) checkDentryCount(clusterID string) {
 	if !isEqual {
 		msg := fmt.Sprintf("dentry count is not equal,vol[%v],mpID[%v],", mp.volName, mp.PartitionID)
 		for _, lr := range mp.LoadResponse {
-			dentryCountStr := strconv.Itoa(lr.DentryCount)
+			dentryCountStr := strconv.FormatUint(lr.DentryCount,10)
 			applyIDStr := strconv.FormatUint(uint64(lr.ApplyID), 10)
 			msg = msg + lr.Addr + " applyId[" + applyIDStr + "] dentryCount[" + dentryCountStr + "],"
 		}

--- a/master/mocktest/meta_server.go
+++ b/master/mocktest/meta_server.go
@@ -296,7 +296,7 @@ func (mms *MockMetaServer) handleLoadMetaPartition(conn net.Conn, p *proto.Packe
 		PartitionID: req.PartitionID,
 		DoCompare:   true,
 		ApplyID:     100,
-		InodeCount:  123456,
+		MaxInode:    123456,
 		DentryCount: 123456,
 	}
 	data, err = json.Marshal(resp)

--- a/proto/admin_proto.go
+++ b/proto/admin_proto.go
@@ -311,8 +311,8 @@ type MetaPartitionLoadResponse struct {
 	PartitionID uint64
 	DoCompare   bool
 	ApplyID     uint64
-	InodeCount  int
-	DentryCount int
+	MaxInode    uint64
+	DentryCount uint64
 	Addr        string
 }
 


### PR DESCRIPTION
When metanode receives loadmetapartition command, it returns applyid and MaxInode and dentryCnt as Check consistency between metaPartition replicas
Signed-off-by: awzhgw <guowl18702995996@gmail.com>