### PR TITLE
fix: broken directory mtime

### DIFF
--- a/client/fs/dir.go
+++ b/client/fs/dir.go
@@ -97,6 +97,8 @@ func (d *Dir) Create(ctx context.Context, req *fuse.CreateRequest, resp *fuse.Cr
 		resp.Flags |= fuse.OpenKeepCache
 	}
 
+	d.super.ic.Delete(d.inode.ino)
+
 	elapsed := time.Since(start)
 	log.LogDebugf("TRACE Create: parent(%v) req(%v) resp(%v) ino(%v) (%v)ns", d.inode.ino, req, resp, inode.ino, elapsed.Nanoseconds())
 	return child, child, nil
@@ -130,6 +132,8 @@ func (d *Dir) Mkdir(ctx context.Context, req *fuse.MkdirRequest) (fs.Node, error
 	d.super.fslock.Lock()
 	d.super.nodeCache[inode.ino] = child
 	d.super.fslock.Unlock()
+
+	d.super.ic.Delete(d.inode.ino)
 
 	elapsed := time.Since(start)
 	log.LogDebugf("TRACE Mkdir: parent(%v) req(%v) ino(%v) (%v)ns", d.inode.ino, req, inode.ino, elapsed.Nanoseconds())

--- a/metanode/inode.go
+++ b/metanode/inode.go
@@ -374,13 +374,16 @@ func (i *Inode) ExtentsTruncate(exts []BtreeItem, length uint64, ct int64) {
 
 // IncNLink increases the nLink value by one.
 func (i *Inode) IncNLink() {
+	mtime := Now.GetCurrentTime().Unix()
 	i.Lock()
 	i.NLink++
+	i.ModifyTime = mtime
 	i.Unlock()
 }
 
 // DecNLink decreases the nLink value by one.
 func (i *Inode) DecNLink() {
+	mtime := Now.GetCurrentTime().Unix()
 	i.Lock()
 	if proto.IsDir(i.Type) && i.NLink == 2 {
 		i.NLink--
@@ -388,6 +391,7 @@ func (i *Inode) DecNLink() {
 	if i.NLink > 0 {
 		i.NLink--
 	}
+	i.ModifyTime = mtime
 	i.Unlock()
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The mtime of parent inode is not updated when create or delete a dentry.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

This commit fixes the issue by updating mtime of parent inode in server
side and evict inode cache in client side.

**Special notes for your reviewer**:

**Release note**:

