### PR TITLE
fix: evict inode cache when dealing with Forget

### DIFF
--- a/client/fs/dir.go
+++ b/client/fs/dir.go
@@ -112,6 +112,8 @@ func (d *Dir) Forget() {
 		log.LogDebugf("TRACE Forget: ino(%v)", ino)
 	}()
 
+	d.super.ic.Delete(ino)
+
 	d.super.fslock.Lock()
 	delete(d.super.nodeCache, ino)
 	d.super.fslock.Unlock()

--- a/client/fs/file.go
+++ b/client/fs/file.go
@@ -91,6 +91,8 @@ func (f *File) Forget() {
 		log.LogDebugf("TRACE Forget: ino(%v)", ino)
 	}()
 
+	f.super.ic.Delete(ino)
+
 	f.super.fslock.Lock()
 	delete(f.super.nodeCache, ino)
 	f.super.fslock.Unlock()


### PR DESCRIPTION
Evict the inode cache upon receiving Forget request, just in case the
background expire eviction is not as fast as file creation and memory
consumption keeps going up.

Signed-off-by: Shuoran Liu <shuoranliu@gmail.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
