### PR TITLE
Enhancement: folder operations in object storage interface

### DIFF
--- a/objectnode/acl_handler.go
+++ b/objectnode/acl_handler.go
@@ -56,13 +56,13 @@ func (o *ObjectNode) getBucketACLHandler(w http.ResponseWriter, r *http.Request)
 	var param *RequestParam
 	param = ParseRequestParam(r)
 	if param.Bucket() == "" {
-		ec = &NoSuchBucket
+		ec = NoSuchBucket
 		return
 	}
 
 	var vol *Volume
 	if vol, err = o.vm.Volume(param.Bucket()); err != nil {
-		ec = &NoSuchBucket
+		ec = NoSuchBucket
 		return
 	}
 	acl := vol.loadACL()
@@ -70,7 +70,7 @@ func (o *ObjectNode) getBucketACLHandler(w http.ResponseWriter, r *http.Request)
 	if acl != nil {
 		aclData, err = xml.Marshal(acl)
 		if err != nil {
-			ec = &InternalError
+			ec = InternalErrorCode(err)
 			return
 		}
 
@@ -82,7 +82,7 @@ func (o *ObjectNode) getBucketACLHandler(w http.ResponseWriter, r *http.Request)
 		acl.Acl.Grants = append(acl.Acl.Grants, defaultGrant)
 		aclData, err = xml.Marshal(acl)
 		if err != nil {
-			ec = &InternalError
+			ec = InternalErrorCode(err)
 			return
 		}
 	}
@@ -106,12 +106,12 @@ func (o *ObjectNode) putBucketACLHandler(w http.ResponseWriter, r *http.Request)
 	var param *RequestParam
 	param = ParseRequestParam(r)
 	if param.Bucket() == "" {
-		ec = &NoSuchBucket
+		ec = NoSuchBucket
 		return
 	}
 	var vol *Volume
 	if vol, err = o.vm.Volume(param.Bucket()); err != nil {
-		ec = &NoSuchBucket
+		ec = NoSuchBucket
 		return
 	}
 

--- a/objectnode/api_handler.go
+++ b/objectnode/api_handler.go
@@ -115,7 +115,7 @@ func (o *ObjectNode) errorResponse(w http.ResponseWriter, r *http.Request, err e
 				GetRequestID(r), err)
 		}
 		if ec == nil {
-			ec = &InternalError
+			ec = InternalErrorCode(err)
 		}
 		_ = ec.ServeResponse(w, r)
 	}

--- a/objectnode/api_handler_multipart.go
+++ b/objectnode/api_handler_multipart.go
@@ -39,11 +39,11 @@ func (o *ObjectNode) createMultipleUploadHandler(w http.ResponseWriter, r *http.
 
 	var param = ParseRequestParam(r)
 	if param.Bucket() == "" {
-		errorCode = &InvalidBucketName
+		errorCode = InvalidBucketName
 		return
 	}
 	if param.Object() == "" {
-		errorCode = &InvalidKey
+		errorCode = InvalidKey
 		return
 	}
 
@@ -51,7 +51,7 @@ func (o *ObjectNode) createMultipleUploadHandler(w http.ResponseWriter, r *http.
 	if vol, err = o.vm.Volume(param.Bucket()); err != nil {
 		log.LogErrorf("createMultipleUploadHandler: load volume fail: requestID(%v) err(%v)",
 			GetRequestID(r), err)
-		errorCode = &NoSuchBucket
+		errorCode = NoSuchBucket
 		return
 	}
 
@@ -59,7 +59,7 @@ func (o *ObjectNode) createMultipleUploadHandler(w http.ResponseWriter, r *http.
 	if uploadID, err = vol.InitMultipart(param.Object()); err != nil {
 		log.LogErrorf("createMultipleUploadHandler:  init multipart fail, requestID(%v) err(%v)",
 			GetRequestID(r), err)
-		errorCode = &InternalError
+		errorCode = InternalErrorCode(err)
 		return
 	}
 
@@ -74,7 +74,7 @@ func (o *ObjectNode) createMultipleUploadHandler(w http.ResponseWriter, r *http.
 	if bytes, marshalError = MarshalXMLEntity(initResult); marshalError != nil {
 		log.LogErrorf("createMultipleUploadHandler: marshal result fail, requestID(%v) err(%v)",
 			GetRequestID(r), err)
-		errorCode = &InternalError
+		errorCode = InternalErrorCode(marshalError)
 		return
 	}
 
@@ -115,7 +115,7 @@ func (o *ObjectNode) uploadPartHandler(w http.ResponseWriter, r *http.Request) {
 	partNumber := param.GetVar(ParamPartNumber)
 	if uploadId == "" || partNumber == "" {
 		log.LogErrorf("uploadPartHandler: illegal uploadID or partNumber, requestID(%v)", GetRequestID(r))
-		errorCode = &InvalidArgument
+		errorCode = InvalidArgument
 		return
 	}
 
@@ -123,16 +123,16 @@ func (o *ObjectNode) uploadPartHandler(w http.ResponseWriter, r *http.Request) {
 	if partNumberInt, err = strconv.ParseUint(partNumber, 10, 64); err != nil {
 		log.LogErrorf("uploadPartHandler: parse part number fail, requestID(%v) raw(%v) err(%v)",
 			GetRequestID(r), partNumber, err)
-		errorCode = &InvalidArgument
+		errorCode = InvalidArgument
 		return
 	}
 
 	if param.Bucket() == "" {
-		errorCode = &InvalidBucketName
+		errorCode = InvalidBucketName
 		return
 	}
 	if param.Object() == "" {
-		errorCode = &InvalidKey
+		errorCode = InvalidKey
 		return
 	}
 
@@ -140,7 +140,7 @@ func (o *ObjectNode) uploadPartHandler(w http.ResponseWriter, r *http.Request) {
 	if vol, err = o.vm.Volume(param.Bucket()); err != nil {
 		log.LogErrorf("uploadPartHandler: load volume fail: requestID(%v) err(%v)",
 			GetRequestID(r), err)
-		errorCode = &NoSuchBucket
+		errorCode = NoSuchBucket
 		return
 	}
 
@@ -148,7 +148,7 @@ func (o *ObjectNode) uploadPartHandler(w http.ResponseWriter, r *http.Request) {
 	var fsFileInfo *FSFileInfo
 	if fsFileInfo, err = vol.WritePart(param.Object(), uploadId, uint16(partNumberInt), r.Body); err != nil {
 		log.LogErrorf("uploadPartHandler: write part fail, requestID(%v) err(%v)", GetRequestID(r), err)
-		errorCode = &InternalError
+		errorCode = InternalErrorCode(err)
 		return
 	}
 	log.LogDebugf("uploadPartHandler: write part, requestID(%v) fsFileInfo(%v)", GetRequestID(r), fsFileInfo)
@@ -216,11 +216,11 @@ func (o *ObjectNode) listPartsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if param.Bucket() == "" {
-		errorCode = &InvalidBucketName
+		errorCode = InvalidBucketName
 		return
 	}
 	if param.Object() == "" {
-		errorCode = &InvalidKey
+		errorCode = InvalidKey
 		return
 	}
 
@@ -228,7 +228,7 @@ func (o *ObjectNode) listPartsHandler(w http.ResponseWriter, r *http.Request) {
 	if vol, err = o.vm.Volume(param.Bucket()); err != nil {
 		log.LogErrorf("listPartsHandler: load volume fail: requestID(%v) err(%v)",
 			GetRequestID(r), err)
-		errorCode = &NoSuchBucket
+		errorCode = NoSuchBucket
 		return
 	}
 
@@ -236,7 +236,7 @@ func (o *ObjectNode) listPartsHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.LogErrorf("listPartsHandler: Volume list parts fail, requestID(%v) uploadID(%v) maxParts(%v) partNoMarker(%v) err(%v)",
 			GetRequestID(r), uploadId, maxPartsInt, partNoMarkerInt, err)
-		errorCode = &InternalError
+		errorCode = InternalErrorCode(err)
 		return
 	}
 	log.LogDebugf("listPartsHandler: Volume list parts, "+
@@ -266,7 +266,7 @@ func (o *ObjectNode) listPartsHandler(w http.ResponseWriter, r *http.Request) {
 	if bytes, marshalError = MarshalXMLEntity(listPartsResult); marshalError != nil {
 		log.LogErrorf("listPartsHandler: marshal result fail, requestID(%v) err(%v)",
 			GetRequestID(r), err)
-		errorCode = &InternalError
+		errorCode = InternalErrorCode(err)
 		return
 	}
 
@@ -303,16 +303,16 @@ func (o *ObjectNode) completeMultipartUploadHandler(w http.ResponseWriter, r *ht
 	uploadId := param.GetVar(ParamUploadId)
 	if uploadId == "" {
 		log.LogErrorf("completeMultipartUploadHandler: non upload ID specified: requestID(%v)", GetRequestID(r))
-		errorCode = &InvalidArgument
+		errorCode = InvalidArgument
 		return
 	}
 
 	if param.Bucket() == "" {
-		errorCode = &InvalidBucketName
+		errorCode = InvalidBucketName
 		return
 	}
 	if param.Object() == "" {
-		errorCode = &InvalidKey
+		errorCode = InvalidKey
 		return
 	}
 
@@ -320,7 +320,7 @@ func (o *ObjectNode) completeMultipartUploadHandler(w http.ResponseWriter, r *ht
 	if vol, err = o.vm.Volume(param.Bucket()); err != nil {
 		log.LogErrorf("completeMultipartUploadHandler: load volume fail: requestID(%v) err(%v)",
 			GetRequestID(r), err)
-		errorCode = &NoSuchBucket
+		errorCode = NoSuchBucket
 		return
 	}
 
@@ -328,7 +328,7 @@ func (o *ObjectNode) completeMultipartUploadHandler(w http.ResponseWriter, r *ht
 	if err != nil {
 		log.LogErrorf("completeMultipartUploadHandler: complete multipart fail, requestID(%v) uploadID(%v) err(%v)",
 			GetRequestID(r), uploadId, err)
-		errorCode = &InternalError
+		errorCode = InternalErrorCode(err)
 		return
 	}
 	log.LogDebugf("completeMultipartUploadHandler: complete multipart, requestID(%v) uploadID(%v) path(%v)",
@@ -345,7 +345,7 @@ func (o *ObjectNode) completeMultipartUploadHandler(w http.ResponseWriter, r *ht
 	var marshalError error
 	if bytes, marshalError = MarshalXMLEntity(completeResult); marshalError != nil {
 		log.LogErrorf("completeMultipartUploadHandler: marshal result fail, requestID(%v) err(%v)", GetRequestID(r), marshalError)
-		errorCode = &InternalError
+		errorCode = InternalErrorCode(marshalError)
 		return
 	}
 
@@ -381,15 +381,15 @@ func (o *ObjectNode) abortMultipartUploadHandler(w http.ResponseWriter, r *http.
 
 	uploadId := param.GetVar(ParamUploadId)
 	if uploadId == "" {
-		errorCode = &InvalidArgument
+		errorCode = InvalidArgument
 		return
 	}
 	if param.Bucket() == "" {
-		errorCode = &InvalidBucketName
+		errorCode = InvalidBucketName
 		return
 	}
 	if param.Object() == "" {
-		errorCode = &InvalidKey
+		errorCode = InvalidKey
 		return
 	}
 
@@ -397,14 +397,14 @@ func (o *ObjectNode) abortMultipartUploadHandler(w http.ResponseWriter, r *http.
 	if vol, err = o.vm.Volume(param.Bucket()); err != nil {
 		log.LogErrorf("abortMultipartUploadHandler: load volume fail: requestID(%v) err(%v)",
 			GetRequestID(r), err)
-		errorCode = &NoSuchBucket
+		errorCode = NoSuchBucket
 		return
 	}
 
 	// Abort multipart upload
 	if err = vol.AbortMultipart(param.Object(), uploadId); err != nil {
 		log.LogErrorf("abortMultipartUploadHandler: Volume abort multipart fail, requestID(%v) uploadID(%v) err(%v)", GetRequestID(r), uploadId, err)
-		errorCode = &InternalError
+		errorCode = InternalErrorCode(err)
 		return
 	}
 	log.LogDebugf("abortMultipartUploadHandler: Volume abort multipart, requestID(%v) uploadID(%v) path(%v)", GetRequestID(r), uploadId, param.Object())
@@ -453,7 +453,7 @@ func (o *ObjectNode) listMultipartUploadsHandler(w http.ResponseWriter, r *http.
 	}
 
 	if param.Bucket() == "" {
-		errorCode = &InvalidBucketName
+		errorCode = InvalidBucketName
 		return
 	}
 
@@ -461,14 +461,14 @@ func (o *ObjectNode) listMultipartUploadsHandler(w http.ResponseWriter, r *http.
 	if vol, err = o.vm.Volume(param.Bucket()); err != nil {
 		log.LogErrorf("listMultipartUploadsHandler: load volume fail: requestID(%v) err(%v)",
 			GetRequestID(r), err)
-		errorCode = &NoSuchBucket
+		errorCode = NoSuchBucket
 		return
 	}
 
 	fsUploads, nextKeyMarker, nextUploadIdMarker, IsTruncated, prefixes, err := vol.ListMultipartUploads(prefix, delimiter, keyMarker, uploadIdMarker, maxUploadsInt)
 	if err != nil {
 		log.LogErrorf("listMultipartUploadsHandler: Volume list multipart uploads fail: requestID(%v), err(%v)", GetRequestID(r), err)
-		errorCode = &NoSuchBucket
+		errorCode = NoSuchBucket
 		return
 	}
 
@@ -500,7 +500,7 @@ func (o *ObjectNode) listMultipartUploadsHandler(w http.ResponseWriter, r *http.
 	var marshalError error
 	if bytes, marshalError = MarshalXMLEntity(listUploadsResult); marshalError != nil {
 		log.LogErrorf("listMultipartUploadsHandler: marshal xml entity fail: requestID(%v) err(%v)", GetRequestID(r), err)
-		errorCode = &InternalError
+		errorCode = InternalErrorCode(marshalError)
 		return
 	}
 

--- a/objectnode/api_middleware.go
+++ b/objectnode/api_middleware.go
@@ -54,7 +54,7 @@ func (o *ObjectNode) traceMiddleware(next http.Handler) http.Handler {
 		if requestID, err = generateRequestID(); err != nil {
 			log.LogErrorf("traceMiddleware: generate request ID fail, remote(%v) url(%v) err(%v)",
 				r.RemoteAddr, r.URL.String(), err)
-			_ = InternalError.ServeResponse(w, r)
+			_ = InternalErrorCode(err).ServeResponse(w, r)
 			return
 		}
 

--- a/objectnode/const.go
+++ b/objectnode/const.go
@@ -14,6 +14,8 @@
 
 package objectnode
 
+import "os"
+
 type OSSOperation string
 
 const (
@@ -49,10 +51,11 @@ const (
 )
 
 const (
-	HeaderValueServer         = "ChubaoFS"
-	HeaderValueAcceptRange    = "bytes"
-	HeaderValueTypeStream     = "application/octet-stream"
-	HeaderValueContentTypeXML = "application/xml"
+	HeaderValueServer               = "ChubaoFS"
+	HeaderValueAcceptRange          = "bytes"
+	HeaderValueTypeStream           = "application/octet-stream"
+	HeaderValueContentTypeXML       = "application/xml"
+	HeaderValueContentTypeDirectory = "application/directory"
 )
 
 const (
@@ -91,9 +94,10 @@ const (
 
 // XAttr keys for ObjectNode compatible feature
 const (
-	XAttrKeyOSSETag    = "oss:etag"
+	XAttrKeyOSSETag    = "oss:tag"
 	XAttrKeyOSSTagging = "oss:tagging"
 	XAttrKeyOSSPolicy  = "oss:policy"
+	XAttrKeyOSSMIME    = "oss:mime"
 )
 
 const (
@@ -102,4 +106,9 @@ const (
 
 const (
 	EmptyContentMD5String = "d41d8cd98f00b204e9800998ecf8427e"
+)
+
+const (
+	DefaultFileMode = 0644
+	DefaultDirMode  = DefaultFileMode | os.ModeDir
 )

--- a/objectnode/fs.go
+++ b/objectnode/fs.go
@@ -27,6 +27,7 @@ type FSFileInfo struct {
 	ModifyTime time.Time
 	ETag       string
 	Inode      uint64
+	MIMEType   string
 }
 
 type Prefixes []string

--- a/objectnode/policy.go
+++ b/objectnode/policy.go
@@ -193,7 +193,7 @@ func (o *ObjectNode) policyCheck(f http.HandlerFunc) http.HandlerFunc {
 				f(w, r)
 			} else {
 				if ec == nil {
-					ec = &AccessDenied
+					ec = AccessDenied
 				}
 				o.errorResponse(w, r, err, ec)
 			}
@@ -249,7 +249,7 @@ func (o *ObjectNode) policyCheck(f http.HandlerFunc) http.HandlerFunc {
 		if err = loadBucketMeta(param.Bucket()); err != nil {
 			log.LogErrorf("policyCheck: load bucket metadata fail: requestID(%v) err(%v)", GetRequestID(r), err)
 			allowed = false
-			ec = &NoSuchBucket
+			ec = NoSuchBucket
 			return
 		}
 

--- a/objectnode/result.go
+++ b/objectnode/result.go
@@ -153,7 +153,7 @@ type ListBucketResult struct {
 	MaxKeys        int             `xml:"MaxKeys"`
 	Delimiter      string          `xml:"Delimiter"`
 	IsTruncated    bool            `xml:"IsTruncated"`
-	NextMarker     string          `xml:"NextMarker"`
+	NextMarker     string          `xml:"NextMarker,omitempty"`
 	Contents       []*Content      `xml:"Contents"`
 	CommonPrefixes []*CommonPrefix `xml:"CommonPrefixes"`
 }

--- a/objectnode/result_error.go
+++ b/objectnode/result_error.go
@@ -65,27 +65,52 @@ func ServeInternalStaticErrorResponse(w http.ResponseWriter, r *http.Request) {
 	_, _ = w.Write([]byte(sb.String()))
 }
 
+// Presets
 var (
-	UnsupportedOperation                = ErrorCode{ErrorCode: "UnsupportedOperation", ErrorMessage: "Operation is not supported", StatusCode: http.StatusBadRequest}
-	AccessDenied                        = ErrorCode{ErrorCode: "AccessDenied", ErrorMessage: "Access Denied", StatusCode: http.StatusForbidden}
-	BadDigest                           = ErrorCode{ErrorCode: "BadDigest", ErrorMessage: "The Content-MD5 you specified did not match what we received.", StatusCode: http.StatusBadRequest}
-	BucketNotExisted                    = ErrorCode{ErrorCode: "BucketNotExisted", ErrorMessage: "The requested bucket name is not existed.", StatusCode: http.StatusNotFound}
-	BucketNotExistedForHead             = ErrorCode{ErrorCode: "BucketNotExisted", ErrorMessage: "The requested bucket name is not existed.", StatusCode: http.StatusConflict}
-	BucketNotEmpty                      = ErrorCode{ErrorCode: "BucketNotEmpty", ErrorMessage: "The bucket you tried to delete is not empty.", StatusCode: http.StatusConflict}
-	BucketNotOwnedByYou                 = ErrorCode{ErrorCode: "BucketNotOwnedByYou", ErrorMessage: "The bucket is not owned by you.", StatusCode: http.StatusConflict}
-	KeyTooLongError                     = ErrorCode{ErrorCode: "KeyTooLongError", ErrorMessage: "", StatusCode: http.StatusBadRequest}
-	InvalidKey                          = ErrorCode{ErrorCode: "InvalidKey", ErrorMessage: "Object key is Illegal", StatusCode: http.StatusBadRequest}
-	EntityTooSmall                      = ErrorCode{ErrorCode: "EntityTooSmall", ErrorMessage: "Your proposed upload is smaller than the minimum allowed object size.", StatusCode: http.StatusBadRequest}
-	EntityTooLarge                      = ErrorCode{ErrorCode: "EntityTooLarge", ErrorMessage: "Your proposed upload exceeds the maximum allowed object size.", StatusCode: http.StatusBadRequest}
-	IncorrectNumberOfFilesInPostRequest = ErrorCode{ErrorCode: "IncorrectNumberOfFilesInPostRequest", ErrorMessage: "POST requires exactly one file upload per request.", StatusCode: http.StatusBadRequest}
-	InternalError                       = ErrorCode{ErrorCode: "InternalError", ErrorMessage: "We encountered an internal error. Please try again.", StatusCode: http.StatusInternalServerError}
-	InvalidArgument                     = ErrorCode{ErrorCode: "InvalidArgument", ErrorMessage: "Invalid Argument", StatusCode: http.StatusBadRequest}
-	InvalidBucketName                   = ErrorCode{ErrorCode: "InvalidBucketName", ErrorMessage: "The specified bucket is not valid.", StatusCode: http.StatusBadRequest}
-	InvalidRange                        = ErrorCode{ErrorCode: "InvalidRange", ErrorMessage: "The requested range cannot be satisfied.", StatusCode: http.StatusRequestedRangeNotSatisfiable}
-	MissingContentLength                = ErrorCode{ErrorCode: "MissingContentLength", ErrorMessage: "You must provide the Content-Length HTTP header.", StatusCode: http.StatusLengthRequired}
-	NoSuchBucket                        = ErrorCode{ErrorCode: "NoSuchBucket", ErrorMessage: "The specified bucket does not exist.", StatusCode: http.StatusNotFound}
-	NoSuchKey                           = ErrorCode{ErrorCode: "NoLoggingStatusForKey", ErrorMessage: "The specified key does not exist.", StatusCode: http.StatusNotFound}
-	PreconditionFailed                  = ErrorCode{ErrorCode: "PreconditionFailed", ErrorMessage: "At least one of the preconditions you specified did not hold.", StatusCode: http.StatusPreconditionFailed}
-	MaxContentLength                    = ErrorCode{ErrorCode: "MaxContentLength", ErrorMessage: "Content-Length is bigger than 20KB.", StatusCode: http.StatusLengthRequired}
-	DuplicatedBucket                    = ErrorCode{ErrorCode: "CreateBucketFailed", ErrorMessage: "Duplicate bucket name.", StatusCode: http.StatusBadRequest}
+	UnsupportedOperation                = &ErrorCode{ErrorCode: "UnsupportedOperation", ErrorMessage: "Operation is not supported", StatusCode: http.StatusBadRequest}
+	AccessDenied                        = &ErrorCode{ErrorCode: "AccessDenied", ErrorMessage: "Access Denied", StatusCode: http.StatusForbidden}
+	BadDigest                           = &ErrorCode{ErrorCode: "BadDigest", ErrorMessage: "The Content-MD5 you specified did not match what we received.", StatusCode: http.StatusBadRequest}
+	BucketNotExisted                    = &ErrorCode{ErrorCode: "BucketNotExisted", ErrorMessage: "The requested bucket name is not existed.", StatusCode: http.StatusNotFound}
+	BucketNotExistedForHead             = &ErrorCode{ErrorCode: "BucketNotExisted", ErrorMessage: "The requested bucket name is not existed.", StatusCode: http.StatusConflict}
+	BucketNotEmpty                      = &ErrorCode{ErrorCode: "BucketNotEmpty", ErrorMessage: "The bucket you tried to delete is not empty.", StatusCode: http.StatusConflict}
+	BucketNotOwnedByYou                 = &ErrorCode{ErrorCode: "BucketNotOwnedByYou", ErrorMessage: "The bucket is not owned by you.", StatusCode: http.StatusConflict}
+	KeyTooLongError                     = &ErrorCode{ErrorCode: "KeyTooLongError", ErrorMessage: "", StatusCode: http.StatusBadRequest}
+	InvalidKey                          = &ErrorCode{ErrorCode: "InvalidKey", ErrorMessage: "Object key is Illegal", StatusCode: http.StatusBadRequest}
+	EntityTooSmall                      = &ErrorCode{ErrorCode: "EntityTooSmall", ErrorMessage: "Your proposed upload is smaller than the minimum allowed object size.", StatusCode: http.StatusBadRequest}
+	EntityTooLarge                      = &ErrorCode{ErrorCode: "EntityTooLarge", ErrorMessage: "Your proposed upload exceeds the maximum allowed object size.", StatusCode: http.StatusBadRequest}
+	IncorrectNumberOfFilesInPostRequest = &ErrorCode{ErrorCode: "IncorrectNumberOfFilesInPostRequest", ErrorMessage: "POST requires exactly one file upload per request.", StatusCode: http.StatusBadRequest}
+	InvalidArgument                     = &ErrorCode{ErrorCode: "InvalidArgument", ErrorMessage: "Invalid Argument", StatusCode: http.StatusBadRequest}
+	InvalidBucketName                   = &ErrorCode{ErrorCode: "InvalidBucketName", ErrorMessage: "The specified bucket is not valid.", StatusCode: http.StatusBadRequest}
+	InvalidRange                        = &ErrorCode{ErrorCode: "InvalidRange", ErrorMessage: "The requested range cannot be satisfied.", StatusCode: http.StatusRequestedRangeNotSatisfiable}
+	MissingContentLength                = &ErrorCode{ErrorCode: "MissingContentLength", ErrorMessage: "You must provide the Content-Length HTTP header.", StatusCode: http.StatusLengthRequired}
+	NoSuchBucket                        = &ErrorCode{ErrorCode: "NoSuchBucket", ErrorMessage: "The specified bucket does not exist.", StatusCode: http.StatusNotFound}
+	NoSuchKey                           = &ErrorCode{ErrorCode: "NoLoggingStatusForKey", ErrorMessage: "The specified key does not exist.", StatusCode: http.StatusNotFound}
+	PreconditionFailed                  = &ErrorCode{ErrorCode: "PreconditionFailed", ErrorMessage: "At least one of the preconditions you specified did not hold.", StatusCode: http.StatusPreconditionFailed}
+	MaxContentLength                    = &ErrorCode{ErrorCode: "MaxContentLength", ErrorMessage: "Content-Length is bigger than 20KB.", StatusCode: http.StatusLengthRequired}
+	DuplicatedBucket                    = &ErrorCode{ErrorCode: "CreateBucketFailed", ErrorMessage: "Duplicate bucket name.", StatusCode: http.StatusBadRequest}
+	Conflict                            = &ErrorCode{ErrorCode: "Conflict", ErrorMessage: "Object already exists and type conflicts", StatusCode: http.StatusConflict}
 )
+
+func HttpStatusErrorCode(code int) *ErrorCode {
+	statusText := http.StatusText(code)
+	statusTextWithoutSpace := strings.ReplaceAll(statusText, " ", "")
+	return &ErrorCode{
+		ErrorCode:    statusTextWithoutSpace,
+		ErrorMessage: statusText,
+		StatusCode:   code,
+	}
+}
+
+func InternalErrorCode(err error) *ErrorCode {
+	var errorMessage string
+	if err != nil {
+		errorMessage = err.Error()
+	} else {
+		errorMessage = "Internal Server Error"
+	}
+	return &ErrorCode{
+		ErrorCode:    "InternalError",
+		ErrorMessage: errorMessage,
+		StatusCode:   http.StatusInternalServerError,
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports folder operations in the same way as Amazon AWS S3.
  - Get folder meta info by HeadObject interface.
  - Create folder when header specifies Content-Type as
    application/directory and Content-Length as 0 on PutObject interface.
  - Delete an empty folder by DeleteObject interface.
  - The GetObject interface responds normally when the target is an
    existing directory.
  - Differentiate folders and files on the ListObject interface through the
    CommonPrefix property (already supported).

Following object storage interface haven been implemented folder operations:
  - HeadObject
  - GetObject
  - DeleteObject
  - DeleteObjects
  - ListObjects
  - ListObjectsV2

**Which issue this PR fixes**: 

- fixes #429 

**Special notes for your reviewer**:

NONE.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Enhancement:
- Support folder operations in object storage interface.
```