### PR TITLE
feature: introduce debug freeosmemory

### DIFF
--- a/client/fuse.go
+++ b/client/fuse.go
@@ -32,6 +32,7 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+	"runtime/debug"
 	"strings"
 	"syscall"
 
@@ -65,8 +66,9 @@ const (
 	ModuleName            = "fuseclient"
 	ConfigKeyExporterPort = "exporterKey"
 
-	ControlCommandSetRate = "/rate/set"
-	ControlCommandGetRate = "/rate/get"
+	ControlCommandSetRate      = "/rate/set"
+	ControlCommandGetRate      = "/rate/get"
+	ControlCommandFreeOSMemory = "/debug/freeosmemory"
 )
 
 var (
@@ -240,6 +242,7 @@ func mount(opt *proto.MountOptions) (fsConn *fuse.Conn, super *cfs.Super, err er
 	http.HandleFunc(ControlCommandSetRate, super.SetRate)
 	http.HandleFunc(ControlCommandGetRate, super.GetRate)
 	http.HandleFunc(log.SetLogLevelPath, log.SetLogLevel)
+	http.HandleFunc(ControlCommandFreeOSMemory, freeOSMemory)
 	go func() {
 		if opt.Profport != "" {
 			syslog.Println("Start pprof with port:", opt.Profport)
@@ -419,4 +422,8 @@ func changeRlimit(val uint64) {
 	} else {
 		syslog.Printf("Successfully set rlimit to %v \n", val)
 	}
+}
+
+func freeOSMemory(w http.ResponseWriter, r *http.Request) {
+	debug.FreeOSMemory()
 }


### PR DESCRIPTION
This commit introduces a debug interface "/debug/freeosmemory" to trigger
garbage collection manually.

Signed-off-by: Shuoran Liu <shuoranliu@gmail.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
