### PR TITLE
enhancement: the replica num of data partition can only be 2 and 3

### DIFF
--- a/master/api_service.go
+++ b/master/api_service.go
@@ -472,8 +472,8 @@ func (m *Server) updateVol(w http.ResponseWriter, r *http.Request) {
 		sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: err.Error()})
 		return
 	}
-	if replicaNum != 0 && replicaNum < 2 {
-		err = fmt.Errorf("replicaNum can't be less than 2,replicaNum[%v]", replicaNum)
+	if replicaNum !=0 && !(replicaNum == 2 || replicaNum == 3) {
+		err = fmt.Errorf("replicaNum can only be 2 and 3,received replicaNum is[%v]", replicaNum)
 		sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: err.Error()})
 		return
 	}
@@ -512,8 +512,8 @@ func (m *Server) createVol(w http.ResponseWriter, r *http.Request) {
 		sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: err.Error()})
 		return
 	}
-	if dpReplicaNum != 0 && dpReplicaNum < 2 {
-		err = fmt.Errorf("replicaNum can't be less than 2,replicaNum[%v]", dpReplicaNum)
+	if !(dpReplicaNum == 2 || dpReplicaNum == 3) {
+		err = fmt.Errorf("replicaNum can only be 2 and 3,received replicaNum is[%v]", dpReplicaNum)
 		sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: err.Error()})
 		return
 	}


### PR DESCRIPTION
Signed-off-by: zhuhyc <zzhniy.163.niy@163.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

   The replica num of data partition can only be 2 and 3

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

N/A

**Special notes for your reviewer**:

N/A

**Release note**:

N/A

```release-note
```
