### PR TITLE
fix: inaccurate document content in ObjectNode user guide

### DIFF
--- a/docs/source/user-guide/objectnode.rst
+++ b/docs/source/user-guide/objectnode.rst
@@ -21,16 +21,23 @@ Object Node using `JSON` format configuration file.
 .. csv-table::
    :header: "Key", "Type", "Description", "Mandatory"
 
-   "role", "string", "Role of process and must be set to *objectnode*", "Yes"
-   "listen", "string", "Listen and accept port of the server. Default: 80", "Yes"
-   "region", "string", "Region of this gateway. Used by S3-like interface signature validation. Default: cfs_default", "No"
+   "role", "string", "Role of process and must be set to ``objectnode``", "Yes"
+   "listen", "string", "
+   | Listen and accept ip address and port of this server.
+   | Format: ``IP:PORT`` or ``:PORT``
+   | Default: ``:80``", "Yes"
+   "region", "string", "
+   | Region of this gateway. Used by S3-like interface signature validation.
+   | Default: ``cfs_default``", "No"
    "domains", "string slice", "
-   | Format: *DOMAIN*.
-   | DOMAIN: Domain of S3-like interface which makes wildcard domain support", "No"
+   | Domain of S3-like interface which makes wildcard domain support
+   | Format: ``DOMAIN``", "No"
    "logDir", "string", "Log directory", "Yes"
-   "logLevel", "string", "Level operation for logging. Default is *error*", "No"
+   "logLevel", "string", "
+   | Level operation for logging.
+   | Default: ``error``", "No"
    "masters", "string slice", "
-   | Format: *HOST:PORT*.
+   | Format: ``HOST:PORT``.
    | HOST: Hostname, domain or IP address of master (resource manager).
    | PORT: port number which listened by this master", "Yes"
    "exporterPort", "string", "Port for monitor system", "No"
@@ -43,8 +50,8 @@ Object Node using `JSON` format configuration file.
 
    {
         "role": "objectnode",
-        "listen": 80,
-        "region": "test",
+        "listen": ":80",
+        "region": "cfs_default",
         "domains": [
             "object.cfs.local"
         ],


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- fix: inaccurate document content in ObjectNode user guide

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #351

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
