### PR TITLE
Fix: if user set rdonly is true or token is readonly token, then client

### DIFF
--- a/client/fuse.go
+++ b/client/fuse.go
@@ -245,7 +245,7 @@ func mount(opt *proto.MountOptions) (fsConn *fuse.Conn, super *cfs.Super, err er
 		os.Exit(1)
 	}
 
-	opt.Rdonly = (super.TokenType() == int8(proto.ReadOnlyToken)) && opt.Rdonly
+	opt.Rdonly = (super.TokenType() == int8(proto.ReadOnlyToken)) || opt.Rdonly
 
 	options := []fuse.MountOption{
 		fuse.AllowOther(),

--- a/clientv2/main.go
+++ b/clientv2/main.go
@@ -221,7 +221,7 @@ func mount(opt *proto.MountOptions) (*fuse.MountedFileSystem, error) {
 		os.Exit(1)
 	}
 
-	opt.Rdonly = (super.TokenType() == int8(proto.ReadOnlyToken)) && opt.Rdonly
+	opt.Rdonly = (super.TokenType() == int8(proto.ReadOnlyToken)) || opt.Rdonly
 
 	server := fuseutil.NewFileSystemServer(super)
 	mntcfg := &fuse.MountConfig{


### PR DESCRIPTION
Fix: if user set rdonly is true or token is readonly token, then client use readonly mount
Signed-off-by: awzhgw <guowl18702995996@gmail.com>


