### PR TITLE
Fix: datestamp validation on signature v4

### DIFF
--- a/docker/conf/nginx.conf
+++ b/docker/conf/nginx.conf
@@ -51,10 +51,11 @@ http {
         location / {
             proxy_pass http://objectnodes;
 
-            proxy_http_version 1.1;
-            proxy_set_header Host $http_host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_http_version  1.1;
+            proxy_set_header    Host $http_host;
+            proxy_set_header    X-Real-IP $remote_addr;
+            proxy_set_header    X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header    Expect $http_Expect;
 
             access_log  /tmp/object_access.log main;
             error_log  /tmp/object_error.log warn;
@@ -69,10 +70,11 @@ http {
         location / {
             proxy_pass http://masters;
 
-            proxy_http_version 1.1;
-            proxy_set_header Host $http_host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_http_version  1.1;
+            proxy_set_header    Host $http_host;
+            proxy_set_header    X-Real-IP $remote_addr;
+            proxy_set_header    X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header    Expect $http_Expect;
 
             access_log  /tmp/master_access.log main;
             error_log  /tmp/master_error.log warn;

--- a/docker/conf/nginx.conf
+++ b/docker/conf/nginx.conf
@@ -55,7 +55,7 @@ http {
             proxy_set_header    Host $http_host;
             proxy_set_header    X-Real-IP $remote_addr;
             proxy_set_header    X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header    Expect $http_Expect;
+            proxy_set_header    X-Forwarded-Expect $http_Expect;
 
             access_log  /tmp/object_access.log main;
             error_log  /tmp/object_error.log warn;
@@ -74,7 +74,6 @@ http {
             proxy_set_header    Host $http_host;
             proxy_set_header    X-Real-IP $remote_addr;
             proxy_set_header    X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header    Expect $http_Expect;
 
             access_log  /tmp/master_access.log main;
             error_log  /tmp/master_error.log warn;

--- a/docker/s3tests/test_put_object.py
+++ b/docker/s3tests/test_put_object.py
@@ -32,6 +32,18 @@ def random_str(length):
     return result
 
 
+def random_bytes(length):
+    """
+    Generate random content with specified length
+    :param length:
+    :return: bytes content
+    """
+    f = open('/dev/random', 'rb')
+    data = f.read(length)
+    f.close()
+    return data
+
+
 class TestPutObject(unittest2.TestCase):
 
     def __init__(self, case):
@@ -75,7 +87,7 @@ class TestPutObject(unittest2.TestCase):
 
     def __do_test_put_object(self, file_name, file_size):
         key = file_name
-        body = bytes(random_str(file_size), 'utf-8')
+        body = random_bytes(file_size)
         md5 = hashlib.md5()
         md5.update(body)
         expect_etag = md5.hexdigest()
@@ -90,7 +102,8 @@ class TestPutObject(unittest2.TestCase):
         # get object
         response = self.s3.get_object(Bucket=bucket, Key=key)
         self.assertEqual(response['ResponseMetadata']['HTTPStatusCode'], 200)
-        self.assertEqual(response['ETag'], expect_etag)
+        actual_etag = response['ETag']
+        self.assertEqual(actual_etag, expect_etag)
         response_body = response['Body']
         response_data = response_body.read()
         md5 = hashlib.md5()

--- a/docker/script/run_test.sh
+++ b/docker/script/run_test.sh
@@ -64,7 +64,7 @@ create_cluster_user() {
     # check user exist
     ${cli} user info ${Owner} &> /dev/null
     if [[ $? -eq 0 ]] ; then
-        echo -e "\033[32m[exist]\033[0m"
+        echo -e "\033[32mdone\033[0m"
         return
     fi
     # try create user

--- a/objectnode/const.go
+++ b/objectnode/const.go
@@ -33,6 +33,9 @@ const (
 	HeaderNameAcceptRange   = "Accept-Ranges"
 	HeaderNameRange         = "Range"
 
+	HeaderNameExpect           = "Expect"
+	HeaderNameXForwardedExpect = "X-Forwarded-Expect"
+
 	// Headers for CORS validation
 	HeaderNameAccessControlAllowOrigin  = "Access-Control-Allow-Origin"
 	HeaderNameAccessControlAllowMethods = "Access-Control-Allow-Methods"

--- a/objectnode/server.go
+++ b/objectnode/server.go
@@ -223,6 +223,7 @@ func (o *ObjectNode) startMuxRestAPI() (err error) {
 	router := mux.NewRouter().SkipClean(true)
 	o.registerApiRouters(router)
 	router.Use(
+		o.expectMiddleware,
 		o.corsMiddleware,
 		o.traceMiddleware,
 		o.authMiddleware,


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1. **Fix: datestamp validation on signature v4.**

Refer to the description of the calculation process of the signature
algorithm v4 in the API Reference document of AWS S3. Each signature is
valid for 7 days.

> Scope binds the resulting signature to a specific date, an AWS Region, and a service. Thus, your resulting signature will work only in the specific Region and for a specific service. The signature is valid for seven days after the specified date.

Reference:
[Signature Calculations for the Authorization Header: Transferring Payload in a Single Chunk (AWS Signature Version 4) - Amazon Simple Storage Service](https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html)

2. **Improve compatibility with nginx.**

The `Expect` header of HTTP is a special header. When nginx is used as the reverse proxy in the front end of ObjectNode, nginx will process the Expect header information in advance, send the http status code `100-continue` to  the client, and will not forward this header information to ObjectNode.

At this time, if the client request uses the Expect header when signing, it will cause the ObjectNode to verify the signature.

A workaround is used here to solve this problem. Add the following configuration in Nginx:
```
proxy_set_header X-Forwarded-Expect $ http_Expect
```

In this way, nginx will not only automatically handle the `Expect` handshake, but also send the original value of Expect to the ObjectNode through `X-Forwarded-Expect`. ObjectNode only needs to use the value of `X-Forwarded-Expect`.

**Which issue this PR fixes**:
NONE.

**Special notes for your reviewer**:
NONE.

**Release note**:
NONE.