### PR TITLE
Fix empty result on list objects

### DIFF
--- a/objectnode/api_handler_object.go
+++ b/objectnode/api_handler_object.go
@@ -106,14 +106,14 @@ func (o *ObjectNode) getObjectHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// validate and fix range
-	if isRangeRead && rangeUpper > uint64(fileInfo.Size) {
-		rangeUpper = uint64(fileInfo.Size)
+	if isRangeRead && rangeUpper > uint64(fileInfo.Size)-1 {
+		rangeUpper = uint64(fileInfo.Size) - 1
 	}
 
 	// compute content length
 	var contentLength = uint64(fileInfo.Size)
 	if isRangeRead {
-		contentLength = rangeUpper - rangeLower
+		contentLength = rangeUpper - rangeLower + 1
 	}
 
 	// set response header for GetObject
@@ -134,7 +134,7 @@ func (o *ObjectNode) getObjectHandler(w http.ResponseWriter, r *http.Request) {
 		if rangeUpper == 0 {
 			size = uint64(fileInfo.Size) - rangeLower
 		} else {
-			size = rangeUpper - rangeLower
+			size = rangeUpper - rangeLower + 1
 		}
 	}
 	if err = vl.ReadFile(object, w, offset, size); err != nil {

--- a/objectnode/fs_volume.go
+++ b/objectnode/fs_volume.go
@@ -1180,7 +1180,7 @@ func (v *volume) listDir(fileInfos []*FSFileInfo, prefixMap PrefixMap, parentId,
 		if delimiter != "" {
 			var nonPrefixPart = strings.Replace(path, prefix, "", 1)
 			if idx := strings.Index(nonPrefixPart, delimiter); idx >= 0 {
-				var commonPrefix = prefix + util.SubString(nonPrefixPart, 0, idx)
+				var commonPrefix = prefix + util.SubString(nonPrefixPart, 0, idx) + delimiter
 				prefixMap.AddPrefix(commonPrefix)
 				continue
 			}

--- a/objectnode/fs_volume.go
+++ b/objectnode/fs_volume.go
@@ -246,9 +246,6 @@ func (v *volume) ListFilesV1(request *ListBucketRequestV1) ([]*FSFileInfo, strin
 	if err != nil {
 		return nil, "", false, nil, err
 	}
-	if len(infos) <= 0 {
-		return nil, "", false, nil, nil
-	}
 
 	var nextMarker string
 	var isTruncated bool
@@ -276,9 +273,6 @@ func (v *volume) ListFilesV2(request *ListBucketRequestV2) ([]*FSFileInfo, uint6
 
 	infos, prefixes, err = v.listFilesV2(prefix, startAfter, contToken, delimiter, maxKeys)
 	if err != nil {
-		return nil, 0, "", false, nil, err
-	}
-	if len(infos) <= 0 {
 		return nil, 0, "", false, nil, err
 	}
 

--- a/objectnode/router.go
+++ b/objectnode/router.go
@@ -63,6 +63,13 @@ func (o *ObjectNode) registerApiRouters(router *mux.Router) {
 				"X-Amz-Date", "{date:.+}", "X-Amz-SignedHeaders", "{signedHeaders:.+}",
 				"X-Amz-Expires", "{expires:[0-9]+}")
 
+		// List parts
+		// API reference: https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListParts.html
+		r.Methods(http.MethodGet).
+			Path("/{object:.+}").
+			HandlerFunc(o.policyCheck(o.listPartsHandler, []Action{ListMultipartUploadPartsAction})).
+			Queries("uploadId", "{uploadId:.*}")
+
 		// Get object tagging
 		// API reference: https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectTagging.html
 		r.Methods(http.MethodGet).
@@ -86,7 +93,7 @@ func (o *ObjectNode) registerApiRouters(router *mux.Router) {
 		// Get object acl
 		// API reference: https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectAcl.html
 		r.Methods(http.MethodGet).
-			Path("/{objject:.+}").
+			Path("/{object:.+}").
 			HandlerFunc(o.policyCheck(o.getObjectACLHandler, []Action{GetObjectAclAction})).
 			Queries("acl", "")
 
@@ -107,12 +114,6 @@ func (o *ObjectNode) registerApiRouters(router *mux.Router) {
 		r.Methods(http.MethodGet).
 			HandlerFunc(o.policyCheck(o.listMultipartUploadsHandler, []Action{ListMultipartUploadPartsAction})).
 			Queries("uploads", "")
-
-		// List parts
-		// API reference: https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListParts.html
-		r.Methods(http.MethodGet).
-			HandlerFunc(o.policyCheck(o.listPartsHandler, []Action{ListMultipartUploadPartsAction})).
-			Queries("uploadId", "{uploadId:.*}")
 
 		// Get bucket location
 		// API reference: https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLocation.html


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- Fix empty result when list files by ListObjects interface with delimiter and prefix specified.
- Fix incorrect content length when read file data by GetObject interface with range option.

**Which issue this PR fixes**: 

- fixes #430
- fixes #432 

**Special notes for your reviewer**:

NONE.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Bug Fixes:
- Fix empty result when list files by ListObjects interface with delimiter and prefix specified.
- Fix incorrect content length when read file data by GetObject interface with range option.
```