### PR TITLE
fix: wait for data sync in close syscall

### DIFF
--- a/client/fs/file.go
+++ b/client/fs/file.go
@@ -236,7 +236,18 @@ func (f *File) Write(ctx context.Context, req *fuse.WriteRequest, resp *fuse.Wri
 
 // Flush has not been implemented.
 func (f *File) Flush(ctx context.Context, req *fuse.FlushRequest) (err error) {
-	return fuse.ENOSYS
+	log.LogDebugf("TRACE Flush enter: ino(%v)", f.inode.ino)
+	start := time.Now()
+	err = f.super.ec.Flush(f.inode.ino)
+	if err != nil {
+		msg := fmt.Sprintf("Flush: ino(%v) err(%v)", f.inode.ino, err)
+		f.super.handleError("Flush", msg)
+		return fuse.EIO
+	}
+	f.super.ic.Delete(f.inode.ino)
+	elapsed := time.Since(start)
+	log.LogDebugf("TRACE Flush: ino(%v) (%v)ns", f.inode.ino, elapsed.Nanoseconds())
+	return nil
 }
 
 // Fsync hanldes the fsync request.


### PR DESCRIPTION
The Linux *close* syscall invokes the fuse Flush method which is not
implemented before. So the data might still in client's buffer after a
file is closed. Although there is no data persistence requirement for
the *close* syscall, we'd better wait for data to be synced so that
other clients can see the latest data after the file is closed in this
client.

Signed-off-by: Shuoran Liu <shuoranliu@gmail.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
