### PR TITLE
Fix several raft snapshot issue in meta subsystem

### DIFF
--- a/docker/run_docker.sh
+++ b/docker/run_docker.sh
@@ -14,7 +14,6 @@ Usage: ./run_docker.sh [ -h | --help ] [ -d | --disk </disk/path> ] [ -l | --ltp
     -d, --disk </disk/path>     set ChubaoFS DataNode local disk path
     -b, --build             build ChubaoFS server and client
     -s, --server            start ChubaoFS servers docker image
-    -o, --object-node       start ChubaoFS
     -c, --client            start ChubaoFS client docker image
     -m, --monitor           start monitor web ui
     -l, --ltptest           run ltp test
@@ -50,10 +49,6 @@ start_client() {
     docker-compose -f ${RootPath}/docker/docker-compose.yml run client bash -c "/cfs/script/start_client.sh ; /bin/bash"
 }
 
-start_objectnode() {
-    docker-compose -f ${RootPath}/docker/docker-compose.yml up -d objectnode
-}
-
 start_monitor() {
     docker-compose -f ${RootPath}/docker/docker-compose.yml up -d monitor
 }
@@ -72,7 +67,6 @@ run() {
     build
     start_monitor
     start_servers
-    start_objectnode
     start_client
 }
 
@@ -151,7 +145,6 @@ case "-$cmd" in
     -build) build ;;
     -run_servers) start_servers ;;
     -run_client) start_client ;;
-    -run_s3node) start_s3node ;;
     -run_monitor) start_monitor ;;
     -run_ltptest) run_ltptest ;;
     -run_test) run_test ;;

--- a/metanode/partition_fsm.go
+++ b/metanode/partition_fsm.go
@@ -255,6 +255,7 @@ func (mp *metaPartition) ApplySnapshot(peers []raftproto.Peer, iter raftproto.Sn
 		if err = snap.UnmarshalBinary(data); err != nil {
 			return
 		}
+		index++
 		switch snap.Op {
 		case opFSMCreateInode:
 			ino := NewInode(0, 0)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- Fix: the `Next` method in `MetaItemIterator` returns unexpected value after it closed. 
- Fix: the `MetaItemIterator` should be transfer `ApplyID` at first.
- Fix: invalid docker compose `objectnode`.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #327

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```