### PR TITLE
Enhancement: use tokens to distinguish read and write permissions for clients

### DIFF
--- a/client/fs/super.go
+++ b/client/fs/super.go
@@ -119,6 +119,10 @@ func (s *Super) ClusterName() string {
 	return s.cluster
 }
 
+func (s *Super) TokenType() int8 {
+	return s.mw.TokenType()
+}
+
 func (s *Super) GetRate(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte(s.ec.GetRate()))
 }

--- a/client/fuse.go
+++ b/client/fuse.go
@@ -235,6 +235,8 @@ func mount(opt *proto.MountOptions) (fsConn *fuse.Conn, super *cfs.Super, err er
 		return
 	}
 
+	opt.Rdonly = super.TokenType() == int8(proto.ReadOnlyToken)
+
 	options := []fuse.MountOption{
 		fuse.AllowOther(),
 		fuse.MaxReadahead(MaxReadAhead),
@@ -304,6 +306,7 @@ func parseMountOption(cfg *config.Config) (*proto.MountOptions, error) {
 			opt.TicketMess.CertFile = GlobalMountOptions[proto.CertFile].GetString()
 		}
 	}
+	opt.TokenKey = GlobalMountOptions[proto.TokenKey].GetString()
 
 	if opt.MountPoint == "" || opt.Volname == "" || opt.Owner == "" || opt.Master == "" {
 		return nil, errors.New(fmt.Sprintf("invalid config file: lack of mandatory fields, mountPoint(%v), volName(%v), owner(%v), masterAddr(%v)", opt.MountPoint, opt.Volname, opt.Owner, opt.Master))

--- a/clientv2/fs/super.go
+++ b/clientv2/fs/super.go
@@ -105,6 +105,10 @@ func (s *Super) ClusterName() string {
 	return s.cluster
 }
 
+func (s *Super) TokenType() int8 {
+	return s.mw.TokenType()
+}
+
 func (s *Super) GetRate(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte(s.ec.GetRate()))
 }

--- a/clientv2/main.go
+++ b/clientv2/main.go
@@ -211,6 +211,8 @@ func mount(opt *proto.MountOptions) (*fuse.MountedFileSystem, error) {
 
 	exporter.RegistConsul(super.ClusterName(), ModuleName, opt.Config)
 
+	opt.Rdonly = super.TokenType() == int8(proto.ReadOnlyToken)
+
 	server := fuseutil.NewFileSystemServer(super)
 	mntcfg := &fuse.MountConfig{
 		FSName:                  "chubaofs-" + opt.Volname,
@@ -284,6 +286,7 @@ func parseMountOption(cfg *config.Config) (*proto.MountOptions, error) {
 			opt.TicketMess.CertFile = GlobalMountOptions[proto.CertFile].GetString()
 		}
 	}
+	opt.TokenKey = GlobalMountOptions[proto.TokenKey].GetString()
 
 	if opt.MountPoint == "" || opt.Volname == "" || opt.Owner == "" || opt.Master == "" {
 		return nil, errors.New(fmt.Sprintf("invalid config file: lack of mandatory fields, mountPoint(%v), volName(%v), owner(%v), masterAddr(%v)", opt.MountPoint, opt.Volname, opt.Owner, opt.Master))

--- a/cmd/master/scripts/manage_token_add.sh
+++ b/cmd/master/scripts/manage_token_add.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+curl -v "http://127.0.0.1/token/add?name=test&tokenType=1&authKey=md5(owner)"

--- a/cmd/master/scripts/manage_token_delete.sh
+++ b/cmd/master/scripts/manage_token_delete.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+curl -v "http://127.0.0.1/token/delete?name=test&token=xx&authKey=md5(owner)"

--- a/cmd/master/scripts/manage_token_get.sh
+++ b/cmd/master/scripts/manage_token_get.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+curl -v "http://127.0.0.1/token/get?name=test&token=xx"

--- a/cmd/master/scripts/manage_token_update.sh
+++ b/cmd/master/scripts/manage_token_update.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+curl -v "http://127.0.0.1/token/update?name=test&token=xx&tokenType=1&authKey=md5(owner)"

--- a/cmd/master/scripts/manage_vol_create.sh
+++ b/cmd/master/scripts/manage_vol_create.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-curl -v "http://127.0.0.1/admin/createVol?name=test&capacity=100&owner=cfs&crossZone=false&zoneName=xx"
+curl -v "http://127.0.0.1/admin/createVol?name=test&capacity=100&owner=cfs&crossZone=false&enableToken=true&zoneName=xx"

--- a/cmd/master/scripts/manage_vol_update.sh
+++ b/cmd/master/scripts/manage_vol_update.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-curl -v "http://127.0.0.1/vol/update?name=test&capacity=100&authKey=md5(owner)"
+curl -v "http://127.0.0.1/vol/update?name=test&capacity=100&enableToken=true&authKey=md5(owner)"

--- a/master/api_service.go
+++ b/master/api_service.go
@@ -204,7 +204,7 @@ func (m *Server) getCluster(w http.ResponseWriter, r *http.Request) {
 	for _, name := range vols {
 		stat, ok := m.cluster.volStatInfo.Load(name)
 		if !ok {
-			cv.VolStatInfo = append(cv.VolStatInfo, newVolStatInfo(name, 0, 0, "0.0001"))
+			cv.VolStatInfo = append(cv.VolStatInfo, newVolStatInfo(name, 0, 0, "0.0001", false))
 			continue
 		}
 		cv.VolStatInfo = append(cv.VolStatInfo, stat.(*volStatInfo))
@@ -505,9 +505,10 @@ func (m *Server) updateVol(w http.ResponseWriter, r *http.Request) {
 		replicaNum   int
 		followerRead bool
 		authenticate bool
+		enableToken  bool
 		vol          *Vol
 	)
-	if name, authKey, capacity, replicaNum, err = parseRequestToUpdateVol(r); err != nil {
+	if name, authKey, capacity, replicaNum, enableToken, err = parseRequestToUpdateVol(r); err != nil {
 		sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: err.Error()})
 		return
 	}
@@ -524,7 +525,7 @@ func (m *Server) updateVol(w http.ResponseWriter, r *http.Request) {
 		sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: err.Error()})
 		return
 	}
-	if err = m.cluster.updateVol(name, authKey, uint64(capacity), uint8(replicaNum), followerRead, authenticate); err != nil {
+	if err = m.cluster.updateVol(name, authKey, uint64(capacity), uint8(replicaNum), followerRead, authenticate, enableToken); err != nil {
 		sendErrReply(w, r, newErrHTTPReply(err))
 		return
 	}
@@ -546,10 +547,11 @@ func (m *Server) createVol(w http.ResponseWriter, r *http.Request) {
 		followerRead bool
 		authenticate bool
 		crossZone    bool
+		enableToken  bool
 		zoneName     string
 	)
 
-	if name, owner, zoneName, mpCount, dpReplicaNum, size, capacity, followerRead, authenticate, crossZone, err = parseRequestToCreateVol(r); err != nil {
+	if name, owner, zoneName, mpCount, dpReplicaNum, size, capacity, followerRead, authenticate, crossZone, enableToken, err = parseRequestToCreateVol(r); err != nil {
 		sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: err.Error()})
 		return
 	}
@@ -558,7 +560,7 @@ func (m *Server) createVol(w http.ResponseWriter, r *http.Request) {
 		sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: err.Error()})
 		return
 	}
-	if vol, err = m.cluster.createVol(name, owner, zoneName, mpCount, dpReplicaNum, size, capacity, followerRead, authenticate, crossZone); err != nil {
+	if vol, err = m.cluster.createVol(name, owner, zoneName, mpCount, dpReplicaNum, size, capacity, followerRead, authenticate, crossZone, enableToken); err != nil {
 		sendErrReply(w, r, newErrHTTPReply(err))
 		return
 	}
@@ -599,6 +601,8 @@ func newSimpleView(vol *Vol) *proto.SimpleVolView {
 		NeedToLowerReplica: vol.NeedToLowerReplica,
 		Authenticate:       vol.authenticate,
 		CrossZone:          vol.crossZone,
+		EnableToken:        vol.enableToken,
+		Tokens:             vol.tokens,
 		RwDpCnt:            vol.dataPartitions.readableAndWritableCnt,
 		MpCnt:              len(vol.MetaPartitions),
 		DpCnt:              len(vol.dataPartitions.partitionMap),
@@ -1042,7 +1046,7 @@ func parseRequestToDeleteVol(r *http.Request) (name, authKey string, err error) 
 
 }
 
-func parseRequestToUpdateVol(r *http.Request) (name, authKey string, capacity, replicaNum int, err error) {
+func parseRequestToUpdateVol(r *http.Request) (name, authKey string, capacity, replicaNum int, enableToken bool, err error) {
 	if err = r.ParseForm(); err != nil {
 		return
 	}
@@ -1067,6 +1071,7 @@ func parseRequestToUpdateVol(r *http.Request) (name, authKey string, capacity, r
 			return
 		}
 	}
+	enableToken = extractEnableToken(r)
 	return
 }
 
@@ -1090,7 +1095,7 @@ func parseBoolFieldToUpdateVol(r *http.Request, vol *Vol) (followerRead, authent
 	return
 }
 
-func parseRequestToCreateVol(r *http.Request) (name, owner, zoneName string, mpCount, dpReplicaNum, size, capacity int, followerRead, authenticate, crossZone bool, err error) {
+func parseRequestToCreateVol(r *http.Request) (name, owner, zoneName string, mpCount, dpReplicaNum, size, capacity int, followerRead, authenticate, crossZone, enableToken bool, err error) {
 	if err = r.ParseForm(); err != nil {
 		return
 	}
@@ -1141,6 +1146,15 @@ func parseRequestToCreateVol(r *http.Request) (name, owner, zoneName string, mpC
 		return
 	}
 	zoneName = r.FormValue(zoneNameKey)
+	enableToken = extractEnableToken(r)
+	return
+}
+
+func extractEnableToken(r *http.Request) (enableToken bool) {
+	enableToken, err := strconv.ParseBool(r.FormValue(enableTokenKey))
+	if err != nil {
+		enableToken = false
+	}
 	return
 }
 
@@ -1542,6 +1556,7 @@ func volStat(vol *Vol) (stat *proto.VolStatInfo) {
 	if stat.UsedSize > stat.TotalSize {
 		stat.UsedSize = stat.TotalSize
 	}
+	stat.EnableToken = vol.enableToken
 	log.LogDebugf("total[%v],usedSize[%v]", stat.TotalSize, stat.UsedSize)
 	return
 }

--- a/master/cluster.go
+++ b/master/cluster.go
@@ -1208,7 +1208,7 @@ func (c *Cluster) deleteMetaNodeFromCache(metaNode *MetaNode) {
 	go metaNode.clean()
 }
 
-func (c *Cluster) updateVol(name, authKey string, capacity uint64, replicaNum uint8, followerRead, authenticate bool) (err error) {
+func (c *Cluster) updateVol(name, authKey string, capacity uint64, replicaNum uint8, followerRead, authenticate, enableToken bool) (err error) {
 	var (
 		vol             *Vol
 		serverAuthKey   string
@@ -1216,6 +1216,7 @@ func (c *Cluster) updateVol(name, authKey string, capacity uint64, replicaNum ui
 		oldCapacity     uint64
 		oldFollowerRead bool
 		oldAuthenticate bool
+		oldEnableToken  bool
 	)
 	if vol, err = c.getVol(name); err != nil {
 		log.LogErrorf("action[updateVol] err[%v]", err)
@@ -1236,13 +1237,24 @@ func (c *Cluster) updateVol(name, authKey string, capacity uint64, replicaNum ui
 		err = fmt.Errorf("don't support new replicaNum[%v] larger than old dpReplicaNum[%v]", replicaNum, vol.dpReplicaNum)
 		goto errHandler
 	}
+	if enableToken == true && len(vol.tokens) == 0 {
+		if err = c.createToken(vol, proto.ReadOnlyToken); err != nil {
+			goto errHandler
+		}
+		if err = c.createToken(vol, proto.ReadWriteToken); err != nil {
+			goto errHandler
+		}
+	}
+
 	oldCapacity = vol.Capacity
 	oldDpReplicaNum = vol.dpReplicaNum
 	oldFollowerRead = vol.FollowerRead
 	oldAuthenticate = vol.authenticate
+	oldEnableToken = vol.enableToken
 	vol.Capacity = capacity
 	vol.FollowerRead = followerRead
 	vol.authenticate = authenticate
+	vol.enableToken = enableToken
 	//only reduced replica num is supported
 	if replicaNum != 0 && replicaNum < vol.dpReplicaNum {
 		vol.dpReplicaNum = replicaNum
@@ -1252,6 +1264,7 @@ func (c *Cluster) updateVol(name, authKey string, capacity uint64, replicaNum ui
 		vol.dpReplicaNum = oldDpReplicaNum
 		vol.FollowerRead = oldFollowerRead
 		vol.authenticate = oldAuthenticate
+		vol.enableToken = oldEnableToken
 		log.LogErrorf("action[updateVol] vol[%v] err[%v]", name, err)
 		err = proto.ErrPersistenceByRaft
 		goto errHandler
@@ -1266,7 +1279,7 @@ errHandler:
 
 // Create a new volume.
 // By default we create 3 meta partitions and 10 data partitions during initialization.
-func (c *Cluster) createVol(name, owner, zoneName string, mpCount, dpReplicaNum, size, capacity int, followerRead, authenticate, crossZone bool) (vol *Vol, err error) {
+func (c *Cluster) createVol(name, owner, zoneName string, mpCount, dpReplicaNum, size, capacity int, followerRead, authenticate, crossZone, enableToken bool) (vol *Vol, err error) {
 	var (
 		dataPartitionSize       uint64
 		readWriteDataPartitions int
@@ -1288,12 +1301,12 @@ func (c *Cluster) createVol(name, owner, zoneName string, mpCount, dpReplicaNum,
 			return
 		}
 	}
-	if vol, err = c.doCreateVol(name, owner, zoneName, dataPartitionSize, uint64(capacity), dpReplicaNum, followerRead, authenticate, crossZone); err != nil {
+	if vol, err = c.doCreateVol(name, owner, zoneName, dataPartitionSize, uint64(capacity), dpReplicaNum, followerRead, authenticate, crossZone, enableToken); err != nil {
 		goto errHandler
 	}
 	if err = vol.initMetaPartitions(c, mpCount); err != nil {
 		vol.Status = markDelete
-		if e := c.syncDeleteVol(vol); e != nil {
+		if e := vol.deleteVolFromStore(c); e != nil {
 			log.LogErrorf("action[createVol] failed,vol[%v] err[%v]", vol.Name, e)
 		}
 		c.deleteVol(name)
@@ -1316,7 +1329,7 @@ errHandler:
 	return
 }
 
-func (c *Cluster) doCreateVol(name, owner, zoneName string, dpSize, capacity uint64, dpReplicaNum int, followerRead, authenticate, crossZone bool) (vol *Vol, err error) {
+func (c *Cluster) doCreateVol(name, owner, zoneName string, dpSize, capacity uint64, dpReplicaNum int, followerRead, authenticate, crossZone, enableToken bool) (vol *Vol, err error) {
 	var id uint64
 	c.createVolMutex.Lock()
 	defer c.createVolMutex.Unlock()
@@ -1328,13 +1341,22 @@ func (c *Cluster) doCreateVol(name, owner, zoneName string, dpSize, capacity uin
 	if err != nil {
 		goto errHandler
 	}
-	vol = newVol(id, name, owner, zoneName, dpSize, capacity, uint8(dpReplicaNum), defaultReplicaNum, followerRead, authenticate, crossZone)
+	vol = newVol(id, name, owner, zoneName, dpSize, capacity, uint8(dpReplicaNum), defaultReplicaNum,
+		followerRead, authenticate, crossZone, enableToken)
 	// refresh oss secure
 	vol.refreshOSSSecure()
 	if err = c.syncAddVol(vol); err != nil {
 		goto errHandler
 	}
 	c.putVol(vol)
+	if enableToken {
+		if err = c.createToken(vol, proto.ReadOnlyToken); err != nil {
+			goto errHandler
+		}
+		if err = c.createToken(vol, proto.ReadWriteToken); err != nil {
+			goto errHandler
+		}
+	}
 	return
 errHandler:
 	err = fmt.Errorf("action[doCreateVol], clusterID[%v] name:%v, err:%v ", c.Name, name, err.Error())

--- a/master/cluster_stat.go
+++ b/master/cluster_stat.go
@@ -27,12 +27,13 @@ type nodeStatInfo = proto.NodeStatInfo
 
 type volStatInfo = proto.VolStatInfo
 
-func newVolStatInfo(name string, total, used uint64, ratio string) *volStatInfo {
+func newVolStatInfo(name string, total, used uint64, ratio string, enableToken bool) *volStatInfo {
 	return &volStatInfo{
-		Name:      name,
-		TotalSize: total,
-		UsedSize:  used,
-		UsedRatio: ratio,
+		Name:        name,
+		TotalSize:   total,
+		UsedSize:    used,
+		UsedRatio:   ratio,
+		EnableToken: enableToken,
 	}
 }
 
@@ -110,6 +111,6 @@ func (c *Cluster) updateVolStatInfo() {
 			continue
 		}
 		useRate := float64(used) / float64(total)
-		c.volStatInfo.Store(vol.Name, newVolStatInfo(vol.Name, total, used, strconv.FormatFloat(useRate, 'f', 3, 32)))
+		c.volStatInfo.Store(vol.Name, newVolStatInfo(vol.Name, total, used, strconv.FormatFloat(useRate, 'f', 3, 32), vol.enableToken))
 	}
 }

--- a/master/cluster_test.go
+++ b/master/cluster_test.go
@@ -19,7 +19,8 @@ func buildPanicVol() *Vol {
 	if err != nil {
 		return nil
 	}
-	vol := newVol(id, commonVol.Name, commonVol.Owner,"", commonVol.dataPartitionSize, commonVol.Capacity, defaultReplicaNum, defaultReplicaNum, false, false,false)
+	vol := newVol(id, commonVol.Name, commonVol.Owner, "", commonVol.dataPartitionSize, commonVol.Capacity, defaultReplicaNum, defaultReplicaNum,
+		false, false, false, false)
 	vol.dataPartitions = nil
 	return vol
 }

--- a/master/const.go
+++ b/master/const.go
@@ -39,6 +39,9 @@ const (
 	authenticateKey       = "authenticate"
 	zoneNameKey           = "zoneName"
 	crossZoneKey          = "crossZone"
+	tokenKey             = "token"
+	tokenTypeKey         = "tokenType"
+	enableTokenKey          = "enableToken"
 )
 
 const (
@@ -112,6 +115,11 @@ const (
 	opSyncBatchPut             uint32 = 0x14
 	opSyncUpdateDataNode       uint32 = 0x15
 	opSyncUpdateMetaNode       uint32 = 0x16
+
+	OpSyncAddToken             uint32 = 0x20
+	OpSyncDelToken             uint32 = 0x21
+	OpSyncUpdateToken          uint32 = 0x22
+
 )
 
 const (
@@ -123,6 +131,7 @@ const (
 	volAcronym            = "vol"
 	clusterAcronym        = "c"
 	nodeSetAcronym        = "s"
+	tokenAcronym          = "t"
 	maxDataPartitionIDKey = keySeparator + "max_dp_id"
 	maxMetaPartitionIDKey = keySeparator + "max_mp_id"
 	maxCommonIDKey        = keySeparator + "max_common_id"
@@ -133,4 +142,5 @@ const (
 	metaPartitionPrefix   = keySeparator + metaPartitionAcronym + keySeparator
 	clusterPrefix         = keySeparator + clusterAcronym + keySeparator
 	nodeSetPrefix         = keySeparator + nodeSetAcronym + keySeparator
+	TokenPrefix           = keySeparator + tokenAcronym + keySeparator
 )

--- a/master/http_server.go
+++ b/master/http_server.go
@@ -72,6 +72,10 @@ func (m *Server) handleFunctions() {
 	http.Handle(proto.GetTopologyView, m.handlerWithInterceptor())
 	http.Handle(proto.UpdateZone, m.handlerWithInterceptor())
 	http.Handle(proto.GetAllZones, m.handlerWithInterceptor())
+	http.Handle(proto.TokenAddURI, m.handlerWithInterceptor())
+	http.Handle(proto.TokenGetURI, m.handlerWithInterceptor())
+	http.Handle(proto.TokenDelURI, m.handlerWithInterceptor())
+	http.Handle(proto.TokenUpdateURI, m.handlerWithInterceptor())
 
 	return
 }
@@ -185,6 +189,14 @@ func (m *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		m.updateZone(w, r)
 	case proto.GetAllZones:
 		m.listZone(w, r)
+	case proto.TokenAddURI:
+		m.addToken(w, r)
+	case proto.TokenGetURI:
+		m.getToken(w, r)
+	case proto.TokenDelURI:
+		m.deleteToken(w, r)
+	case proto.TokenUpdateURI:
+		m.updateToken(w, r)
 	default:
 
 	}

--- a/master/master_manager.go
+++ b/master/master_manager.go
@@ -110,6 +110,10 @@ func (m *Server) loadMetadata() {
 		panic(err)
 	}
 
+	if err = m.cluster.loadTokens(); err != nil {
+		panic(err)
+	}
+
 	if err = m.cluster.loadMetaPartitions(); err != nil {
 		panic(err)
 	}

--- a/master/metadata_fsm.go
+++ b/master/metadata_fsm.go
@@ -119,7 +119,7 @@ func (mf *MetadataFsm) Apply(command []byte, index uint64) (resp interface{}, er
 		cmdMap[applied] = []byte(strconv.FormatUint(uint64(index), 10))
 	}
 	switch cmd.Op {
-	case opSyncDeleteDataNode, opSyncDeleteMetaNode, opSyncDeleteVol, opSyncDeleteDataPartition, opSyncDeleteMetaPartition:
+	case opSyncDeleteDataNode, opSyncDeleteMetaNode, opSyncDeleteVol, opSyncDeleteDataPartition, opSyncDeleteMetaPartition, OpSyncDelToken:
 		if err = mf.delKeyAndPutIndex(cmd.K, cmdMap); err != nil {
 			panic(err)
 		}

--- a/master/metadata_fsm_op.go
+++ b/master/metadata_fsm_op.go
@@ -117,6 +117,7 @@ type volValue struct {
 	FollowerRead      bool
 	Authenticate      bool
 	CrossZone         bool
+	EnableToken       bool
 	ZoneName          string
 	OSSAccessKey      string
 	OSSSecretKey      string
@@ -141,6 +142,7 @@ func newVolValue(vol *Vol) (vv *volValue) {
 		Authenticate:      vol.authenticate,
 		CrossZone:         vol.crossZone,
 		ZoneName:          vol.zoneName,
+		EnableToken:       vol.enableToken,
 		OSSAccessKey:      vol.OSSAccessKey,
 		OSSSecretKey:      vol.OSSSecretKey,
 	}
@@ -246,9 +248,35 @@ func (m *RaftCmd) setOpType() {
 		m.Op = opSyncAllocMetaPartitionID
 	case maxCommonIDKey:
 		m.Op = opSyncAllocCommonID
+	case tokenAcronym:
+		m.Op = OpSyncAddToken
 	default:
 		log.LogWarnf("action[setOpType] unknown opCode[%v]", keyArr[1])
 	}
+}
+
+func (c *Cluster) syncDeleteToken(token *bsProto.Token) (err error) {
+	return c.syncPutTokenInfo(OpSyncDelToken, token)
+}
+
+func (c *Cluster) syncAddToken(token *bsProto.Token) (err error) {
+	return c.syncPutTokenInfo(OpSyncAddToken, token)
+}
+
+func (c *Cluster) syncUpdateToken(token *bsProto.Token) (err error) {
+	return c.syncPutTokenInfo(OpSyncUpdateToken, token)
+}
+
+func (c *Cluster) syncPutTokenInfo(opType uint32, token *bsProto.Token) (err error) {
+	metadata := new(RaftCmd)
+	metadata.Op = opType
+	metadata.K = TokenPrefix + token.VolName + keySeparator + token.Value
+	tv := newTokenValue(token)
+	metadata.V, err = json.Marshal(tv)
+	if err != nil {
+		return
+	}
+	return c.submit(metadata)
 }
 
 //key=#c#name
@@ -637,6 +665,38 @@ func (c *Cluster) loadDataPartitions() (err error) {
 		}
 		vol.dataPartitions.put(dp)
 		log.LogInfof("action[loadDataPartitions],vol[%v],dp[%v]", vol.Name, dp.PartitionID)
+	}
+	return
+}
+
+func (c *Cluster) loadTokens() (err error) {
+	snapshot := c.fsm.store.RocksDBSnapshot()
+	it := c.fsm.store.Iterator(snapshot)
+	defer func() {
+		it.Close()
+		c.fsm.store.ReleaseSnapshot(snapshot)
+	}()
+	prefixKey := []byte(TokenPrefix)
+	it.Seek(prefixKey)
+	for ; it.ValidForPrefix(prefixKey); it.Next() {
+		encodedKey := it.Key()
+		encodedValue := it.Value()
+		tv := &TokenValue{}
+		if err = json.Unmarshal(encodedValue.Data(), tv); err != nil {
+			err = fmt.Errorf("action[loadTokens],value:%v,err:%v", encodedValue.Data(), err)
+			return err
+		}
+		vol, err1 := c.getVol(tv.VolName)
+		if err1 != nil {
+			// if vol not found,record log and continue
+			log.LogErrorf("action[loadTokens] err:%v", err1.Error())
+			continue
+		}
+		token := &bsProto.Token{VolName: tv.VolName, TokenType: tv.TokenType, Value: tv.Value}
+		vol.putToken(token)
+		encodedKey.Free()
+		encodedValue.Free()
+		log.LogInfof("action[loadTokens],vol[%v],token[%v]", vol.Name, token.Value)
 	}
 	return
 }

--- a/master/token.go
+++ b/master/token.go
@@ -1,0 +1,317 @@
+// Copyright 2018 The Chubao Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package master
+
+import (
+	"github.com/chubaofs/chubaofs/proto"
+	"fmt"
+	"time"
+	"encoding/base64"
+	"strconv"
+	"net/url"
+	"net/http"
+	"github.com/chubaofs/chubaofs/util/log"
+)
+
+type TokenValue struct {
+	VolName   string
+	Value     string
+	TokenType int8
+}
+
+func newTokenValue(token *proto.Token) (tv *TokenValue) {
+	tv = &TokenValue{
+		TokenType: token.TokenType,
+		Value:     token.Value,
+		VolName:   token.VolName,
+	}
+	return
+}
+
+func createToken(volName string, tokenType int8) (token *proto.Token, err error) {
+	str := fmt.Sprintf("%v_%v_%v", volName, tokenType, time.Now().UnixNano())
+	encodeStr := base64.StdEncoding.EncodeToString([]byte(str))
+	token = &proto.Token{
+		TokenType: tokenType,
+		VolName:   volName,
+		Value:     encodeStr,
+	}
+	return
+
+}
+
+func (c *Cluster) createToken(vol *Vol, tokenType int8) (err error) {
+	token, err := createToken(vol.Name, tokenType)
+	if err != nil {
+		return
+	}
+	if err = c.syncAddToken(token); err != nil {
+		return
+	}
+	vol.putToken(token)
+	return
+}
+
+func (c *Cluster) deleteToken(vol *Vol, token, authKey string) (err error) {
+	var serverAuthKey string
+	if vol.Owner != "" {
+		serverAuthKey = vol.Owner
+	} else {
+		serverAuthKey = vol.Name
+	}
+	if !matchKey(serverAuthKey, authKey) {
+		return proto.ErrVolAuthKeyNotMatch
+	}
+	var tokenObj *proto.Token
+	if tokenObj, err = vol.getToken(token); err != nil {
+		return
+	}
+	if err = c.syncDeleteToken(tokenObj); err != nil {
+		return
+	}
+	vol.deleteToken(token)
+	return
+}
+
+func (c *Cluster) addToken(vol *Vol, tokenType int8, authKey string) (err error) {
+	var serverAuthKey string
+	if vol.Owner != "" {
+		serverAuthKey = vol.Owner
+	} else {
+		serverAuthKey = vol.Name
+	}
+	if !matchKey(serverAuthKey, authKey) {
+		return proto.ErrVolAuthKeyNotMatch
+	}
+	return c.createToken(vol, tokenType)
+}
+
+func (c *Cluster) updateToken(vol *Vol, tokenType int8, token, authKey string) (err error) {
+	var serverAuthKey string
+	if vol.Owner != "" {
+		serverAuthKey = vol.Owner
+	} else {
+		serverAuthKey = vol.Name
+	}
+	if !matchKey(serverAuthKey, authKey) {
+		return proto.ErrVolAuthKeyNotMatch
+	}
+	var tokenObj *proto.Token
+	if tokenObj, err = vol.getToken(token); err != nil {
+		return
+	}
+	oldTokenType := tokenObj.TokenType
+	tokenObj.TokenType = tokenType
+	if err = c.syncUpdateToken(tokenObj); err != nil {
+		tokenObj.TokenType = oldTokenType
+		return
+	}
+	vol.putToken(tokenObj)
+	return
+}
+
+func (m *Server) addToken(w http.ResponseWriter, r *http.Request) {
+	var (
+		err       error
+		name      string
+		tokenType int8
+		vol       *Vol
+		msg       string
+		authKey   string
+	)
+	if name, tokenType, authKey, err = parseAddTokenPara(r); err != nil {
+		sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: err.Error()})
+		return
+	}
+	if vol, err = m.cluster.getVol(name); err != nil {
+		sendErrReply(w, r, newErrHTTPReply(proto.ErrVolNotExists))
+		return
+	}
+	if err = m.cluster.addToken(vol, tokenType, authKey); err != nil {
+		sendErrReply(w, r, newErrHTTPReply(err))
+		return
+	}
+	msg = fmt.Sprintf("add tokenType[%v] of vol [%v] successed,from[%v]", tokenType, name, r.RemoteAddr)
+	log.LogWarn(msg)
+	sendOkReply(w, r, newSuccessHTTPReply(msg))
+	return
+}
+
+func (m *Server) updateToken(w http.ResponseWriter, r *http.Request) {
+	var (
+		err       error
+		name      string
+		tokenType int8
+		vol       *Vol
+		msg       string
+		authKey   string
+		token     string
+	)
+	if name, tokenType, token, authKey, err = parseUpdateTokenPara(r); err != nil {
+		sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: err.Error()})
+		return
+	}
+	if vol, err = m.cluster.getVol(name); err != nil {
+		sendErrReply(w, r, newErrHTTPReply(proto.ErrVolNotExists))
+		return
+	}
+	if err = m.cluster.updateToken(vol, tokenType, token, authKey); err != nil {
+		sendErrReply(w, r, newErrHTTPReply(err))
+		return
+	}
+	msg = fmt.Sprintf("update tokenType[%v] of vol [%v] successed,from[%v]", tokenType, name, r.RemoteAddr)
+	log.LogWarn(msg)
+	sendOkReply(w, r, newSuccessHTTPReply(msg))
+	return
+}
+
+func (m *Server) deleteToken(w http.ResponseWriter, r *http.Request) {
+	var (
+		err     error
+		name    string
+		token   string
+		vol     *Vol
+		msg     string
+		authKey string
+	)
+	if name, token, authKey, err = parseDeleteTokenPara(r); err != nil {
+		sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: err.Error()})
+		return
+	}
+	if vol, err = m.cluster.getVol(name); err != nil {
+		sendErrReply(w, r, newErrHTTPReply(proto.ErrVolNotExists))
+		return
+	}
+
+	if err = m.cluster.deleteToken(vol, token, authKey); err != nil {
+		sendErrReply(w, r, newErrHTTPReply(err))
+		return
+	}
+	msg = fmt.Sprintf("delete token[%v] of vol [%v] successed,from[%v]", token, name, r.RemoteAddr)
+	log.LogWarn(msg)
+	sendOkReply(w, r, newSuccessHTTPReply(msg))
+	return
+}
+
+func (m *Server) getToken(w http.ResponseWriter, r *http.Request) {
+	var (
+		err      error
+		name     string
+		token    string
+		tokenObj *proto.Token
+		vol      *Vol
+	)
+	if name, token, err = parseGetTokenPara(r); err != nil {
+		sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: err.Error()})
+		return
+	}
+	if vol, err = m.cluster.getVol(name); err != nil {
+		sendErrReply(w, r, newErrHTTPReply(proto.ErrVolNotExists))
+		return
+	}
+
+	if tokenObj, err = vol.getToken(token); err != nil {
+		sendErrReply(w, r, newErrHTTPReply(err))
+		return
+	}
+	sendOkReply(w, r, newSuccessHTTPReply(tokenObj))
+	return
+}
+
+func parseAddTokenPara(r *http.Request) (name string, tokenType int8, authKey string, err error) {
+	r.ParseForm()
+	if name, err = extractName(r); err != nil {
+		return
+	}
+	if tokenType, err = extractTokenType(r); err != nil {
+		return
+	}
+	if authKey, err = extractAuthKey(r); err != nil {
+		return
+	}
+	return
+}
+
+func parseUpdateTokenPara(r *http.Request) (name string, tokenType int8, token, authKey string, err error) {
+	r.ParseForm()
+	if name, err = extractName(r); err != nil {
+		return
+	}
+	if tokenType, err = extractTokenType(r); err != nil {
+		return
+	}
+	if token, err = extractTokenValue(r); err != nil {
+		return
+	}
+	if authKey, err = extractAuthKey(r); err != nil {
+		return
+	}
+	return
+}
+
+func parseDeleteTokenPara(r *http.Request) (name string, token, authKey string, err error) {
+	r.ParseForm()
+	if name, err = extractName(r); err != nil {
+		return
+	}
+	if token, err = extractTokenValue(r); err != nil {
+		return
+	}
+	if authKey, err = extractAuthKey(r); err != nil {
+		return
+	}
+	return
+}
+
+func extractTokenType(r *http.Request) (tokenType int8, err error) {
+	var (
+		tokenTypeStr string
+		iTokenType   int
+	)
+	if tokenTypeStr = r.FormValue(tokenTypeKey); tokenTypeStr == "" {
+		err = keyNotFound(tokenTypeKey)
+		return
+	}
+	if iTokenType, err = strconv.Atoi(tokenTypeStr); err != nil {
+		return
+	}
+
+	if !(iTokenType == proto.ReadWriteToken || iTokenType == proto.ReadOnlyToken) {
+		err = fmt.Errorf("token type must be 1(readOnly) or 2(readWrite)")
+		return
+	}
+	tokenType = int8(iTokenType)
+	return
+}
+
+func parseGetTokenPara(r *http.Request) (name string, token string, err error) {
+	r.ParseForm()
+	if name, err = extractName(r); err != nil {
+		return
+	}
+	if token, err = extractTokenValue(r); err != nil {
+		return
+	}
+	return
+}
+
+func extractTokenValue(r *http.Request) (token string, err error) {
+	if token = r.FormValue(tokenKey); token == "" {
+		err = keyNotFound(tokenKey)
+		return
+	}
+	token, err = url.QueryUnescape(token)
+	return
+}

--- a/master/vol_test.go
+++ b/master/vol_test.go
@@ -171,7 +171,8 @@ func markDeleteVol(name string, t *testing.T) {
 
 func TestVolReduceReplicaNum(t *testing.T) {
 	volName := "reduce-replica-num"
-	vol, err := server.cluster.createVol(volName, volName, "",3, 3, util.DefaultDataPartitionSize, 100, false, false,false)
+	vol, err := server.cluster.createVol(volName, volName, "", 3, 3, util.DefaultDataPartitionSize,
+		100, false, false, false, false)
 	if err != nil {
 		t.Error(err)
 		return
@@ -210,7 +211,8 @@ func TestVolReduceReplicaNum(t *testing.T) {
 func TestConcurrentReadWriteDataPartitionMap(t *testing.T) {
 	name := "TestConcurrentReadWriteDataPartitionMap"
 	var volID uint64 = 1
-	vol := newVol(volID, name, name,"", util.DefaultDataPartitionSize, 100, defaultReplicaNum, defaultReplicaNum, false, false,false)
+	vol := newVol(volID, name, name, "", util.DefaultDataPartitionSize, 100, defaultReplicaNum,
+		defaultReplicaNum, false, false, false, false)
 	//unavaliable mp
 	mp1 := newMetaPartition(1, 1, defaultMaxMetaPartitionInodeID, 3, name, volID)
 	vol.addMetaPartition(mp1)

--- a/proto/admin_proto.go
+++ b/proto/admin_proto.go
@@ -65,9 +65,26 @@ const (
 	UpdateZone      = "/zone/update"
 	GetAllZones     = "/zone/list"
 
+	//token
+	TokenGetURI    = "/token/get"
+	TokenAddURI    = "/token/add"
+	TokenDelURI    = "/token/delete"
+	TokenUpdateURI = "/token/update"
+
 	// Header keys
 	SkipOwnerValidation = "Skip-Owner-Validation"
 )
+
+const (
+	ReadOnlyToken  = 1
+	ReadWriteToken = 2
+)
+
+type Token struct {
+	TokenType int8
+	Value     string
+	VolName   string
+}
 
 // HTTPReply uniform response structure
 type HTTPReply struct {
@@ -415,6 +432,8 @@ type SimpleVolView struct {
 	NeedToLowerReplica bool
 	Authenticate       bool
 	CrossZone          bool
+	EnableToken        bool
+	Tokens             map[string]*Token
 }
 
 // MasterAPIAccessResp defines the response for getting meta partition

--- a/proto/errors.go
+++ b/proto/errors.go
@@ -66,6 +66,7 @@ var (
 	ErrExpiredTicket                   = errors.New("expired ticket")
 	ErrMasterAPIGenRespError           = errors.New("master API generate response error")
 	ErrZoneNotExists                   = errors.New("zone not exists")
+	ErrTokenNotFound                   = errors.New("token not found")
 )
 
 // http response error code and error message definitions
@@ -160,4 +161,5 @@ var Err2CodeMap = map[error]int32{
 	ErrExpiredTicket:                   ErrCodeExpiredTicket,
 	ErrMasterAPIGenRespError:           ErrCodeMasterAPIGenRespError,
 	ErrZoneNotExists:                   ErrCodeNotExists,
+	ErrTokenNotFound:                   ErrCodeNotExists,
 }

--- a/proto/model.go
+++ b/proto/model.go
@@ -123,10 +123,11 @@ type NodeStatInfo struct {
 }
 
 type VolStatInfo struct {
-	Name      string
-	TotalSize uint64
-	UsedSize  uint64
-	UsedRatio string
+	Name        string
+	TotalSize   uint64
+	UsedSize    uint64
+	UsedRatio   string
+	EnableToken bool
 }
 
 // DataPartition represents the structure of storing the file contents.
@@ -166,7 +167,7 @@ type DataReplica struct {
 	ReportTime      int64
 	FileCount       uint32
 	Status          int8
-	HasLoadResponse bool // if there is any response when loading
+	HasLoadResponse bool   // if there is any response when loading
 	Total           uint64 `json:"TotalSize"`
 	Used            uint64 `json:"UsedSize"`
 	IsLeader        bool

--- a/proto/mount_options.go
+++ b/proto/mount_options.go
@@ -37,6 +37,7 @@ const (
 	TicketHost
 	EnableHTTPS
 	CertFile
+	TokenKey
 
 	MaxMountOption
 )
@@ -89,6 +90,8 @@ func InitMountOptions(opts []MountOption) {
 	opts[TicketHost] = MountOption{"ticketHost", "Ticket Host", "", ""}
 	opts[EnableHTTPS] = MountOption{"enableHTTPS", "Enable HTTPS", "", false}
 	opts[CertFile] = MountOption{"certFile", "Cert File", "", ""}
+
+	opts[TokenKey] = MountOption{"token", "Token Key", "", ""}
 
 	for i := 0; i < MaxMountOption; i++ {
 		flag.StringVar(&opts[i].cmdlineValue, opts[i].keyword, "", opts[i].description)
@@ -197,4 +200,5 @@ type MountOptions struct {
 	FollowerRead  bool
 	Authenticate  bool
 	TicketMess    auth.TicketMess
+	TokenKey      string
 }

--- a/sdk/master/api_client.go
+++ b/sdk/master/api_client.go
@@ -17,6 +17,7 @@ package master
 import (
 	"encoding/json"
 	"net/http"
+	"net/url"
 	"strconv"
 
 	"github.com/chubaofs/chubaofs/proto"
@@ -92,6 +93,21 @@ func (api *ClientAPI) GetVolumeStat(volName string) (info *proto.VolStatInfo, er
 	}
 	info = &proto.VolStatInfo{}
 	if err = json.Unmarshal(data, info); err != nil {
+		return
+	}
+	return
+}
+
+func (api *ClientAPI) GetToken(volName, tokenKey string) (token *proto.Token, err error) {
+	var request = newAPIRequest(http.MethodGet, proto.TokenGetURI)
+	request.addParam("name", volName)
+	request.addParam("token", url.QueryEscape(tokenKey))
+	var data []byte
+	if data, err = api.mc.serveRequest(request); err != nil {
+		return
+	}
+	token = &proto.Token{}
+	if err = json.Unmarshal(data, token); err != nil {
 		return
 	}
 	return

--- a/sdk/meta/view.go
+++ b/sdk/meta/view.go
@@ -134,7 +134,20 @@ func (mw *MetaWrapper) updateVolStatInfo() (err error) {
 	}
 	atomic.StoreUint64(&mw.totalSize, info.TotalSize)
 	atomic.StoreUint64(&mw.usedSize, info.UsedSize)
+	mw.enableToken = info.EnableToken
 	log.LogInfof("VolStatInfo: info(%v)", info)
+	return
+}
+
+func (mw *MetaWrapper) updateTokenType() (err error) {
+
+	var token *proto.Token
+	if token, err = mw.mc.ClientAPI().GetToken(mw.volname, mw.tokenKey); err != nil {
+		log.LogWarnf("updateTokenType: get token type failed: volume(%v) tokenKey(%v) err(%v)", mw.volname, mw.tokenKey, err)
+		return
+	}
+	mw.tokenType = token.TokenType
+	log.LogInfof("GetToken: token(%v)", token)
 	return
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- Implemented token-based client permissions control.

Use token to distinguish the cabilities of client, readonly or readwrite

**Which issue this PR fixes**: 

- fixes #436 

**Special notes for your reviewer**:

N/A

**Release note**:
```release-note
Features:
- Token-based permissions control for mountable client.
```