### PR TITLE
Fix: precondition parsing issue

### DIFF
--- a/objectnode/api_handler.go
+++ b/objectnode/api_handler.go
@@ -122,10 +122,11 @@ func (o *ObjectNode) errorResponse(w http.ResponseWriter, r *http.Request, err e
 }
 
 func (o *ObjectNode) unsupportedOperationHandler(w http.ResponseWriter, r *http.Request) {
-	var err error
-	if err = UnsupportedOperation.ServeResponse(w, r); err != nil {
-		log.LogErrorf("unsupportedOperationHandler: serve response fail: requestID(%v) err(%v)",
-			GetRequestID(r), err)
-	}
+	log.LogInfof("Audit: unsupported operation: requestID(%v) remote(%v) action(%v) userAgent(%v)",
+		GetRequestID(r),
+		getRequestIP(r),
+		ActionFromRouteName(mux.CurrentRoute(r).GetName()),
+		r.UserAgent())
+	_ = UnsupportedOperation.ServeResponse(w, r)
 	return
 }

--- a/objectnode/fs_volume.go
+++ b/objectnode/fs_volume.go
@@ -208,7 +208,6 @@ func (v *Volume) getInodeFromPath(path string) (inode uint64, err error) {
 	}
 
 	dirs, filename := splitPath(path)
-	log.LogInfof("dirs %v %v %v", path, len(dirs), filename)
 
 	if len(dirs) == 0 && filename == "" {
 		return volumeRootInode, nil

--- a/objectnode/result.go
+++ b/objectnode/result.go
@@ -266,23 +266,6 @@ func NewTagging() *Tagging {
 	}
 }
 
-func NewGetObjectTaggingOutput() *Tagging {
-	return &Tagging{
-		XMLName: xml.Name{Local: "GetObjectTaggingOutput"},
-	}
-}
-
-func NewGetBucketTaggingOutput() *Tagging {
-	return &Tagging{
-		XMLName: xml.Name{Local: "GetBucketTaggingOutput"},
-	}
-}
-
-type GetObjectTaggingOutput struct {
-	XMLName xml.Name `xml:"GetObjectTaggingOutput"`
-	Tagging
-}
-
 type XAttr struct {
 	Key   string `xml:"Key"`
 	Value string `xml:"Value"`

--- a/objectnode/result_test.go
+++ b/objectnode/result_test.go
@@ -219,25 +219,6 @@ func TestMarshalTagging(t *testing.T) {
 	t.Logf("json result:\n%v", string(marshaled))
 }
 
-func TestMarshalGetObjectTaggingOutput(t *testing.T) {
-	tagging := NewGetObjectTaggingOutput()
-	tagging.TagSet = []*Tag{
-		{
-			Key:   "tag1",
-			Value: "val1",
-		},
-		{
-			Key:   "tag2",
-			Value: "val2",
-		},
-	}
-	marshaled, err := MarshalXMLEntity(tagging)
-	if err != nil {
-		t.Fatalf("marshal tagging fail: err(%v)", err)
-	}
-	t.Logf("marshal tagging:\n%v", string(marshaled))
-}
-
 func TestResult_PutXAttrRequest_Marshal(t *testing.T) {
 	var err error
 	var request = PutXAttrRequest{


### PR DESCRIPTION


<!-- Thanks for sending a pull request! -->
**What this PR does / why we need it**:
Fix the parsing issue of the two preconditions of **If-Match** and
**If-None-Match**.

We found that the request sent through the AWS S3 SDK included
double quotes for the values of these two preconditions.

This part is not specified in the AWS S3 API Reference.

Affected APIs: 
- **HeadObject**
- **GetObject**

**Which issue this PR fixes**:
NONE

**Special notes for your reviewer**:
NONE.

**Release note**:
NONE.