### PR TITLE
Refactor: Optimize small file write performance

### DIFF
--- a/storage/extent.go
+++ b/storage/extent.go
@@ -178,10 +178,6 @@ func (e *Extent) WriteTiny(data []byte, offset, size int64, crc uint32, writeTyp
 	e.Lock()
 	defer e.Unlock()
 	index := offset + size
-	if index >= math.MaxUint32 {
-		return ExtentIsFullError
-	}
-
 	if IsAppendWrite(writeType) && offset != e.dataSize {
 		return ParameterMismatchError
 	}


### PR DESCRIPTION
The scenario is as follows: The client keeps writing small files and
deleting these small files, which will cause the size of tinyExtent
under dataPartition to exceed 4GB, but this dataPartition is still
writable, so remove the 4GB limit. The tinyExtent of these
dataPartitions can still be written, which can greatly reduce the number
of dataPartitions allocated

Signed-off-by: awzhgw <guowl18702995996@gmail.com>

