### PR TITLE
change: meta node config label name

### DIFF
--- a/cmd/cfg/meta.json
+++ b/cmd/cfg/meta.json
@@ -12,7 +12,7 @@
     "warnLogDir":"/export/home/tomcat/UMP-Monitor/logs/",
     "consulAddr": "http://consul.prometheus-cfs.local",
     "exporterPort": 9511,
-    "masterAddrs": [
+    "masterAddr": [
         "192.168.31.173:80",
         "192.168.31.141:80",
         "192.168.30.200:80"

--- a/docker/conf/metanode.json
+++ b/docker/conf/metanode.json
@@ -11,7 +11,7 @@
     "totalMem":"536870912",
     "metadataDir": "/cfs/data/meta",
     "raftDir": "/cfs/data/raft",
-    "masterAddrs": [
+    "masterAddr": [
         "192.168.0.11:17010",
         "192.168.0.12:17010",
         "192.168.0.13:17010"

--- a/docs/source/quick-start-guide.rst
+++ b/docs/source/quick-start-guide.rst
@@ -72,7 +72,7 @@ Sample *meta.json is* shown as follows,
        "totalMem":  "17179869184",
        "consulAddr": "http://consul.prometheus-cfs.local",
        "exporterPort": 9511,
-       "masterAddrs": [
+       "masterAddr": [
            "192.168.31.173:80",
            "192.168.31.141:80",
            "192.168.30.200:80"

--- a/docs/source/user-guide/metanode.rst
+++ b/docs/source/user-guide/metanode.rst
@@ -20,7 +20,7 @@ At lease 3 meta nodes are required in respect to high availability.
    "raftReplicaPort", "string", "Raft replicate port", "Yes"
    "consulAddr", "string", "Addresses of monitor system", "No" 
    "exporterPort", "string", "Port for monitor system", "No" 
-   "masterAddrs", "string", "Addresses of master server", "Yes"
+   "masterAddr", "string", "Addresses of master server", "Yes"
    "totalMem","string","Max memory metadata used","No"
 
 
@@ -44,7 +44,7 @@ Example:
         "consulAddr": "http://consul.prometheus-cfs.local",
         "exporterPort": 9511,
         "totalMem":  "17179869184",
-        "masterAddrs": [
+        "masterAddr": [
             "192.168.31.173:80",
             "192.168.31.141:80",
             "192.168.30.200:80"

--- a/metanode/const.go
+++ b/metanode/const.go
@@ -126,7 +126,8 @@ const (
 	cfgListen            = "listen"
 	cfgMetadataDir       = "metadataDir"
 	cfgRaftDir           = "raftDir"
-	cfgMasterAddrs       = "masterAddrs"
+	cfgMasterAddrs       = "masterAddrs" // will be deprecated
+	cfgMasterAddr        = "masterAddr"
 	cfgRaftHeartbeatPort = "raftHeartbeatPort"
 	cfgRaftReplicaPort   = "raftReplicaPort"
 	cfgTotalMem          = "totalMem"

--- a/metanode/metanode.go
+++ b/metanode/metanode.go
@@ -226,7 +226,10 @@ func (m *MetaNode) parseConfig(cfg *config.Config) (err error) {
 	log.LogInfof("[parseConfig] load raftHeartbeatPort[%v].", m.raftHeartbeatPort)
 	log.LogInfof("[parseConfig] load raftReplicatePort[%v].", m.raftReplicatePort)
 
-	addrs := cfg.GetArray(cfgMasterAddrs)
+	addrs := cfg.GetArray(cfgMasterAddr)
+	if len(addrs) == 0 {
+		addrs = cfg.GetArray(cfgMasterAddrs)
+	}
 	masterHelper = util.NewMasterHelper()
 	for _, addr := range addrs {
 		masterHelper.AddNode(addr.(string))


### PR DESCRIPTION
Change config label name of meta node from *masterAddrs* to *masterAddr*
to align with config labels of master and client.

Signed-off-by: Shuoran Liu <shuoranliu@gmail.com>