### PR TITLE
fix: set lookup valid duration for newly created file

### DIFF
--- a/client/fs/dir.go
+++ b/client/fs/dir.go
@@ -96,6 +96,7 @@ func (d *Dir) Create(ctx context.Context, req *fuse.CreateRequest, resp *fuse.Cr
 	if d.super.keepCache {
 		resp.Flags |= fuse.OpenKeepCache
 	}
+	resp.EntryValid = LookupValidDuration
 
 	d.super.ic.Delete(d.inode.ino)
 


### PR DESCRIPTION
Set the dentry valid duration in the create file process. Otherwise the newly
crated dentry will be using a default value instead of the specified
value in the config file, although the latter dentries generated by
lookup requests remains configurable.

Signed-off-by: Shuoran Liu <shuoranliu@gmail.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
