### PR TITLE
Replaced Dup2 syscall with Dup3

### DIFF
--- a/client/fuse.go
+++ b/client/fuse.go
@@ -139,7 +139,7 @@ func main() {
 	}()
 	syslog.SetOutput(outputFile)
 
-	if err = syscall.Dup2(int(outputFile.Fd()), int(os.Stderr.Fd())); err != nil {
+	if err = syscall.Dup3(int(outputFile.Fd()), int(os.Stderr.Fd()), 0); err != nil {
 		daemonize.SignalOutcome(err)
 		os.Exit(1)
 	}

--- a/clientv2/main.go
+++ b/clientv2/main.go
@@ -140,7 +140,7 @@ func main() {
 	}()
 	syslog.SetOutput(outputFile)
 
-	if err = syscall.Dup2(int(outputFile.Fd()), int(os.Stderr.Fd())); err != nil {
+	if err = syscall.Dup3(int(outputFile.Fd()), int(os.Stderr.Fd()), 0); err != nil {
 		daemonize.SignalOutcome(err)
 		os.Exit(1)
 	}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -216,7 +216,7 @@ func main() {
 	}()
 	syslog.SetOutput(outputFile)
 
-	if err = syscall.Dup2(int(outputFile.Fd()), int(os.Stderr.Fd())); err != nil {
+	if err = syscall.Dup3(int(outputFile.Fd()), int(os.Stderr.Fd()), 0); err != nil {
 		daemonize.SignalOutcome(err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
The Dup2 syscall doesn't seem to be supported on all architectures on Linux. The newer Dup3 syscall however seems to have a much wider architecture support. This PR replaces all occurences of Dup2 with Dup3 to help push #393 forward.
Unfortunately the file `vendor/github.com/tiglabs/raft/util/log/log_crash_unix.go` still contains a call to Dup2 which isn't behind a build flag. So either this vendored dependency needs to be patched locally in the vendor folder (bad), or this is fixed upstream or the dependency is replaced by something else.