### PR TITLE
Fix: metanode opResponseLoadPartition removes duplicate locks because…

### DIFF
--- a/metanode/partition.go
+++ b/metanode/partition.go
@@ -596,9 +596,7 @@ func (mp *metaPartition) ResponseLoadMetaPartition(p *Packet) (err error) {
 		DoCompare:   true,
 	}
 	resp.MaxInode = mp.GetCursor()
-	mp.dentryTree.RLock()
 	resp.DentryCount = uint64(mp.dentryTree.Len())
-	mp.dentryTree.RUnlock()
 	resp.ApplyID = mp.applyID
 	if err != nil {
 		err = errors.Trace(err,

--- a/metanode/partition_fsm.go
+++ b/metanode/partition_fsm.go
@@ -316,7 +316,7 @@ func (mp *metaPartition) HandleFatalEvent(err *raft.FatalError) {
 
 // HandleLeaderChange handles the leader changes.
 func (mp *metaPartition) HandleLeaderChange(leader uint64) {
-	exporter.Warning(exporterKey)
+	exporter.Warning(fmt.Sprintf("metaPartition(%v) changeLeader to (%v)",mp.config.PartitionId,leader))
 	if mp.config.NodeId != leader {
 		mp.storeChan <- &storeMsg{
 			command: stopStoreTick,


### PR DESCRIPTION
Signed-off-by: awzhgw <guowl18702995996@gmail.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
metanode on function opResponseLoadPartition, the mp.dentryTree.Len has lock,so delete duplicate lock
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
