### PR TITLE
fix: a object with a map field type are locked during serialization

### DIFF
--- a/master/api_service.go
+++ b/master/api_service.go
@@ -1577,6 +1577,8 @@ func (m *Server) getMetaPartition(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var toInfo = func(mp *MetaPartition) *proto.MetaPartitionInfo {
+		mp.RLock()
+		defer mp.RUnlock()
 		var replicas = make([]*proto.MetaReplicaInfo, len(mp.Replicas))
 		zones := make([]string, len(mp.Hosts))
 		for idx, host := range mp.Hosts {

--- a/master/data_partition.go
+++ b/master/data_partition.go
@@ -664,6 +664,8 @@ func (partition *DataPartition) getLiveZones(offlineAddr string) (zones []string
 }
 
 func (partition *DataPartition) ToProto(c *Cluster) *proto.DataPartitionInfo {
+	partition.RLock()
+	defer partition.RUnlock()
 	var replicas = make([]*proto.DataReplica, len(partition.Replicas))
 	for i, replica := range partition.Replicas {
 		replicas[i] = &replica.DataReplica


### PR DESCRIPTION
Signed-off-by: zhuhyc <zzhniy.163.niy@163.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

A object with a map field type are locked during serialization

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

N/A

**Special notes for your reviewer**:

N/A

**Release note**:

N/A
