### PR TITLE
fix: if the listening port has not been started,execute the tryToLead…

### DIFF
--- a/metanode/partition_fsm.go
+++ b/metanode/partition_fsm.go
@@ -317,14 +317,16 @@ func (mp *metaPartition) HandleFatalEvent(err *raft.FatalError) {
 // HandleLeaderChange handles the leader changes.
 func (mp *metaPartition) HandleLeaderChange(leader uint64) {
 	exporter.Warning(fmt.Sprintf("metaPartition(%v) changeLeader to (%v)", mp.config.PartitionId, leader))
-	conn, err := net.DialTimeout("tcp", net.JoinHostPort("127.0.0.1", serverPort), time.Second)
-	if err != nil {
-		log.LogErrorf(fmt.Sprintf("HandleLeaderChange serverPort not exsit ,error %v",err))
-		mp.raftPartition.TryToLeader(mp.config.PartitionId)
-		return
+	if mp.config.NodeId == leader {
+		conn, err := net.DialTimeout("tcp", net.JoinHostPort("127.0.0.1", serverPort), time.Second)
+		if err != nil {
+			log.LogErrorf(fmt.Sprintf("HandleLeaderChange serverPort not exsit ,error %v", err))
+			mp.raftPartition.TryToLeader(mp.config.PartitionId)
+			return
+		}
+		conn.(*net.TCPConn).SetLinger(0)
+		conn.Close()
 	}
-	conn.(*net.TCPConn).SetLinger(0)
-	conn.Close()
 	if mp.config.NodeId != leader {
 		mp.storeChan <- &storeMsg{
 			command: stopStoreTick,


### PR DESCRIPTION
What this PR does / why we need it:
     if the listening port has not been started,the new leader id match with metanode id,then execute the tryToLeader method directly

Which issue this PR fixes

Special notes for your reviewer:

Release note: