### PR TITLE
Enhancement: compatible with older version S3 credential

### DIFF
--- a/proto/user_proto.go
+++ b/proto/user_proto.go
@@ -15,6 +15,7 @@
 package proto
 
 import (
+	"fmt"
 	"regexp"
 	"sync"
 )
@@ -99,6 +100,14 @@ type UserInfo struct {
 	Policy     *UserPolicy `json:"policy"`
 	UserType   UserType    `json:"user_type"`
 	CreateTime string      `json:"create_time"`
+}
+
+func (i *UserInfo) String() string {
+	if i == nil {
+		return "nil"
+	}
+	return fmt.Sprintf("%v_%v_%v_%v",
+		i.UserID, i.AccessKey, i.SecretKey, i.UserType)
 }
 
 func NewUserInfo() *UserInfo {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Added compatibility with 1.5 version of credential information for
signature verification and policy check of s3 interface.

In version 1.5, each volume has its own access key, which is stored
in the view information center of the volume to which it belongs.

In version 2.0, user security and authorization are added. Each user
has their own access key, and users can use this access key to operate
all their own volumes.

Increase the compatibility with the old version authentication method
to reduce the impact of online version 1.5 cluster upgrade to 2.0 on
online services.

Adjusted signature verification process:

**Step 1.** Attempt to obtain the user information that matches the requested access key, and use the secret key information of the user for signature calculation if successful.
**Step 2.** If the result of the **Step 1** is that the specified user does not exist (got `proto.ErrAccessKeyNotExists` error or `proto.ErrUserNotExists` error), and the user requests to specify a volume, then proceed to the **Step 3**, otherwise the signature verification fails.
**Step 3.** Try to load the volume requested by the user. If the access key of the volume is the same as the user's request, the secret key of the volume is used for signature calculation, otherwise the signature verification fails.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

NONE.

**Special notes for your reviewer**:

Focus on checking the adjustment of v2, v4 signature verification and policy inspection related processing.

**Release note**:
NONE.