### PR TITLE
Fix: metanode leak memory on DeleteMetaPartition operator

### DIFF
--- a/metanode/btree.go
+++ b/metanode/btree.go
@@ -146,7 +146,7 @@ func (b *BTree) GetTree() *BTree {
 // Reset resets the current btree.
 func (b *BTree) Reset() {
 	b.Lock()
-	b.tree.Clear(false)
+	b.tree.Clear(true)
 	b.Unlock()
 }
 

--- a/metanode/manager.go
+++ b/metanode/manager.go
@@ -364,8 +364,14 @@ func (m *metadataManager) createPartition(id uint64, volName string, start,
 }
 
 func (m *metadataManager) deletePartition(id uint64) (err error) {
-	// TODO Unhandled errors
-	m.detachPartition(id)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	mp, has := m.partitions[id]
+	if !has {
+		return
+	}
+	mp.Reset()
+	delete(m.partitions, id)
 	return
 }
 

--- a/metanode/manager_op.go
+++ b/metanode/manager_op.go
@@ -18,7 +18,7 @@ import (
 	"encoding/json"
 	"net"
 	"os"
-
+	"runtime"
 	"bytes"
 	"fmt"
 
@@ -546,6 +546,7 @@ func (m *metadataManager) opDeleteMetaPartition(conn net.Conn,
 	os.RemoveAll(conf.RootDir)
 	p.PacketOkReply()
 	m.respondToClient(conn, p)
+	runtime.GC()
 	log.LogInfof("%s [opDeleteMetaPartition] req: %d - %v, resp: %v",
 		remoteAddr, p.GetReqID(), req, err)
 	return

--- a/metanode/partition.go
+++ b/metanode/partition.go
@@ -169,7 +169,7 @@ type OpPartition interface {
 	ResponseLoadMetaPartition(p *Packet) (err error)
 	PersistMetadata() (err error)
 	ChangeMember(changeType raftproto.ConfChangeType, peer raftproto.Peer, context []byte) (resp interface{}, err error)
-	DeletePartition() (err error)
+	Reset() (err error)
 	UpdatePartition(req *UpdatePartitionReq, resp *UpdatePartitionResp) (err error)
 	DeleteRaft() error
 	IsExsitPeer(peer proto.Peer) bool
@@ -537,12 +537,6 @@ func (mp *metaPartition) ChangeMember(changeType raftproto.ConfChangeType, peer 
 // GetBaseConfig returns the configuration stored in the meta partition. TODO remove? no usage?
 func (mp *metaPartition) GetBaseConfig() MetaPartitionConfig {
 	return *mp.config
-}
-
-// DeletePartition deletes the meta partition. TODO remove? no usage?
-func (mp *metaPartition) DeletePartition() (err error) {
-	_, err = mp.Put(opFSMDeletePartition, nil)
-	return
 }
 
 // UpdatePartition updates the meta partition. TODO remove? no usage?

--- a/metanode/partition_free_list.go
+++ b/metanode/partition_free_list.go
@@ -55,12 +55,12 @@ func (mp *metaPartition) updateVolWorker() {
 		newView := &DataPartitionsView{
 			DataPartitions: make([]*DataPartition, len(view.DataPartitions)),
 		}
-		for i:=0; i<len(view.DataPartitions); i++ {
+		for i := 0; i < len(view.DataPartitions); i++ {
 			newView.DataPartitions[i] = &DataPartition{
 				PartitionID: view.DataPartitions[i].PartitionID,
-				Status: view.DataPartitions[i].Status,
-				Hosts: view.DataPartitions[i].Hosts,
-				ReplicaNum: view.DataPartitions[i].ReplicaNum,
+				Status:      view.DataPartitions[i].Status,
+				Hosts:       view.DataPartitions[i].Hosts,
+				ReplicaNum:  view.DataPartitions[i].ReplicaNum,
 			}
 		}
 		return newView

--- a/metanode/partition_fsm.go
+++ b/metanode/partition_fsm.go
@@ -103,8 +103,6 @@ func (mp *metaPartition) Apply(command []byte, index uint64) (resp interface{}, 
 			return
 		}
 		resp = mp.fsmUpdateDentry(den)
-	case opFSMDeletePartition:
-		resp = mp.fsmDeletePartition()
 	case opFSMUpdatePartition:
 		req := &UpdatePartitionReq{}
 		if err = json.Unmarshal(msg.V, req); err != nil {
@@ -316,7 +314,7 @@ func (mp *metaPartition) HandleFatalEvent(err *raft.FatalError) {
 
 // HandleLeaderChange handles the leader changes.
 func (mp *metaPartition) HandleLeaderChange(leader uint64) {
-	exporter.Warning(fmt.Sprintf("metaPartition(%v) changeLeader to (%v)",mp.config.PartitionId,leader))
+	exporter.Warning(fmt.Sprintf("metaPartition(%v) changeLeader to (%v)", mp.config.PartitionId, leader))
 	if mp.config.NodeId != leader {
 		mp.storeChan <- &storeMsg{
 			command: stopStoreTick,

--- a/metanode/partition_fsmop.go
+++ b/metanode/partition_fsmop.go
@@ -81,13 +81,6 @@ func (mp *metaPartition) fsmUpdatePartition(end uint64) (status uint8,
 	return
 }
 
-func (mp *metaPartition) fsmDeletePartition() (status uint8) {
-	mp.Stop()
-	// TODO Unhandled errors
-	os.RemoveAll(mp.config.RootDir)
-	return
-}
-
 func (mp *metaPartition) confAddNode(req *proto.
 	MetaPartitionDecommissionRequest, index uint64) (updated bool, err error) {
 	var (


### PR DESCRIPTION
Signed-off-by: awzhgw <guowl18702995996@gmail.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
when delete vol by admin,the metanode do deleteMetaPartition cannot call mp.Reset() func,the inodeTree and dentryTree cannot free memory
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #333

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
