### PR TITLE
feature: introduce subdir mount option

### DIFF
--- a/client/fuse.go
+++ b/client/fuse.go
@@ -322,6 +322,7 @@ func parseMountOption(cfg *config.Config) (*proto.MountOptions, error) {
 	opt.AccessKey = GlobalMountOptions[proto.AccessKey].GetString()
 	opt.SecretKey = GlobalMountOptions[proto.SecretKey].GetString()
 	opt.DisableDcache = GlobalMountOptions[proto.DisableDcache].GetBool()
+	opt.SubDir = GlobalMountOptions[proto.SubDir].GetString()
 
 	if opt.MountPoint == "" || opt.Volname == "" || opt.Owner == "" || opt.Master == "" {
 		return nil, errors.New(fmt.Sprintf("invalid config file: lack of mandatory fields, mountPoint(%v), volName(%v), owner(%v), masterAddr(%v)", opt.MountPoint, opt.Volname, opt.Owner, opt.Master))

--- a/proto/mount_options.go
+++ b/proto/mount_options.go
@@ -41,6 +41,7 @@ const (
 	AccessKey
 	SecretKey
 	DisableDcache
+	SubDir
 
 	MaxMountOption
 )
@@ -99,6 +100,7 @@ func InitMountOptions(opts []MountOption) {
 	opts[SecretKey] = MountOption{"secretKey", "Secret Key", "", ""}
 
 	opts[DisableDcache] = MountOption{"disableDcache", "Disable Dentry Cache", "", false}
+	opts[SubDir] = MountOption{"subdir", "Mount sub directory", "", ""}
 
 	for i := 0; i < MaxMountOption; i++ {
 		flag.StringVar(&opts[i].cmdlineValue, opts[i].keyword, "", opts[i].description)
@@ -211,4 +213,5 @@ type MountOptions struct {
 	AccessKey     string
 	SecretKey     string
 	DisableDcache bool
+	SubDir        string
 }


### PR DESCRIPTION
This commit introduces the capability of mounting subdirectory in a
volume. Instead of using the default root ino, we use the ino of
specified subdir as root. The subdir can be defined in the client config
file like below:

    "subdir": "path/to/subdir",

Signed-off-by: Shuoran Liu <shuoranliu@gmail.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
