### PR TITLE
Refactor: proccess on token validation

### DIFF
--- a/client/fs/super.go
+++ b/client/fs/super.go
@@ -71,7 +71,6 @@ func NewSuper(opt *proto.MountOptions) (s *Super, err error) {
 		Masters:       masters,
 		Authenticate:  opt.Authenticate,
 		TicketMess:    opt.TicketMess,
-		TokenKey:      opt.TokenKey,
 		ValidateOwner: true,
 	}
 	s.mw, err = meta.NewMetaWrapper(metaConfig)
@@ -149,10 +148,6 @@ func (s *Super) Statfs(ctx context.Context, req *fuse.StatfsRequest, resp *fuse.
 // ClusterName returns the cluster name.
 func (s *Super) ClusterName() string {
 	return s.cluster
-}
-
-func (s *Super) TokenType() int8 {
-	return s.mw.TokenType()
 }
 
 func (s *Super) GetRate(w http.ResponseWriter, r *http.Request) {

--- a/client/fuse.go
+++ b/client/fuse.go
@@ -153,14 +153,21 @@ func main() {
 
 	registerInterceptedSignal(opt.MountPoint)
 
+	if err = checkPermission(opt); err != nil {
+		syslog.Println("check permission failed: ", err)
+		log.LogFlush()
+		_ = daemonize.SignalOutcome(err)
+		os.Exit(1)
+	}
+
 	fsConn, super, err := mount(opt)
 	if err != nil {
-		syslog.Println("mount err", err)
+		syslog.Println("mount failed: ", err)
 		log.LogFlush()
-		daemonize.SignalOutcome(err)
+		_ = daemonize.SignalOutcome(err)
 		os.Exit(1)
 	} else {
-		daemonize.SignalOutcome(nil)
+		_ = daemonize.SignalOutcome(nil)
 	}
 	defer fsConn.Close()
 
@@ -236,16 +243,6 @@ func mount(opt *proto.MountOptions) (fsConn *fuse.Conn, super *cfs.Super, err er
 	if err = ump.InitUmp(fmt.Sprintf("%v_%v", super.ClusterName(), ModuleName), opt.UmpDatadir); err != nil {
 		return
 	}
-
-	// Validate permission
-	if err = checkVolAccessPerm(opt); err != nil {
-		syslog.Printf("check permission failed: %v", err)
-		log.LogFlush()
-		_ = daemonize.SignalOutcome(err)
-		os.Exit(1)
-	}
-
-	opt.Rdonly = (super.TokenType() == int8(proto.ReadOnlyToken)) || opt.Rdonly
 
 	options := []fuse.MountOption{
 		fuse.AllowOther(),
@@ -332,36 +329,51 @@ func parseMountOption(cfg *config.Config) (*proto.MountOptions, error) {
 	return opt, nil
 }
 
-func checkVolAccessPerm(opt *proto.MountOptions) (err error) {
-	if opt.AccessKey == "" {
-		return
-	}
+func checkPermission(opt *proto.MountOptions) (err error) {
 	var mc = master.NewMasterClientFromString(opt.Master, false)
-	var userInfo *proto.UserInfo
-	if userInfo, err = mc.UserAPI().GetAKInfo(opt.AccessKey); err != nil {
+
+	// Check token permission
+	var info *proto.VolStatInfo
+	if info, err = mc.ClientAPI().GetVolumeStat(opt.Volname); err != nil {
 		return
 	}
-	if userInfo.SecretKey != opt.SecretKey {
+	if info.EnableToken {
+		var token *proto.Token
+		if token, err = mc.ClientAPI().GetToken(opt.Volname, opt.TokenKey); err != nil {
+			log.LogWarnf("checkPermission: get token type failed: volume(%v) tokenKey(%v) err(%v)",
+				opt.Volname, opt.TokenKey, err)
+			return
+		}
+		log.LogInfof("checkPermission: get token: token(%v)", token)
+		opt.Rdonly = token.TokenType == int8(proto.ReadOnlyToken) || opt.Rdonly
+	}
+
+	// Check user access policy is enabled
+	if opt.AccessKey != "" {
+		var userInfo *proto.UserInfo
+		if userInfo, err = mc.UserAPI().GetAKInfo(opt.AccessKey); err != nil {
+			return
+		}
+		if userInfo.SecretKey != opt.SecretKey {
+			err = proto.ErrNoPermission
+			return
+		}
+		var policy = userInfo.Policy
+		if policy.IsOwn(opt.Volname) {
+			return
+		}
+		if policy.IsAuthorized(opt.Volname, proto.POSIXWriteAction) &&
+			policy.IsAuthorized(opt.Volname, proto.POSIXReadAction) {
+			return
+		}
+		if policy.IsAuthorized(opt.Volname, proto.POSIXReadAction) &&
+			!policy.IsAuthorized(opt.Volname, proto.POSIXWriteAction) {
+			opt.Rdonly = true
+			return
+		}
 		err = proto.ErrNoPermission
 		return
 	}
-	var policy = userInfo.Policy
-	if policy.IsOwn(opt.Volname) {
-		opt.Rdonly = false
-		return
-	}
-	if policy.IsAuthorized(opt.Volname, proto.POSIXWriteAction) &&
-		policy.IsAuthorized(opt.Volname, proto.POSIXReadAction) {
-		opt.Rdonly = false
-		return
-	}
-	if policy.IsAuthorized(opt.Volname, proto.POSIXReadAction) &&
-		!policy.IsAuthorized(opt.Volname, proto.POSIXWriteAction) {
-		opt.Rdonly = true
-		return
-	}
-	opt.Rdonly = true
-	err = proto.ErrNoPermission
 	return
 }
 

--- a/clientv2/fs/super.go
+++ b/clientv2/fs/super.go
@@ -60,7 +60,6 @@ func NewSuper(opt *proto.MountOptions) (s *Super, err error) {
 		Masters:       masters,
 		Authenticate:  opt.Authenticate,
 		TicketMess:    opt.TicketMess,
-		TokenKey:      opt.TokenKey,
 		ValidateOwner: true,
 	}
 	s.mw, err = meta.NewMetaWrapper(metaConfig)
@@ -125,10 +124,6 @@ func (s *Super) Destroy() {
 
 func (s *Super) ClusterName() string {
 	return s.cluster
-}
-
-func (s *Super) TokenType() int8 {
-	return s.mw.TokenType()
 }
 
 func (s *Super) GetRate(w http.ResponseWriter, r *http.Request) {

--- a/sdk/meta/meta.go
+++ b/sdk/meta/meta.go
@@ -73,7 +73,6 @@ type MetaConfig struct {
 	Masters          []string
 	Authenticate     bool
 	TicketMess       auth.TicketMess
-	TokenKey         string
 	ValidateOwner    bool
 	OnAsyncTaskError AsyncTaskErrorFunc
 }
@@ -115,10 +114,6 @@ type MetaWrapper struct {
 	accessToken  proto.APIAccessReq
 	sessionKey   string
 	ticketMess   auth.TicketMess
-
-	enableToken bool
-	tokenKey    string
-	tokenType   int8
 
 	closeCh   chan struct{}
 	closeOnce sync.Once
@@ -179,7 +174,6 @@ func NewMetaWrapper(config *MetaConfig) (*MetaWrapper, error) {
 	if err = mw.updateVolStatInfo(); err != nil {
 		return nil, err
 	}
-	mw.tokenKey = config.TokenKey
 
 	limit := MaxMountRetryLimit
 retry:
@@ -202,12 +196,6 @@ func (mw *MetaWrapper) initMetaWrapper() error {
 	err := mw.updateVolStatInfo()
 	if err != nil {
 		return err
-	}
-	if mw.enableToken {
-		err = mw.updateTokenType()
-		if err != nil {
-			return err
-		}
 	}
 	return mw.updateMetaPartitions()
 }
@@ -234,10 +222,6 @@ func (mw *MetaWrapper) Cluster() string {
 
 func (mw *MetaWrapper) LocalIP() string {
 	return mw.localIP
-}
-
-func (mw *MetaWrapper) TokenType() int8 {
-	return mw.tokenType
 }
 
 func (mw *MetaWrapper) exporterKey(act string) string {

--- a/sdk/meta/view.go
+++ b/sdk/meta/view.go
@@ -136,20 +136,7 @@ func (mw *MetaWrapper) updateVolStatInfo() (err error) {
 	}
 	atomic.StoreUint64(&mw.totalSize, info.TotalSize)
 	atomic.StoreUint64(&mw.usedSize, info.UsedSize)
-	mw.enableToken = info.EnableToken
 	log.LogInfof("VolStatInfo: info(%v)", info)
-	return
-}
-
-func (mw *MetaWrapper) updateTokenType() (err error) {
-
-	var token *proto.Token
-	if token, err = mw.mc.ClientAPI().GetToken(mw.volname, mw.tokenKey); err != nil {
-		log.LogWarnf("updateTokenType: get token type failed: volume(%v) tokenKey(%v) err(%v)", mw.volname, mw.tokenKey, err)
-		return
-	}
-	mw.tokenType = token.TokenType
-	log.LogInfof("GetToken: token(%v)", token)
 	return
 }
 
@@ -159,6 +146,7 @@ func (mw *MetaWrapper) updateMetaPartitions() error {
 		log.LogInfof("error: %v", err.Error())
 		switch err {
 		case proto.ErrExpiredTicket:
+			// TODO: bad logic, remove later (Mofei Zhang)
 			if e := mw.updateTicket(); e != nil {
 				log.LogFlush()
 				daemonize.SignalOutcome(err)
@@ -167,6 +155,7 @@ func (mw *MetaWrapper) updateMetaPartitions() error {
 			log.LogInfof("updateTicket: ok!")
 			return err
 		case proto.ErrInvalidTicket:
+			// TODO: bad logic, remove later (Mofei Zhang)
 			log.LogFlush()
 			daemonize.SignalOutcome(err)
 			os.Exit(1)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Replace process of token validation from meta wrapper to client.
Meta wrapper is now a basic metadata operation component shared by multiple functional modules. 

Permission verification should not be placed in the meta wrapper. 
Otherwise, modules which operates the metadata without permission validation will not work correctly.

**Which issue this PR fixes**: 
fixes #497 

**Special notes for your reviewer**:
NONE.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Bug fix:
- Fixed the problem that the token-enabled volume cannot be operated through the object storage interface.
```