### PR TITLE
Enhancement: optional not including ETag

### DIFF
--- a/objectnode/api_handler_object.go
+++ b/objectnode/api_handler_object.go
@@ -142,7 +142,9 @@ func (o *ObjectNode) getObjectHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// set response header for GetObject
-	w.Header().Set(HeaderNameETag, fileInfo.ETag)
+	if len(fileInfo.ETag) > 0 {
+		w.Header().Set(HeaderNameETag, fileInfo.ETag)
+	}
 	w.Header().Set(HeaderNameAcceptRange, HeaderValueAcceptRange)
 	w.Header().Set(HeaderNameLastModified, formatTimeRFC1123(fileInfo.ModifyTime))
 	w.Header().Set(HeaderNameContentType, HeaderValueTypeStream)
@@ -223,7 +225,9 @@ func (o *ObjectNode) headObjectHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// set response header
-	w.Header().Set(HeaderNameETag, fileInfo.ETag)
+	if len(fileInfo.ETag) > 0 {
+		w.Header().Set(HeaderNameETag, fileInfo.ETag)
+	}
 	w.Header().Set(HeaderNameAcceptRange, HeaderValueAcceptRange)
 	w.Header().Set(HeaderNameContentType, HeaderValueTypeStream)
 	w.Header().Set(HeaderNameLastModified, formatTimeRFC1123(fileInfo.ModifyTime))

--- a/objectnode/fs_volume.go
+++ b/objectnode/fs_volume.go
@@ -227,9 +227,6 @@ func (v *Volume) SetXAttr(path string, key string, data []byte) error {
 			return err
 		}
 		inode = inodeInfo.Inode
-		if err = v.mw.XAttrSet_ll(inode, []byte(XAttrKeyOSSETag), []byte(EmptyContentMD5String)); err != nil {
-			return err
-		}
 	}
 	return v.mw.XAttrSet_ll(inode, []byte(key), data)
 }

--- a/objectnode/server.go
+++ b/objectnode/server.go
@@ -40,7 +40,7 @@ const (
 
 // Default of configuration value
 const (
-	defaultListen = ":80"
+	defaultListen = "80"
 )
 
 var (


### PR DESCRIPTION
**What this PR does / why we need it**:

When the object storage HeadObject and GetObject have no `ETag` information in the extended attributes of the file, the `ETag` header is not included in response header. 
This solves the problem of data verification failure when reading files written through the file system interface using the AWS S3 SDK through the object storage interface to a certain extent.

**Which issue this PR fixes**:

NONE.

**Special notes for your reviewer**:

NONE.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
NONE.