### PR TITLE
feature: support client command line argument

### DIFF
--- a/client/fuse.go
+++ b/client/fuse.go
@@ -31,7 +31,6 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
-	"strconv"
 	"strings"
 	"syscall"
 
@@ -77,6 +76,13 @@ var (
 	configForeground = flag.Bool("f", false, "run foreground")
 )
 
+var GlobalMountOptions []proto.MountOption
+
+func init() {
+	GlobalMountOptions = proto.NewMountOptions()
+	proto.InitMountOptions(GlobalMountOptions)
+}
+
 func main() {
 	runtime.GOMAXPROCS(runtime.NumCPU())
 
@@ -88,16 +94,6 @@ func main() {
 		fmt.Printf("Commit: %s\n", CommitID)
 		fmt.Printf("Build: %s %s %s %s\n", runtime.Version(), runtime.GOOS, runtime.GOARCH, BuildTime)
 		os.Exit(0)
-	}
-
-	/*
-	 * LoadConfigFile should be checked before start daemon, since it will
-	 * call os.Exit() w/o notifying the parent process.
-	 */
-	cfg, err := config.LoadConfigFile(*configFile)
-	if err != nil {
-		daemonize.SignalOutcome(err)
-		os.Exit(1)
 	}
 
 	if !*configForeground {
@@ -113,6 +109,7 @@ func main() {
 	 * Must notify the parent process through SignalOutcome anyway.
 	 */
 
+	cfg, _ := config.LoadConfigFile(*configFile)
 	opt, err := parseMountOption(cfg)
 	if err != nil {
 		daemonize.SignalOutcome(err)
@@ -140,6 +137,12 @@ func main() {
 		outputFile.Close()
 	}()
 	syslog.SetOutput(outputFile)
+
+	syslog.Println("*** Final Mount Options ***")
+	for _, o := range GlobalMountOptions {
+		syslog.Println(o)
+	}
+	syslog.Println("*** End ***")
 
 	if err = sysutil.RedirectFD(int(outputFile.Fd()), int(os.Stderr.Fd())); err != nil {
 		daemonize.SignalOutcome(err)
@@ -181,14 +184,26 @@ func startDaemon() error {
 		return fmt.Errorf("startDaemon failed: cannot get absolute command path, err(%v)", err)
 	}
 
-	configPath, err := filepath.Abs(*configFile)
-	if err != nil {
-		return fmt.Errorf("startDaemon failed: cannot get absolute command path of config file(%v) , err(%v)", *configFile, err)
+	if len(os.Args) <= 1 {
+		return fmt.Errorf("startDaemon failed: cannot use null arguments")
 	}
 
 	args := []string{"-f"}
-	args = append(args, "-c")
-	args = append(args, configPath)
+	args = append(args, os.Args[1:]...)
+
+	if *configFile != "" {
+		configPath, err := filepath.Abs(*configFile)
+		if err != nil {
+			return fmt.Errorf("startDaemon failed: cannot get absolute command path of config file(%v) , err(%v)", *configFile, err)
+		}
+		for i := 0; i < len(args); i++ {
+			if args[i] == "-c" {
+				// Since *configFile is not "", the (i+1)th argument must be the config file path
+				args[i+1] = configPath
+				break
+			}
+		}
+	}
 
 	env := []string{
 		fmt.Sprintf("PATH=%s", os.Getenv("PATH")),
@@ -254,37 +269,39 @@ func parseMountOption(cfg *config.Config) (*proto.MountOptions, error) {
 	var err error
 	opt := new(proto.MountOptions)
 
-	rawmnt := cfg.GetString(proto.MountPoint)
+	proto.ParseMountOptions(GlobalMountOptions, cfg)
+
+	rawmnt := GlobalMountOptions[proto.MountPoint].GetString()
 	opt.MountPoint, err = filepath.Abs(rawmnt)
 	if err != nil {
 		return nil, errors.Trace(err, "invalide mount point (%v) ", rawmnt)
 	}
 
-	opt.Volname = cfg.GetString(proto.VolName)
-	opt.Owner = cfg.GetString(proto.Owner)
-	opt.Master = cfg.GetString(proto.MasterAddr)
-	opt.Logpath = cfg.GetString(proto.LogDir)
-	opt.Loglvl = cfg.GetString(proto.LogLevel)
-	opt.Profport = cfg.GetString(proto.ProfPort)
-	opt.IcacheTimeout = parseConfigString(cfg, proto.IcacheTimeout)
-	opt.LookupValid = parseConfigString(cfg, proto.LookupValid)
-	opt.AttrValid = parseConfigString(cfg, proto.AttrValid)
-	opt.ReadRate = parseConfigString(cfg, proto.ReadRate)
-	opt.WriteRate = parseConfigString(cfg, proto.WriteRate)
-	opt.EnSyncWrite = parseConfigString(cfg, proto.EnSyncWrite)
-	opt.AutoInvalData = parseConfigString(cfg, proto.AutoInvalData)
-	opt.UmpDatadir = cfg.GetString(proto.WarnLogDir)
-	opt.Rdonly = cfg.GetBool(proto.Rdonly)
-	opt.WriteCache = cfg.GetBool(proto.WriteCache)
-	opt.KeepCache = cfg.GetBool(proto.KeepCache)
-	opt.FollowerRead = cfg.GetBool(proto.FollowerRead)
-	opt.Authenticate = cfg.GetBool(proto.Authenticate)
+	opt.Volname = GlobalMountOptions[proto.VolName].GetString()
+	opt.Owner = GlobalMountOptions[proto.Owner].GetString()
+	opt.Master = GlobalMountOptions[proto.Master].GetString()
+	opt.Logpath = GlobalMountOptions[proto.LogDir].GetString()
+	opt.Loglvl = GlobalMountOptions[proto.LogLevel].GetString()
+	opt.Profport = GlobalMountOptions[proto.ProfPort].GetString()
+	opt.IcacheTimeout = GlobalMountOptions[proto.IcacheTimeout].GetInt64()
+	opt.LookupValid = GlobalMountOptions[proto.LookupValid].GetInt64()
+	opt.AttrValid = GlobalMountOptions[proto.AttrValid].GetInt64()
+	opt.ReadRate = GlobalMountOptions[proto.ReadRate].GetInt64()
+	opt.WriteRate = GlobalMountOptions[proto.WriteRate].GetInt64()
+	opt.EnSyncWrite = GlobalMountOptions[proto.EnSyncWrite].GetInt64()
+	opt.AutoInvalData = GlobalMountOptions[proto.AutoInvalData].GetInt64()
+	opt.UmpDatadir = GlobalMountOptions[proto.WarnLogDir].GetString()
+	opt.Rdonly = GlobalMountOptions[proto.Rdonly].GetBool()
+	opt.WriteCache = GlobalMountOptions[proto.WriteCache].GetBool()
+	opt.KeepCache = GlobalMountOptions[proto.KeepCache].GetBool()
+	opt.FollowerRead = GlobalMountOptions[proto.FollowerRead].GetBool()
+	opt.Authenticate = GlobalMountOptions[proto.Authenticate].GetBool()
 	if opt.Authenticate {
-		opt.TicketMess.ClientKey = cfg.GetString(proto.ClientKey)
-		opt.TicketMess.TicketHost = cfg.GetString(proto.TicketHost)
-		opt.TicketMess.EnableHTTPS = cfg.GetBool(proto.EnableHTTPS)
+		opt.TicketMess.ClientKey = GlobalMountOptions[proto.ClientKey].GetString()
+		opt.TicketMess.TicketHost = GlobalMountOptions[proto.TicketHost].GetString()
+		opt.TicketMess.EnableHTTPS = GlobalMountOptions[proto.EnableHTTPS].GetBool()
 		if opt.TicketMess.EnableHTTPS {
-			opt.TicketMess.CertFile = cfg.GetString(proto.CertFile)
+			opt.TicketMess.CertFile = GlobalMountOptions[proto.CertFile].GetString()
 		}
 	}
 
@@ -293,19 +310,6 @@ func parseMountOption(cfg *config.Config) (*proto.MountOptions, error) {
 	}
 
 	return opt, nil
-}
-
-func parseConfigString(cfg *config.Config, keyword string) int64 {
-	var ret int64 = -1
-	rawstr := cfg.GetString(keyword)
-	if rawstr != "" {
-		val, err := strconv.Atoi(rawstr)
-		if err == nil {
-			ret = int64(val)
-			fmt.Println(fmt.Sprintf("keyword[%v] value[%v]", keyword, ret))
-		}
-	}
-	return ret
 }
 
 func parseLogLevel(loglvl string) log.Level {

--- a/clientv2/main.go
+++ b/clientv2/main.go
@@ -32,7 +32,6 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
-	"strconv"
 	"strings"
 	"syscall"
 
@@ -78,6 +77,13 @@ var (
 	configForeground = flag.Bool("f", false, "run foreground")
 )
 
+var GlobalMountOptions []proto.MountOption
+
+func init() {
+	GlobalMountOptions = proto.NewMountOptions()
+	proto.InitMountOptions(GlobalMountOptions)
+}
+
 func main() {
 	runtime.GOMAXPROCS(runtime.NumCPU())
 
@@ -89,16 +95,6 @@ func main() {
 		fmt.Printf("Commit: %s\n", CommitID)
 		fmt.Printf("Build: %s %s %s %s\n", runtime.Version(), runtime.GOOS, runtime.GOARCH, BuildTime)
 		os.Exit(0)
-	}
-
-	/*
-	 * LoadConfigFile should be checked before start daemon, since it will
-	 * call os.Exit() w/o notifying the parent process.
-	 */
-	cfg, err := config.LoadConfigFile(*configFile)
-	if err != nil {
-		daemonize.SignalOutcome(err)
-		os.Exit(1)
 	}
 
 	if !*configForeground {
@@ -114,6 +110,7 @@ func main() {
 	 * Must notify the parent process through SignalOutcome anyway.
 	 */
 
+	cfg, _ := config.LoadConfigFile(*configFile)
 	opt, err := parseMountOption(cfg)
 	if err != nil {
 		daemonize.SignalOutcome(err)
@@ -141,6 +138,12 @@ func main() {
 		outputFile.Close()
 	}()
 	syslog.SetOutput(outputFile)
+
+	syslog.Println("*** Final Mount Options ***")
+	for _, o := range GlobalMountOptions {
+		syslog.Println(o)
+	}
+	syslog.Println("*** End ***")
 
 	if err = sysutil.RedirectFD(int(outputFile.Fd()), int(os.Stderr.Fd())); err != nil {
 		daemonize.SignalOutcome(err)
@@ -246,36 +249,39 @@ func parseMountOption(cfg *config.Config) (*proto.MountOptions, error) {
 	opt := new(proto.MountOptions)
 	opt.Config = cfg
 
-	rawmnt := cfg.GetString(proto.MountPoint)
+	proto.ParseMountOptions(GlobalMountOptions, cfg)
+
+	rawmnt := GlobalMountOptions[proto.MountPoint].GetString()
 	opt.MountPoint, err = filepath.Abs(rawmnt)
 	if err != nil {
 		return nil, errors.Trace(err, "invalide mount point (%v) ", rawmnt)
 	}
 
-	opt.Volname = cfg.GetString(proto.VolName)
-	opt.Owner = cfg.GetString(proto.Owner)
-	opt.Master = cfg.GetString(proto.MasterAddr)
-	opt.Logpath = cfg.GetString(proto.LogDir)
-	opt.Loglvl = cfg.GetString(proto.LogLevel)
-	opt.Profport = cfg.GetString(proto.ProfPort)
-	opt.IcacheTimeout = parseConfigString(cfg, proto.IcacheTimeout)
-	opt.LookupValid = parseConfigString(cfg, proto.LookupValid)
-	opt.AttrValid = parseConfigString(cfg, proto.AttrValid)
-	opt.ReadRate = parseConfigString(cfg, proto.ReadRate)
-	opt.WriteRate = parseConfigString(cfg, proto.WriteRate)
-	opt.EnSyncWrite = parseConfigString(cfg, proto.EnSyncWrite)
-	opt.UmpDatadir = cfg.GetString(proto.WarnLogDir)
-	opt.Rdonly = cfg.GetBool(proto.Rdonly)
-	opt.WriteCache = cfg.GetBool(proto.WriteCache)
-	opt.KeepCache = cfg.GetBool(proto.KeepCache)
-	opt.FollowerRead = cfg.GetBool(proto.FollowerRead)
-	opt.Authenticate = cfg.GetBool(proto.Authenticate)
+	opt.Volname = GlobalMountOptions[proto.VolName].GetString()
+	opt.Owner = GlobalMountOptions[proto.Owner].GetString()
+	opt.Master = GlobalMountOptions[proto.Master].GetString()
+	opt.Logpath = GlobalMountOptions[proto.LogDir].GetString()
+	opt.Loglvl = GlobalMountOptions[proto.LogLevel].GetString()
+	opt.Profport = GlobalMountOptions[proto.ProfPort].GetString()
+	opt.IcacheTimeout = GlobalMountOptions[proto.IcacheTimeout].GetInt64()
+	opt.LookupValid = GlobalMountOptions[proto.LookupValid].GetInt64()
+	opt.AttrValid = GlobalMountOptions[proto.AttrValid].GetInt64()
+	opt.ReadRate = GlobalMountOptions[proto.ReadRate].GetInt64()
+	opt.WriteRate = GlobalMountOptions[proto.WriteRate].GetInt64()
+	opt.EnSyncWrite = GlobalMountOptions[proto.EnSyncWrite].GetInt64()
+	opt.AutoInvalData = GlobalMountOptions[proto.AutoInvalData].GetInt64()
+	opt.UmpDatadir = GlobalMountOptions[proto.WarnLogDir].GetString()
+	opt.Rdonly = GlobalMountOptions[proto.Rdonly].GetBool()
+	opt.WriteCache = GlobalMountOptions[proto.WriteCache].GetBool()
+	opt.KeepCache = GlobalMountOptions[proto.KeepCache].GetBool()
+	opt.FollowerRead = GlobalMountOptions[proto.FollowerRead].GetBool()
+	opt.Authenticate = GlobalMountOptions[proto.Authenticate].GetBool()
 	if opt.Authenticate {
-		opt.TicketMess.ClientKey = cfg.GetString(proto.ClientKey)
-		opt.TicketMess.TicketHost = cfg.GetString(proto.TicketHost)
-		opt.TicketMess.EnableHTTPS = cfg.GetBool(proto.EnableHTTPS)
+		opt.TicketMess.ClientKey = GlobalMountOptions[proto.ClientKey].GetString()
+		opt.TicketMess.TicketHost = GlobalMountOptions[proto.TicketHost].GetString()
+		opt.TicketMess.EnableHTTPS = GlobalMountOptions[proto.EnableHTTPS].GetBool()
 		if opt.TicketMess.EnableHTTPS {
-			opt.TicketMess.CertFile = cfg.GetString(proto.CertFile)
+			opt.TicketMess.CertFile = GlobalMountOptions[proto.CertFile].GetString()
 		}
 	}
 
@@ -284,19 +290,6 @@ func parseMountOption(cfg *config.Config) (*proto.MountOptions, error) {
 	}
 
 	return opt, nil
-}
-
-func parseConfigString(cfg *config.Config, keyword string) int64 {
-	var ret int64 = -1
-	rawstr := cfg.GetString(keyword)
-	if rawstr != "" {
-		val, err := strconv.Atoi(rawstr)
-		if err == nil {
-			ret = int64(val)
-			fmt.Println(fmt.Sprintf("keyword[%v] value[%v]", keyword, ret))
-		}
-	}
-	return ret
 }
 
 // ParseLogLevel returns the log level based on the given string.

--- a/proto/mount_options.go
+++ b/proto/mount_options.go
@@ -1,40 +1,178 @@
 package proto
 
 import (
+	"flag"
+	"fmt"
+	"strconv"
+
 	"github.com/chubaofs/chubaofs/util/auth"
 	"github.com/chubaofs/chubaofs/util/config"
 )
 
+// For client
 const (
 	// Mandatory
-	MountPoint   = "mountPoint"
-	VolName      = "volName"
-	Owner        = "owner"
-	MasterAddr   = "masterAddr"
-	LogDir       = "logDir"
-	WarnLogDir   = "warnLogDir"
-	Authenticate = "authenticate"
+	MountPoint int = iota
+	VolName
+	Owner
+	Master
 	// Optional
-	LogLevel      = "logLevel"
-	ProfPort      = "profPort"
-	IcacheTimeout = "icacheTimeout"
-	LookupValid   = "lookupValid"
-	AttrValid     = "attrValid"
-	ReadRate      = "readRate"
-	WriteRate     = "writeRate"
-	EnSyncWrite   = "enSyncWrite"
-	AutoInvalData = "autoInvalData"
-	Rdonly        = "rdonly"
-	WriteCache    = "writecache"
-	KeepCache     = "keepcache"
-	FollowerRead  = "followerRead"
-	CertFile      = "certFile"
-	ClientKey     = "clientKey"
-	TicketHost    = "ticketHost"
-	EnableHTTPS   = "enableHTTPS"
+	LogDir
+	WarnLogDir
+	LogLevel
+	ProfPort
+	IcacheTimeout
+	LookupValid
+	AttrValid
+	ReadRate
+	WriteRate
+	EnSyncWrite
+	AutoInvalData
+	Rdonly
+	WriteCache
+	KeepCache
+	FollowerRead
+	Authenticate
+	ClientKey
+	TicketHost
+	EnableHTTPS
+	CertFile
 
+	MaxMountOption
+)
+
+// For server
+const (
+	MasterAddr = "masterAddr"
 	ListenPort = "listen"
 )
+
+type MountOption struct {
+	keyword      string
+	description  string
+	cmdlineValue string
+	value        interface{}
+}
+
+func (o MountOption) String() string {
+	return fmt.Sprintf("[%v] %T: %v", o.keyword, o.value, o.value)
+}
+
+func NewMountOptions() []MountOption {
+	opts := make([]MountOption, MaxMountOption)
+	return opts
+}
+
+func InitMountOptions(opts []MountOption) {
+	opts[MountPoint] = MountOption{"mountPoint", "Mount Point", "", ""}
+	opts[VolName] = MountOption{"volName", "Volume Name", "", ""}
+	opts[Owner] = MountOption{"owner", "Owner", "", ""}
+	opts[Master] = MountOption{MasterAddr, "Master Address", "", ""}
+	opts[LogDir] = MountOption{"logDir", "Log Path", "", ""}
+	opts[WarnLogDir] = MountOption{"warnLogDir", "Warn Log Path", "", ""}
+	opts[LogLevel] = MountOption{"logLevel", "Log Level", "", ""}
+	opts[ProfPort] = MountOption{"profPort", "PProf Port", "", ""}
+	opts[IcacheTimeout] = MountOption{"icacheTimeout", "Inode Cache Expiration Time", "", int64(-1)}
+	opts[LookupValid] = MountOption{"lookupValid", "Lookup Valid Duration", "", int64(-1)}
+	opts[AttrValid] = MountOption{"attrValid", "Attr Valid Duration", "", int64(-1)}
+	opts[ReadRate] = MountOption{"readRate", "Read Rate Limit", "", int64(-1)}
+	opts[WriteRate] = MountOption{"writeRate", "Write Rate Limit", "", int64(-1)}
+	opts[EnSyncWrite] = MountOption{"enSyncWrite", "Enable Sync Write", "", int64(-1)}
+	opts[AutoInvalData] = MountOption{"autoInvalData", "Auto Invalidate Data", "", int64(-1)}
+	opts[Rdonly] = MountOption{"rdonly", "Mount as readonly", "", false}
+	opts[WriteCache] = MountOption{"writecache", "Enable FUSE writecache feature", "", false}
+	opts[KeepCache] = MountOption{"keepcache", "Enable FUSE keepcache feature", "", false}
+	opts[FollowerRead] = MountOption{"followerRead", "Enable read from follower", "", false}
+
+	opts[Authenticate] = MountOption{"authenticate", "Enable Authenticate", "", false}
+	opts[ClientKey] = MountOption{"clientKey", "Client Key", "", ""}
+	opts[TicketHost] = MountOption{"ticketHost", "Ticket Host", "", ""}
+	opts[EnableHTTPS] = MountOption{"enableHTTPS", "Enable HTTPS", "", false}
+	opts[CertFile] = MountOption{"certFile", "Cert File", "", ""}
+
+	for i := 0; i < MaxMountOption; i++ {
+		flag.StringVar(&opts[i].cmdlineValue, opts[i].keyword, "", opts[i].description)
+	}
+}
+
+func ParseMountOptions(opts []MountOption, cfg *config.Config) {
+	for i := 0; i < MaxMountOption; i++ {
+		switch v := opts[i].value.(type) {
+		case string:
+			if opts[i].cmdlineValue != "" {
+				opts[i].value = opts[i].cmdlineValue
+			} else {
+				opts[i].value = cfg.GetString(opts[i].keyword)
+			}
+			fmt.Println(fmt.Sprintf("keyword[%v] value[%v] type[%T]", opts[i].keyword, opts[i].value, v))
+
+		case int64:
+			if opts[i].cmdlineValue != "" {
+				opts[i].value = parseInt64(opts[i].cmdlineValue)
+			} else {
+				rawstr := cfg.GetString(opts[i].keyword)
+				opts[i].value = parseInt64(rawstr)
+			}
+			fmt.Println(fmt.Sprintf("keyword[%v] value[%v] type[%T]", opts[i].keyword, opts[i].value, v))
+
+		case bool:
+			if opts[i].cmdlineValue != "" {
+				opts[i].value = parseBool(opts[i].cmdlineValue)
+			} else {
+				opts[i].value = cfg.GetBool(opts[i].keyword)
+			}
+			fmt.Println(fmt.Sprintf("keyword[%v] value[%v] type[%T]", opts[i].keyword, opts[i].value, v))
+
+		default:
+			fmt.Println(fmt.Sprintf("keyword[%v] unknown type[%T]", opts[i].keyword, v))
+		}
+	}
+}
+
+func parseInt64(s string) int64 {
+	var ret int64 = -1
+
+	if s != "" {
+		val, err := strconv.Atoi(s)
+		if err == nil {
+			ret = int64(val)
+		}
+	}
+	return ret
+}
+
+func parseBool(s string) bool {
+	var ret bool = false
+
+	if s == "true" {
+		ret = true
+	}
+	return ret
+}
+
+func (opt *MountOption) GetString() string {
+	val, ok := opt.value.(string)
+	if !ok {
+		return ""
+	}
+	return val
+}
+
+func (opt *MountOption) GetBool() bool {
+	val, ok := opt.value.(bool)
+	if !ok {
+		return false
+	}
+	return val
+}
+
+func (opt *MountOption) GetInt64() int64 {
+	val, ok := opt.value.(int64)
+	if !ok {
+		return int64(-1)
+	}
+	return val
+}
 
 type MountOptions struct {
 	Config        *config.Config


### PR DESCRIPTION
The client mount options can be obtained from both config file and
command line arguments. Note that the priority of command line argument is
higher than that of config file, and will overwrite the corresponding
field.

Signed-off-by: Shuoran Liu <shuoranliu@gmail.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
