### PR TITLE
Fix: user name verification issues

### DIFF
--- a/master/api_service_user.go
+++ b/master/api_service_user.go
@@ -26,11 +26,14 @@ func (m *Server) createUser(w http.ResponseWriter, r *http.Request) {
 		sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: err.Error()})
 		return
 	}
+	if !ownerRegexp.MatchString(param.ID) {
+		sendErrReply(w, r, newErrHTTPReply(proto.ErrInvalidUserID))
+		return
+	}
 	if param.Type == proto.UserTypeRoot {
 		sendErrReply(w, r, newErrHTTPReply(proto.ErrInvalidUserType))
 		return
 	}
-
 	if userInfo, err = m.user.createKey(&param); err != nil {
 		sendErrReply(w, r, newErrHTTPReply(err))
 		return
@@ -254,10 +257,6 @@ func extractUser(r *http.Request) (user string, err error) {
 		err = keyNotFound(userKey)
 		return
 	}
-	if !ownerRegexp.MatchString(user) {
-		return "", errors.New("user id can only be number and letters")
-	}
-
 	return
 }
 

--- a/proto/errors.go
+++ b/proto/errors.go
@@ -136,6 +136,7 @@ const (
 	ErrCodeZoneNotExists
 	ErrCodeOwnVolExists
 	ErrCodeSuperAdminExists
+	ErrCodeInvalidUserID
 	ErrCodeInvalidUserType
 	ErrCodeNoPermission
 	ErrCodeTokenNotExist
@@ -195,6 +196,7 @@ var Err2CodeMap = map[error]int32{
 	ErrZoneNotExists:                   ErrCodeZoneNotExists,
 	ErrOwnVolExists:                    ErrCodeOwnVolExists,
 	ErrSuperAdminExists:                ErrCodeSuperAdminExists,
+	ErrInvalidUserID:                   ErrCodeInvalidUserID,
 	ErrInvalidUserType:                 ErrCodeInvalidUserType,
 	ErrNoPermission:                    ErrCodeNoPermission,
 	ErrTokenNotFound:                   ErrCodeTokenNotExist,
@@ -262,6 +264,7 @@ var code2ErrMap = map[int32]error{
 	ErrCodeOwnVolExists:                    ErrOwnVolExists,
 	ErrCodeSuperAdminExists:                ErrSuperAdminExists,
 	ErrCodeInvalidUserType:                 ErrInvalidUserType,
+	ErrCodeInvalidUserID:                   ErrInvalidUserID,
 	ErrCodeNoPermission:                    ErrNoPermission,
 	ErrCodeTokenNotExist:                   ErrTokenNotFound,
 	ErrCodeInvalidAccessKey:                ErrInvalidAccessKey,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The user name (ID) is verified when the user is created.
Do not verify user name parameters when viewing user information,
deleting users, modifying authorization, etc. for specific users.

**Which issue this PR fixes**: 

fixes #464 

**Special notes for your reviewer**:
NONE.

**Release note**:
NONE.
