### PR TITLE
feature: make followerRead a client specific option

### DIFF
--- a/client/fs/super.go
+++ b/client/fs/super.go
@@ -25,36 +25,13 @@ import (
 	"bazil.org/fuse"
 	"bazil.org/fuse/fs"
 
+	"github.com/chubaofs/chubaofs/proto"
 	"github.com/chubaofs/chubaofs/sdk/data/stream"
 	"github.com/chubaofs/chubaofs/sdk/meta"
-	"github.com/chubaofs/chubaofs/util/auth"
 	"github.com/chubaofs/chubaofs/util/errors"
 	"github.com/chubaofs/chubaofs/util/log"
 	"github.com/chubaofs/chubaofs/util/ump"
 )
-
-type MountOption struct {
-	MountPoint    string
-	Volname       string
-	Owner         string
-	Master        string
-	Logpath       string
-	Loglvl        string
-	Profport      string
-	IcacheTimeout int64
-	LookupValid   int64
-	AttrValid     int64
-	ReadRate      int64
-	WriteRate     int64
-	EnSyncWrite   int64
-	AutoInvalData int64
-	UmpDatadir    string
-	Rdonly        bool
-	WriteCache    bool
-	KeepCache     bool
-	Authenticate  bool
-	TicketMess    auth.TicketMess
-}
 
 // Super defines the struct of a super block.
 type Super struct {
@@ -79,14 +56,14 @@ var (
 )
 
 // NewSuper returns a new Super.
-func NewSuper(opt *MountOption) (s *Super, err error) {
+func NewSuper(opt *proto.MountOptions) (s *Super, err error) {
 	s = new(Super)
-	s.mw, err = meta.NewMetaWrapper(opt.Volname, opt.Owner, opt.Master, opt.Authenticate, true, &opt.TicketMess)
+	s.mw, err = meta.NewMetaWrapper(opt, true)
 	if err != nil {
 		return nil, errors.Trace(err, "NewMetaWrapper failed!")
 	}
 
-	s.ec, err = stream.NewExtentClient(opt.Volname, opt.Master, opt.ReadRate, opt.WriteRate, s.mw.AppendExtentKey, s.mw.GetExtents, s.mw.Truncate)
+	s.ec, err = stream.NewExtentClient(opt, s.mw.AppendExtentKey, s.mw.GetExtents, s.mw.Truncate)
 	if err != nil {
 		return nil, errors.Trace(err, "NewExtentClient failed!")
 	}

--- a/client/fuse.go
+++ b/client/fuse.go
@@ -200,7 +200,7 @@ func startDaemon() error {
 	return nil
 }
 
-func mount(opt *cfs.MountOption) (fsConn *fuse.Conn, super *cfs.Super, err error) {
+func mount(opt *proto.MountOptions) (fsConn *fuse.Conn, super *cfs.Super, err error) {
 	super, err = cfs.NewSuper(opt)
 	if err != nil {
 		log.LogError(errors.Stack(err))
@@ -248,9 +248,9 @@ func registerInterceptedSignal(mnt string) {
 	}()
 }
 
-func parseMountOption(cfg *config.Config) (*cfs.MountOption, error) {
+func parseMountOption(cfg *config.Config) (*proto.MountOptions, error) {
 	var err error
-	opt := new(cfs.MountOption)
+	opt := new(proto.MountOptions)
 
 	rawmnt := cfg.GetString(proto.MountPoint)
 	opt.MountPoint, err = filepath.Abs(rawmnt)
@@ -275,6 +275,7 @@ func parseMountOption(cfg *config.Config) (*cfs.MountOption, error) {
 	opt.Rdonly = cfg.GetBool(proto.Rdonly)
 	opt.WriteCache = cfg.GetBool(proto.WriteCache)
 	opt.KeepCache = cfg.GetBool(proto.KeepCache)
+	opt.FollowerRead = cfg.GetBool(proto.FollowerRead)
 	opt.Authenticate = cfg.GetBool(proto.Authenticate)
 	if opt.Authenticate {
 		opt.TicketMess.ClientKey = cfg.GetString(proto.ClientKey)

--- a/clientv2/fs/super.go
+++ b/clientv2/fs/super.go
@@ -24,36 +24,12 @@ import (
 	"github.com/jacobsa/fuse/fuseops"
 	"github.com/jacobsa/fuse/fuseutil"
 
+	"github.com/chubaofs/chubaofs/proto"
 	"github.com/chubaofs/chubaofs/sdk/data/stream"
 	"github.com/chubaofs/chubaofs/sdk/meta"
-	"github.com/chubaofs/chubaofs/util/auth"
-	"github.com/chubaofs/chubaofs/util/config"
 	"github.com/chubaofs/chubaofs/util/errors"
 	"github.com/chubaofs/chubaofs/util/log"
 )
-
-type MountOption struct {
-	Config        *config.Config
-	MountPoint    string
-	Volname       string
-	Owner         string
-	Master        string
-	Logpath       string
-	Loglvl        string
-	Profport      string
-	IcacheTimeout int64
-	LookupValid   int64
-	AttrValid     int64
-	ReadRate      int64
-	WriteRate     int64
-	EnSyncWrite   int64
-	UmpDatadir    string
-	Rdonly        bool
-	WriteCache    bool
-	KeepCache     bool
-	Authenticate  bool
-	TicketMess    auth.TicketMess
-}
 
 type Super struct {
 	cluster     string
@@ -73,14 +49,14 @@ var (
 	_ fuseutil.FileSystem = (*Super)(nil)
 )
 
-func NewSuper(opt *MountOption) (s *Super, err error) {
+func NewSuper(opt *proto.MountOptions) (s *Super, err error) {
 	s = new(Super)
-	s.mw, err = meta.NewMetaWrapper(opt.Volname, opt.Owner, opt.Master, opt.Authenticate, true, &opt.TicketMess)
+	s.mw, err = meta.NewMetaWrapper(opt, true)
 	if err != nil {
 		return nil, errors.Trace(err, "NewMetaWrapper failed!")
 	}
 
-	s.ec, err = stream.NewExtentClient(opt.Volname, opt.Master, opt.ReadRate, opt.WriteRate, s.mw.AppendExtentKey, s.mw.GetExtents, s.mw.Truncate)
+	s.ec, err = stream.NewExtentClient(opt, s.mw.AppendExtentKey, s.mw.GetExtents, s.mw.Truncate)
 	if err != nil {
 		return nil, errors.Trace(err, "NewExtentClient failed!")
 	}

--- a/clientv2/main.go
+++ b/clientv2/main.go
@@ -190,7 +190,7 @@ func startDaemon() error {
 	return nil
 }
 
-func mount(opt *cfs.MountOption) (*fuse.MountedFileSystem, error) {
+func mount(opt *proto.MountOptions) (*fuse.MountedFileSystem, error) {
 	super, err := cfs.NewSuper(opt)
 	if err != nil {
 		log.LogError(errors.Stack(err))
@@ -239,9 +239,9 @@ func registerInterceptedSignal(mnt string) {
 	}()
 }
 
-func parseMountOption(cfg *config.Config) (*cfs.MountOption, error) {
+func parseMountOption(cfg *config.Config) (*proto.MountOptions, error) {
 	var err error
-	opt := new(cfs.MountOption)
+	opt := new(proto.MountOptions)
 	opt.Config = cfg
 
 	rawmnt := cfg.GetString(proto.MountPoint)
@@ -266,6 +266,7 @@ func parseMountOption(cfg *config.Config) (*cfs.MountOption, error) {
 	opt.Rdonly = cfg.GetBool(proto.Rdonly)
 	opt.WriteCache = cfg.GetBool(proto.WriteCache)
 	opt.KeepCache = cfg.GetBool(proto.KeepCache)
+	opt.FollowerRead = cfg.GetBool(proto.FollowerRead)
 	opt.Authenticate = cfg.GetBool(proto.Authenticate)
 	if opt.Authenticate {
 		opt.TicketMess.ClientKey = cfg.GetString(proto.ClientKey)

--- a/objectnode/fs_volume.go
+++ b/objectnode/fs_volume.go
@@ -1373,10 +1373,16 @@ func (v *volume) copyFile(parentID uint64, newFileName string, sourceFileInode u
 
 func newVolume(masters []string, vol string) (*volume, error) {
 	var err error
-	var masterHosts = strings.Join(masters, ",")
+	opt := &proto.MountOptions{
+		Volname:      vol,
+		Owner:        "",
+		Master:       strings.Join(masters, ","),
+		FollowerRead: true,
+		Authenticate: false,
+	}
 
 	var mw *meta.MetaWrapper
-	if mw, err = meta.NewMetaWrapper(vol, "", masterHosts, false, false, nil); err != nil {
+	if mw, err = meta.NewMetaWrapper(opt, false); err != nil {
 		return nil, err
 	}
 	defer func() {
@@ -1385,7 +1391,7 @@ func newVolume(masters []string, vol string) (*volume, error) {
 		}
 	}()
 	var ec *stream.ExtentClient
-	if ec, err = stream.NewExtentClient(vol, masterHosts, -1, -1, mw.AppendExtentKey, mw.GetExtents, mw.Truncate); err != nil {
+	if ec, err = stream.NewExtentClient(opt, mw.AppendExtentKey, mw.GetExtents, mw.Truncate); err != nil {
 		return nil, err
 	}
 

--- a/proto/mount_options.go
+++ b/proto/mount_options.go
@@ -1,5 +1,10 @@
 package proto
 
+import (
+	"github.com/chubaofs/chubaofs/util/auth"
+	"github.com/chubaofs/chubaofs/util/config"
+)
+
 const (
 	// Mandatory
 	MountPoint   = "mountPoint"
@@ -22,13 +27,36 @@ const (
 	Rdonly        = "rdonly"
 	WriteCache    = "writecache"
 	KeepCache     = "keepcache"
+	FollowerRead  = "followerRead"
 	CertFile      = "certFile"
 	ClientKey     = "clientKey"
 	TicketHost    = "ticketHost"
 	EnableHTTPS   = "enableHTTPS"
 
-
 	ListenPort = "listen"
 )
 
-
+type MountOptions struct {
+	Config        *config.Config
+	MountPoint    string
+	Volname       string
+	Owner         string
+	Master        string
+	Logpath       string
+	Loglvl        string
+	Profport      string
+	IcacheTimeout int64
+	LookupValid   int64
+	AttrValid     int64
+	ReadRate      int64
+	WriteRate     int64
+	EnSyncWrite   int64
+	AutoInvalData int64
+	UmpDatadir    string
+	Rdonly        bool
+	WriteCache    bool
+	KeepCache     bool
+	FollowerRead  bool
+	Authenticate  bool
+	TicketMess    auth.TicketMess
+}

--- a/sdk/data/stream/extent_client.go
+++ b/sdk/data/stream/extent_client.go
@@ -68,13 +68,13 @@ type ExtentClient struct {
 }
 
 // NewExtentClient returns a new extent client.
-func NewExtentClient(volname, master string, readRate, writeRate int64, appendExtentKey AppendExtentKeyFunc, getExtents GetExtentsFunc, truncate TruncateFunc) (client *ExtentClient, err error) {
+func NewExtentClient(opt *proto.MountOptions, appendExtentKey AppendExtentKeyFunc, getExtents GetExtentsFunc, truncate TruncateFunc) (client *ExtentClient, err error) {
 	runtime.GOMAXPROCS(runtime.NumCPU())
 	client = new(ExtentClient)
 
 	limit := MaxMountRetryLimit
 retry:
-	client.dataWrapper, err = wrapper.NewDataPartitionWrapper(volname, master)
+	client.dataWrapper, err = wrapper.NewDataPartitionWrapper(opt.Volname, opt.Master)
 	if err != nil {
 		if limit <= 0 {
 			return nil, errors.Trace(err, "Init data wrapper failed!")
@@ -89,7 +89,7 @@ retry:
 	client.appendExtentKey = appendExtentKey
 	client.getExtents = getExtents
 	client.truncate = truncate
-	client.followerRead = client.dataWrapper.FollowerRead()
+	client.followerRead = opt.FollowerRead
 
 	// Init request pools
 	openRequestPool = &sync.Pool{New: func() interface{} {
@@ -112,15 +112,15 @@ retry:
 	}}
 
 	var readLimit, writeLimit rate.Limit
-	if readRate <= 0 {
+	if opt.ReadRate <= 0 {
 		readLimit = defaultReadLimitRate
 	} else {
-		readLimit = rate.Limit(readRate)
+		readLimit = rate.Limit(opt.ReadRate)
 	}
-	if writeRate <= 0 {
+	if opt.WriteRate <= 0 {
 		writeLimit = defaultWriteLimitRate
 	} else {
-		writeLimit = rate.Limit(writeRate)
+		writeLimit = rate.Limit(opt.WriteRate)
 	}
 
 	client.readLimiter = rate.NewLimiter(readLimit, defaultReadLimitBurst)


### PR DESCRIPTION
Make followerRead a client specific option, so we don't need to set this
option during volume creation. Besides, various clients can have a more
flexible behavioral read pattern in one volume.

Signed-off-by: Shuoran Liu <shuoranliu@gmail.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Make "followeRead" a client specific option.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

N/A

**Special notes for your reviewer**:

N/A

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
