### PR TITLE
enhance: decrease request channel size to save memory

### DIFF
--- a/sdk/data/stream/stream_reader.go
+++ b/sdk/data/stream/stream_reader.go
@@ -56,7 +56,7 @@ func NewStreamer(client *ExtentClient, inode uint64) *Streamer {
 	s.client = client
 	s.inode = inode
 	s.extents = NewExtentCache(inode)
-	s.request = make(chan interface{}, 1000)
+	s.request = make(chan interface{}, 64)
 	s.done = make(chan struct{})
 	s.dirtylist = NewDirtyExtentList()
 	go s.server()


### PR DESCRIPTION
This commit decreases the size of one file's request channel, since
there is no need for such a large value. Besides, this commit saves the
memory usage when tons of files are written just once.

Signed-off-by: Shuoran Liu <shuoranliu@gmail.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
