### PR TITLE
Fix: If the metapartition or data partition raft peers does not have …

### DIFF
--- a/datanode/partition_raft.go
+++ b/datanode/partition_raft.go
@@ -126,7 +126,7 @@ func (dp *DataPartition) CanRemoveRaftMember(peer proto.Peer) error {
 		}
 	}
 	if !hasExsit {
-		return fmt.Errorf("peer(%v) not exsit hasDownReplicasExcludePeer(%v)", peer, downReplicas)
+		return nil
 	}
 
 	hasDownReplicasExcludePeer := make([]uint64, 0)

--- a/metanode/partition_fsmop.go
+++ b/metanode/partition_fsmop.go
@@ -203,7 +203,7 @@ func (mp *metaPartition) CanRemoveRaftMember(peer proto.Peer) error {
 		}
 	}
 	if !hasExsit {
-		return fmt.Errorf("peer(%v) not exsit downReplicas(%v)", peer, downReplicas)
+		return nil
 	}
 
 	hasDownReplicasExcludePeer := make([]uint64, 0)


### PR DESCRIPTION
Fix: If the metapartition or data partition raft peers does not have  a peer
to be offline, the datanode or metanode will report an error to the
master at this time, causing the metapartition or datapartition cannot to be
offline
Signed-off-by: awzhgw <guowl18702995996@gmail.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
#468 
