### PR TITLE
Fix: issue on list objects with delimiter

### DIFF
--- a/objectnode/result.go
+++ b/objectnode/result.go
@@ -145,7 +145,7 @@ type Content struct {
 }
 
 type ListBucketResult struct {
-	XMLName        xml.Name        `xml:"ListBucketResults"`
+	XMLName        xml.Name        `xml:"ListBucketResult"`
 	Bucket         string          `xml:"Name"`
 	Prefix         string          `xml:"Prefix"`
 	Marker         string          `xml:"Marker"`


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- Fix issue that server respond incorrect result when using ListObjects with
delimiter parameter.
- Fix compatibility issue on ListObjects interface when using java SDK v1.

**Which issue this PR fixes**: 

- fixes #426
- fixes #427

**Special notes for your reviewer**:

NONE.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Bug Fixes:
- Fix a bug that server respond incorrect result when using ListObjects with
delimiter parameter.
- Fix a compatibility issue on ListObjects interface when using java SDK v1.
```