### PR TITLE
Refactor: unbinding regions in signature algorithm v4

### DIFF
--- a/master/mocktest/data_server.go
+++ b/master/mocktest/data_server.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"time"
 
 	"github.com/chubaofs/chubaofs/proto"
 	"github.com/chubaofs/chubaofs/sdk/master"
@@ -45,7 +46,17 @@ func (mds *MockDataServer) Start() {
 }
 
 func (mds *MockDataServer) register() {
-	nodeID, err := mds.mc.NodeAPI().AddDataNode(mds.TcpAddr,mds.zoneName)
+	var err error
+	var nodeID uint64
+	var retry int
+	for retry < 3 {
+		nodeID, err = mds.mc.NodeAPI().AddDataNode(mds.TcpAddr, mds.zoneName)
+		if err == nil {
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+		retry++
+	}
 	if err != nil {
 		panic(err)
 	}

--- a/master/mocktest/meta_server.go
+++ b/master/mocktest/meta_server.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/chubaofs/chubaofs/proto"
 	"github.com/chubaofs/chubaofs/sdk/master"
@@ -37,7 +38,17 @@ func (mms *MockMetaServer) Start() {
 }
 
 func (mms *MockMetaServer) register() {
-	nodeID, err := mms.mc.NodeAPI().AddMetaNode(mms.TcpAddr, mms.ZoneName)
+	var err error
+	var nodeID uint64
+	var retry int
+	for retry < 3 {
+		nodeID, err = mms.mc.NodeAPI().AddMetaNode(mms.TcpAddr, mms.ZoneName)
+		if err == nil {
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+		retry++
+	}
 	if err != nil {
 		panic(err)
 	}

--- a/objectnode/auth_signature_v4.go
+++ b/objectnode/auth_signature_v4.go
@@ -108,7 +108,7 @@ func (o *ObjectNode) checkSignatureV4(r *http.Request) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	newSignature := calculateSignatureV4(r, o.region, secretKey, req.SignedHeaders)
+	newSignature := calculateSignatureV4(r, req.Credential.Region, secretKey, req.SignedHeaders)
 	if req.Signature != newSignature {
 		log.LogDebugf("checkSignatureV4: invalid signature: requestID(%v) client(%v) server(%v)",
 			RequestIDFromRequest(r), req.Signature, newSignature)


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Unbinding regions in signature algorithm v4. 
ObjectNode uses the region in the request to calculate the signature in the signature algorithm v4.