### PR TITLE
Fix: Raft LeaderChange check serverPort if not open,then Try to Leader…

### DIFF
--- a/datanode/server.go
+++ b/datanode/server.go
@@ -45,7 +45,7 @@ var (
 	ErrNoSpaceToCreatePartition = errors.New("No disk space to create a data partition")
 	ErrNewSpaceManagerFailed    = errors.New("Creater new space manager failed")
 
-	LocalIP      string
+	LocalIP ,serverPort     string
 	gConnPool    = util.NewConnectPool()
 	MasterClient = masterSDK.NewMasterClient(nil, false)
 )
@@ -184,6 +184,7 @@ func (s *DataNode) parseConfig(cfg *config.Config) (err error) {
 	)
 	LocalIP = cfg.GetString(ConfigKeyLocalIP)
 	port = cfg.GetString(ConfigKeyPort)
+	serverPort=port
 	if regexpPort, err = regexp.Compile("^(\\d)+$"); err != nil {
 		return fmt.Errorf("Err:no port")
 	}

--- a/metanode/metanode.go
+++ b/metanode/metanode.go
@@ -39,6 +39,7 @@ var (
 	clusterInfo    *proto.ClusterInfo
 	masterClient   *masterSDK.MasterClient
 	configTotalMem uint64
+	serverPort       string
 )
 
 // The MetaNode manages the dentry and inode information of the meta partitions on a meta node.
@@ -173,6 +174,7 @@ func (m *MetaNode) parseConfig(cfg *config.Config) (err error) {
 	}
 	m.localAddr = cfg.GetString(cfgLocalIP)
 	m.listen = cfg.GetString(cfgListen)
+	serverPort=m.listen
 	m.metadataDir = cfg.GetString(cfgMetadataDir)
 	m.raftDir = cfg.GetString(cfgRaftDir)
 	m.raftHeartbeatPort = cfg.GetString(cfgRaftHeartbeatPort)


### PR DESCRIPTION
Signed-off-by: awzhgw <guowl18702995996@gmail.com>

**What this PR does / why we need it**:
Raft LeaderChange check serverPort if not open,then Try to Leader…

If the metadata server restarts, the metanode will load all metaPartitions. If one of the metaPartitions is successfully loaded, this metaPartition may be selected as the raft leader. However, because the service port is not listen, other metanode  cannot connect it.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #349 


