### PR TITLE
fix: checks only file type instead of the whole mode

### DIFF
--- a/metanode/partition_fsmop_dentry.go
+++ b/metanode/partition_fsmop_dentry.go
@@ -56,7 +56,7 @@ func (mp *metaPartition) fsmCreateDentry(dentry *Dentry,
 		//do not allow directories and files to overwrite each
 		// other when renaming
 		d := item.(*Dentry)
-		if dentry.Type != d.Type {
+		if proto.OsModeType(dentry.Type) != proto.OsModeType(d.Type) {
 			status = proto.OpArgMismatchErr
 			return
 		}

--- a/proto/fs_proto.go
+++ b/proto/fs_proto.go
@@ -35,6 +35,11 @@ func OsMode(mode uint32) os.FileMode {
 	return os.FileMode(mode)
 }
 
+// Returns os.FileMode masked by os.ModeType
+func OsModeType(mode uint32) os.FileMode {
+	return os.FileMode(mode) & os.ModeType
+}
+
 // IsRegular checks if the mode is regular.
 func IsRegular(mode uint32) bool {
 	return OsMode(mode).IsRegular()


### PR DESCRIPTION
Meta node checks the dentry file mode when dealing with CreateDentry
request if the target dentry already exists to avoid files replacement
with different types, i.e. rename a regular file to overwrite a
directory. However, file mode contains permission bits as well as file
type bits. And we certainly do not want permissions involved in such
situation. So mask the file mode to compare file type bits only.

Signed-off-by: Shuoran Liu <shuoranliu@gmail.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Fix inappropriate file mode checks in meta node when dealing with create dentry requests.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

N/A

**Special notes for your reviewer**:

Compare only the file types but not permissions.

**Release note**:

N/A
