### PR TITLE
Multiple enhancements and issue fixes

### DIFF
--- a/cli/cmd/fmt.go
+++ b/cli/cmd/fmt.go
@@ -90,14 +90,14 @@ func formatVolumeStatus(status uint8) string {
 }
 
 var (
-	volumeInfoTablePattern = "%-32v    %-10v    %-8v    %-8v    %-8v    %-10v"
+	volumeInfoTablePattern = "%-63v    %-20v    %-8v    %-8v    %-8v    %-10v"
 	volumeInfoTableHeader  = fmt.Sprintf(volumeInfoTablePattern, "VOLUME", "OWNER", "USED", "TOTAL", "STATUS", "CREATE TIME")
 )
 
 func formatVolInfoTableRow(vi *proto.VolInfo) string {
 	return fmt.Sprintf(volumeInfoTablePattern,
 		vi.Name, vi.Owner, formatSize(vi.UsedSize), formatSize(vi.TotalSize),
-		formatVolumeStatus(vi.Status), time.Unix(vi.CreateTime, 0))
+		formatVolumeStatus(vi.Status), time.Unix(vi.CreateTime, 0).Local().Format(time.RFC1123))
 }
 
 var (
@@ -131,7 +131,7 @@ func formatMetaPartitionTableRow(view *proto.MetaPartitionView) string {
 }
 
 var (
-	userInfoTablePattern = "%-10v    %-6v    %-16v    %-32v    %-10v"
+	userInfoTablePattern = "%-20v    %-6v    %-16v    %-32v    %-10v"
 	userInfoTableHeader  = fmt.Sprintf(userInfoTablePattern,
 		"ID", "TYPE", "ACCESS KEY", "SECRET KEY", "CREATE TIME")
 )

--- a/cli/cmd/user.go
+++ b/cli/cmd/user.go
@@ -371,7 +371,6 @@ func newUserListCmd(client *master.MasterClient) *cobra.Command {
 			if users, err = client.UserAPI().ListUsers(optKeyword); err != nil {
 				return
 			}
-			stdout("[Users]\n")
 			stdout("%v\n", userInfoTableHeader)
 			for _, user := range users {
 				stdout("%v\n", formatUserInfoTableRow(user))

--- a/cli/cmd/vol.go
+++ b/cli/cmd/vol.go
@@ -76,7 +76,6 @@ func newVolListCmd(client *master.MasterClient) *cobra.Command {
 			if vols, err = client.AdminAPI().ListVols(optKeyword); err != nil {
 				return
 			}
-			stdout("[Volumes]\n")
 			stdout("%v\n", volumeInfoTableHeader)
 			for _, vol := range vols {
 				stdout("%v\n", formatVolInfoTableRow(vol))
@@ -173,7 +172,7 @@ func newVolInfoCmd(client *master.MasterClient) *cobra.Command {
 				os.Exit(1)
 			}
 			// print summary info
-			stdout("[Summary]\n%s\n", formatSimpleVolView(svv))
+			stdout("Summary:\n%s\n", formatSimpleVolView(svv))
 
 			// print metadata detail
 			if optMetaDetail {
@@ -182,7 +181,7 @@ func newVolInfoCmd(client *master.MasterClient) *cobra.Command {
 					errout("Get volume metadata detail information failed:\n%v\n", err)
 					os.Exit(1)
 				}
-				stdout("[Meta partitions]\n")
+				stdout("Meta partitions:\n")
 				stdout("%v\n", metaPartitionTableHeader)
 				sort.SliceStable(views, func(i, j int) bool {
 					return views[i].PartitionID < views[j].PartitionID
@@ -199,7 +198,7 @@ func newVolInfoCmd(client *master.MasterClient) *cobra.Command {
 					errout("Get volume data detail information failed:\n%v\n", err)
 					os.Exit(1)
 				}
-				stdout("[Data partitions]\n")
+				stdout("Data partitions:\n")
 				stdout("%v\n", dataPartitionTableHeader)
 				sort.SliceStable(view.DataPartitions, func(i, j int) bool {
 					return view.DataPartitions[i].PartitionID < view.DataPartitions[j].PartitionID

--- a/docker/s3tests/base.py
+++ b/docker/s3tests/base.py
@@ -1,0 +1,221 @@
+# Copyright 2020 The ChubaoFS Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+# -*- coding: utf-8 -*-
+import boto3
+import hashlib
+import json
+import random
+import requests
+import time
+from botocore.config import Config
+from botocore.exceptions import ClientError
+from unittest2 import TestCase
+
+import env
+
+
+def random_string(length):
+    seed = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
+    result = ''
+    while len(result) <= length:
+        result += random.choice(seed)
+    return result
+
+
+def random_string_cn(length):
+    result = ''
+    while len(result) <= length:
+        result += chr(random.randint(0x4e00, 0x9fbf))
+    return result
+
+
+def random_bytes(length):
+    """
+    Generate random content with specified length
+    :param length:
+    :return: bytes content
+    """
+    f = open('/dev/random', 'rb')
+    data = f.read(length)
+    f.close()
+    return data
+
+
+def compute_md5(data):
+    md5 = hashlib.md5()
+    md5.update(data)
+    return md5.hexdigest()
+
+
+def generate_file(path, size):
+    """
+    :type path: str
+    :param path: File path
+    :type size: int
+    :param size: File size
+    :rtype string
+    :return: file MD5
+    """
+    data = random_bytes(size)
+    md5 = compute_md5(data)
+    f = open(path, 'wb+')
+    f.write(data)
+    f.flush()
+    f.close()
+    return md5
+
+
+def wait_future_done(future, timeout=0):
+    """
+    :type future: future
+    :param future:
+    :type timeout: int
+    :param timeout:
+    :rtype bool
+    :return: done
+    """
+    loop = 0
+    while True:
+        if future.done() is True:
+            break
+        time.sleep(0.1)
+        loop += 1
+        if loop == 10 * timeout:
+            return False
+    return True
+
+
+def get_env_s3_client(signature_version='s3v4'):
+    return boto3.client(
+        's3',
+        aws_access_key_id=env.ACCESS_KEY,
+        aws_secret_access_key=env.SECRET_KEY,
+        endpoint_url=env.ENDPOINT,
+        use_ssl=env.USE_SSL,
+        config=Config(signature_version=signature_version))
+
+
+def get_env_s3_client_volume_credential(signature_version='s3v4'):
+    resp = requests.get(
+        url=env.MASTER + '/client/vol?name=%s' % env.BUCKET,
+        headers={
+            'Skip-Owner-Validation': 'true'
+        })
+    assert resp.status_code == 200
+    content = json.loads(resp.content.decode())
+    assert 'code' in content
+    assert content['code'] == 0
+    assert ('data' in content)
+    data = content['data']
+    assert 'OSSSecure' in data
+    credential = data['OSSSecure']
+    access_key = credential['AccessKey']
+    secret_key = credential['SecretKey']
+    assert access_key != ''
+    assert secret_key != ''
+    return boto3.client(
+        's3',
+        aws_access_key_id=access_key,
+        aws_secret_access_key=secret_key,
+        endpoint_url=env.ENDPOINT,
+        use_ssl=env.USE_SSL,
+        config=Config(signature_version=signature_version))
+
+
+class S3TestCase(TestCase):
+
+    def assert_head_bucket_result(self, result):
+        self.assertNotEqual(result, None)
+        self.assertEqual(type(result), dict)
+        self.assertTrue('ResponseMetadata' in result)
+        self.assertTrue('HTTPStatusCode' in result['ResponseMetadata'])
+        self.assertEqual(result['ResponseMetadata']['HTTPStatusCode'], 200)
+
+    def assert_get_bucket_location_result(self, result, location=None):
+        self.assertNotEqual(result, None)
+        self.assertEqual(type(result), dict)
+        self.assertTrue('ResponseMetadata' in result)
+        self.assertTrue('HTTPStatusCode' in result['ResponseMetadata'])
+        self.assertEqual(result['ResponseMetadata']['HTTPStatusCode'], 200)
+        if location is not None:
+            self.assertTrue('LocationConstraint' in result)
+            self.assertEqual(result['LocationConstraint'], location)
+
+    def assert_head_object_result(self, result, etag=None, content_type=None, content_length=None):
+        self.assertNotEqual(result, None)
+        self.assertEqual(type(result), dict)
+        self.assertTrue('ResponseMetadata' in result)
+        self.assertTrue('HTTPStatusCode' in result['ResponseMetadata'])
+        self.assertEqual(result['ResponseMetadata']['HTTPStatusCode'], 200)
+        if etag is not None:
+            self.assertEqual(result['ETag'].strip('"'), etag.strip('"'))
+        if content_type is not None:
+            self.assertEqual(result['ResponseMetadata']['HTTPHeaders']['content-type'], content_type)
+        if content_length is not None:
+            self.assertEqual(result['ResponseMetadata']['HTTPHeaders']['content-length'], str(content_length))
+
+    def assert_get_object_result(self, result, etag=None, content_type=None, content_length=None, body_md5=None):
+        self.assertNotEqual(result, None)
+        self.assertEqual(type(result), dict)
+        self.assertTrue('ResponseMetadata' in result)
+        self.assertTrue('HTTPStatusCode' in result['ResponseMetadata'])
+        self.assertEqual(result['ResponseMetadata']['HTTPStatusCode'], 200)
+        if etag is not None:
+            self.assertEqual(result['ETag'].strip('"'), etag.strip('"'))
+        if content_type is not None:
+            self.assertEqual(result['ResponseMetadata']['HTTPHeaders']['content-type'], content_type)
+        if content_length is not None:
+            self.assertEqual(result['ResponseMetadata']['HTTPHeaders']['content-length'], str(content_length))
+        if body_md5 is not None:
+            self.assertTrue('Body' in result)
+            body = result['Body'].read()
+            self.assertEqual(compute_md5(body), body_md5)
+
+    def assert_put_object_result(self, result, etag=None, content_type=None, content_length=None):
+        self.assertNotEqual(result, None)
+        self.assertEqual(type(result), dict)
+        self.assertTrue('ResponseMetadata' in result)
+        self.assertTrue('HTTPStatusCode' in result['ResponseMetadata'])
+        self.assertEqual(result['ResponseMetadata']['HTTPStatusCode'], 200)
+        if etag is not None:
+            self.assertEqual(result['ETag'].strip('"'), etag.strip('"'))
+        if content_type is not None:
+            self.assertEqual(result['ResponseMetadata']['HTTPHeaders']['content-type'], content_type)
+        if content_length is not None:
+            self.assertEqual(result['ResponseMetadata']['HTTPHeaders']['content-length'], str(content_length))
+
+    def assert_delete_object_result(self, result):
+        self.assertNotEqual(result, None)
+        self.assertEqual(type(result), dict)
+        self.assertTrue('ResponseMetadata' in result)
+        self.assertTrue('HTTPStatusCode' in result['ResponseMetadata'])
+        self.assertEqual(result['ResponseMetadata']['HTTPStatusCode'], 204)
+
+    def assert_delete_objects_result(self, result):
+        self.assertNotEqual(result, None)
+        self.assertEqual(type(result), dict)
+        self.assertTrue('ResponseMetadata' in result)
+        self.assertTrue('HTTPStatusCode' in result['ResponseMetadata'])
+        self.assertEqual(result['ResponseMetadata']['HTTPStatusCode'], 200)
+
+    def assert_client_error(self, error, expect_code):
+        self.assertNotEqual(error, None)
+        self.assertEqual(type(error), ClientError)
+        self.assertTrue(hasattr(error, 'response'))
+        self.assertEqual(type(error.response), dict)
+        self.assertTrue('Error' in error.response)
+        self.assertTrue(type(error.response['Error']), dict)
+        self.assertTrue('Code' in error.response['Error'])
+        self.assertEqual(error.response['Error']['Code'], str(expect_code))

--- a/docker/s3tests/base.py
+++ b/docker/s3tests/base.py
@@ -197,18 +197,35 @@ class S3TestCase(TestCase):
             self.assertEqual(result['ResponseMetadata']['HTTPHeaders']['content-length'], str(content_length))
 
     def assert_delete_object_result(self, result):
-        self.assertNotEqual(result, None)
-        self.assertEqual(type(result), dict)
-        self.assertTrue('ResponseMetadata' in result)
-        self.assertTrue('HTTPStatusCode' in result['ResponseMetadata'])
-        self.assertEqual(result['ResponseMetadata']['HTTPStatusCode'], 204)
+        self.assert_result_status_code(result=result, status_code=204)
 
     def assert_delete_objects_result(self, result):
+        self.assert_result_status_code(result, status_code=200)
+
+    def assert_put_tagging_result(self, result):
+        self.assert_result_status_code(result=result, status_code=200)
+
+    def assert_get_tagging_result(self, result, expect_tag_set=None):
+        self.assert_result_status_code(result=result, status_code=200)
+        if expect_tag_set is not None:
+            if len(expect_tag_set) > 0:
+                self.assertTrue('TagSet' in result)
+                self.assertEqual(type(result['TagSet']), list)
+                self.assertEqual(len(result['TagSet']), len(expect_tag_set))
+                for expect_tag in expect_tag_set:
+                    self.assertTrue(expect_tag in result['TagSet'])
+            else:
+                self.assertTrue(len(result['TagSet']) == 0 if 'TagSet' in result else True)
+
+    def assert_delete_tagging_result(self, result):
+        self.assert_result_status_code(result=result, status_code=204)
+
+    def assert_result_status_code(self, result, status_code=200):
         self.assertNotEqual(result, None)
         self.assertEqual(type(result), dict)
         self.assertTrue('ResponseMetadata' in result)
         self.assertTrue('HTTPStatusCode' in result['ResponseMetadata'])
-        self.assertEqual(result['ResponseMetadata']['HTTPStatusCode'], 200)
+        self.assertEqual(result['ResponseMetadata']['HTTPStatusCode'], status_code)
 
     def assert_client_error(self, error, expect_status_code=None, expect_code=None):
         self.assertNotEqual(error, None)

--- a/docker/s3tests/base.py
+++ b/docker/s3tests/base.py
@@ -210,12 +210,18 @@ class S3TestCase(TestCase):
         self.assertTrue('HTTPStatusCode' in result['ResponseMetadata'])
         self.assertEqual(result['ResponseMetadata']['HTTPStatusCode'], 200)
 
-    def assert_client_error(self, error, expect_code):
+    def assert_client_error(self, error, expect_status_code=None, expect_code=None):
         self.assertNotEqual(error, None)
         self.assertEqual(type(error), ClientError)
         self.assertTrue(hasattr(error, 'response'))
         self.assertEqual(type(error.response), dict)
-        self.assertTrue('Error' in error.response)
-        self.assertTrue(type(error.response['Error']), dict)
-        self.assertTrue('Code' in error.response['Error'])
-        self.assertEqual(error.response['Error']['Code'], str(expect_code))
+        if expect_status_code is not None:
+            response = error.response
+            self.assertTrue('ResponseMetadata' in response)
+            self.assertTrue('HTTPStatusCode' in response['ResponseMetadata'])
+            self.assertEqual(response['ResponseMetadata']['HTTPStatusCode'], expect_status_code)
+        if expect_code is not None:
+            self.assertTrue('Error' in error.response)
+            self.assertTrue(type(error.response['Error']), dict)
+            self.assertTrue('Code' in error.response['Error'])
+            self.assertEqual(error.response['Error']['Code'], str(expect_code))

--- a/docker/s3tests/base.py
+++ b/docker/s3tests/base.py
@@ -153,18 +153,21 @@ class S3TestCase(TestCase):
             self.assertTrue('LocationConstraint' in result)
             self.assertEqual(result['LocationConstraint'], location)
 
-    def assert_head_object_result(self, result, etag=None, content_type=None, content_length=None):
-        self.assertNotEqual(result, None)
-        self.assertEqual(type(result), dict)
-        self.assertTrue('ResponseMetadata' in result)
-        self.assertTrue('HTTPStatusCode' in result['ResponseMetadata'])
-        self.assertEqual(result['ResponseMetadata']['HTTPStatusCode'], 200)
+    def assert_head_object_result(self, result, etag=None, content_type=None, content_length=None, metadata=None):
+        self.assert_result_status_code(result=result, status_code=200)
         if etag is not None:
             self.assertEqual(result['ETag'].strip('"'), etag.strip('"'))
         if content_type is not None:
             self.assertEqual(result['ResponseMetadata']['HTTPHeaders']['content-type'], content_type)
         if content_length is not None:
             self.assertEqual(result['ResponseMetadata']['HTTPHeaders']['content-length'], str(content_length))
+        if metadata is not None:
+            if len(metadata) > 0:
+                self.assertTrue('Metadata' in result)
+                self.assertEqual(type(result['Metadata']), dict)
+                self.assertEqual(result['Metadata'], metadata)
+            else:
+                self.assertTrue(len(result['Metadata']) == 0 if 'Metadata' in result else True)
 
     def assert_get_object_result(self, result, etag=None, content_type=None, content_length=None, body_md5=None):
         self.assertNotEqual(result, None)

--- a/docker/s3tests/env.py
+++ b/docker/s3tests/env.py
@@ -1,0 +1,23 @@
+# Copyright 2020 The ChubaoFS Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+# -*- coding: utf-8 -*-
+
+MASTER = 'http://master.chubao.io'
+ENDPOINT = 'http://object.chubao.io'
+ACCESS_KEY = '39bEF4RrAQgMj6RV'
+SECRET_KEY = 'TRL6o3JL16YOqvZGIohBDFTHZDEcFsyd'
+BUCKET = 'ltptest'
+USE_SSL = False
+REGION = 'chubaofs01'

--- a/docker/s3tests/requirements.txt
+++ b/docker/s3tests/requirements.txt
@@ -1,3 +1,3 @@
-boto3 >=1.0.0
+boto3>=1.0.0
 unittest2
 requests

--- a/docker/s3tests/test_bucket.py
+++ b/docker/s3tests/test_bucket.py
@@ -1,0 +1,39 @@
+# Copyright 2020 The ChubaoFS Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+# -*- coding: utf-8 -*-
+
+import env
+from base import S3TestCase, get_env_s3_client
+
+
+class BucketTest(S3TestCase):
+    s3 = None
+
+    def __init__(self, case):
+        super(BucketTest, self).__init__(case)
+        self.s3 = get_env_s3_client()
+
+    def test_head_bucket(self):
+        self.assert_head_bucket_result(self.s3.head_bucket(Bucket=env.BUCKET))
+
+    def test_get_bucket_location(self):
+        self.assert_get_bucket_location_result(
+            result=self.s3.get_bucket_location(Bucket=env.BUCKET),
+            location=env.REGION)
+
+    def test_list_buckets(self):
+        response = self.s3.list_buckets()
+        buckets = response['Buckets']
+        self.assertGreater(len(buckets), 0)

--- a/docker/s3tests/test_object_head.py
+++ b/docker/s3tests/test_object_head.py
@@ -1,0 +1,172 @@
+# Copyright 2020 The ChubaoFS Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+# -*- coding: utf-8 -*-
+import datetime
+
+import env
+from base import S3TestCase
+from base import random_string, random_bytes, compute_md5, get_env_s3_client
+
+KEY_PREFIX = 'test-object-head/'
+
+
+class ObjectHeadTest(S3TestCase):
+    s3 = None
+
+    def __init__(self, case):
+        super(ObjectHeadTest, self).__init__(case)
+        self.s3 = get_env_s3_client()
+
+    def test_head_object(self):
+        size = 1024 * 256
+        self.assert_head_bucket_result(self.s3.head_bucket(Bucket=env.BUCKET))
+        key = KEY_PREFIX + random_string(16)
+        body = random_bytes(size)
+        expect_md5 = compute_md5(body)
+        self.assert_put_object_result(
+            result=self.s3.put_object(Bucket=env.BUCKET, Key=key, Body=body),
+            etag=expect_md5)
+        self.assert_head_object_result(
+            result=self.s3.head_object(Bucket=env.BUCKET, Key=key), etag=expect_md5,
+            content_length=size)
+        self.assert_delete_object_result(
+            result=self.s3.delete_object(Bucket=env.BUCKET, Key=key))
+        self.assert_delete_object_result(
+            result=self.s3.delete_object(Bucket=env.BUCKET, Key=KEY_PREFIX))
+        try:
+            self.s3.head_object(Bucket=env.BUCKET, Key=key)
+            self.fail()  # Non exception occurred is illegal.
+        except Exception as e:
+            # Error code 404 is legal.
+            self.assert_client_error(e, 404)
+
+    def test_head_object_if_match(self):
+        size = 1024 * 256
+        self.assert_head_bucket_result(
+            result=self.s3.head_bucket(Bucket=env.BUCKET))
+        key = KEY_PREFIX + random_string(16)
+        body = random_bytes(size)
+        expect_md5 = compute_md5(body)
+        self.assert_put_object_result(
+            result=self.s3.put_object(Bucket=env.BUCKET, Key=key, Body=body),
+            etag=expect_md5)
+        self.assert_head_object_result(
+            result=self.s3.head_object(Bucket=env.BUCKET, Key=key, IfMatch=expect_md5),
+            etag=expect_md5,
+            content_length=size)
+        try:
+            fake_etag = '1b2cf535f27731c974343645a3985328'
+            self.s3.head_object(Bucket=env.BUCKET, Key=key, IfMatch=fake_etag)
+            self.fail()  # Non exception occurred is illegal.
+        except Exception as e:
+            # Error code 412 is legal.
+            self.assert_client_error(
+                error=e,
+                expect_code=412)
+        self.assert_delete_object_result(
+            result=self.s3.delete_object(Bucket=env.BUCKET, Key=key))
+        self.assert_delete_object_result(
+            result=self.s3.delete_object(Bucket=env.BUCKET, Key=KEY_PREFIX))
+
+    def test_head_object_if_modified_since(self):
+        size = 1024 * 256
+        self.assert_head_bucket_result(
+            result=self.s3.head_bucket(Bucket=env.BUCKET))
+        key = KEY_PREFIX + random_string(16)
+        body = random_bytes(size)
+        expect_md5 = compute_md5(body)
+        self.assert_put_object_result(
+            result=self.s3.put_object(Bucket=env.BUCKET, Key=key, Body=body),
+            etag=expect_md5)
+        self.assert_head_object_result(
+            result=self.s3.head_object(
+                Bucket=env.BUCKET,
+                Key=key,
+                IfModifiedSince=datetime.datetime(1946, 2, 14)),
+            etag=expect_md5,
+            content_length=size)
+        try:
+            self.s3.head_object(
+                Bucket=env.BUCKET,
+                Key=key,
+                IfModifiedSince=datetime.datetime.now())
+            self.fail()  # Non exception occurred is illegal.
+        except Exception as e:
+            # Error code 304 is legal.
+            self.assert_client_error(
+                error=e,
+                expect_code=304)
+        self.assert_delete_object_result(
+            result=self.s3.delete_object(Bucket=env.BUCKET, Key=key))
+        self.assert_delete_object_result(
+            result=self.s3.delete_object(Bucket=env.BUCKET, Key=KEY_PREFIX))
+
+    def test_head_object_if_none_match(self):
+        size = 1024 * 256
+        self.assert_head_bucket_result(
+            result=self.s3.head_bucket(Bucket=env.BUCKET))
+        key = KEY_PREFIX + random_string(16)
+        body = random_bytes(size)
+        expect_md5 = compute_md5(body)
+        self.assert_put_object_result(
+            result=self.s3.put_object(Bucket=env.BUCKET, Key=key, Body=body),
+            etag=expect_md5)
+        fake_etag = '1b2cf535f27731c974343645a3985328'
+        self.assert_head_object_result(
+            result=self.s3.head_object(
+                Bucket=env.BUCKET,
+                Key=key,
+                IfNoneMatch=fake_etag),
+            etag=expect_md5,
+            content_length=size)
+        try:
+            self.s3.head_object(Bucket=env.BUCKET, Key=key, IfNoneMatch=expect_md5)
+            self.fail()  # Non exception occurred is illegal.
+        except Exception as e:
+            # Error code 304 is legal.
+            self.assert_client_error(error=e, expect_code=304)
+        self.assert_delete_object_result(
+            result=self.s3.delete_object(Bucket=env.BUCKET, Key=key))
+        self.assert_delete_object_result(
+            result=self.s3.delete_object(Bucket=env.BUCKET, Key=KEY_PREFIX))
+
+    def test_head_object_if_unmodified_since(self):
+        size = 1024 * 256
+        self.assert_head_bucket_result(
+            result=self.s3.head_bucket(Bucket=env.BUCKET))
+        key = KEY_PREFIX + random_string(16)
+        body = random_bytes(size)
+        expect_md5 = compute_md5(body)
+        self.assert_put_object_result(
+            result=self.s3.put_object(Bucket=env.BUCKET, Key=key, Body=body),
+            etag=expect_md5)
+        self.assert_head_object_result(
+            result=self.s3.head_object(
+                Bucket=env.BUCKET,
+                Key=key,
+                IfUnmodifiedSince=datetime.datetime.now()),
+            etag=expect_md5,
+            content_length=size)
+        try:
+            self.s3.head_object(Bucket=env.BUCKET, Key=key, IfUnmodifiedSince=datetime.datetime(1946, 2, 14))
+            self.fail()  # Non exception occurred is illegal.
+        except Exception as e:
+            # Error code 412 is legal.
+            self.assert_client_error(
+                error=e, expect_code=412)
+        self.assert_delete_object_result(
+            result=self.s3.delete_object(Bucket=env.BUCKET, Key=key))
+        self.assert_delete_object_result(
+            result=self.s3.delete_object(Bucket=env.BUCKET, Key=KEY_PREFIX))

--- a/docker/s3tests/test_object_head.py
+++ b/docker/s3tests/test_object_head.py
@@ -50,7 +50,7 @@ class ObjectHeadTest(S3TestCase):
             self.fail()  # Non exception occurred is illegal.
         except Exception as e:
             # Error code 404 is legal.
-            self.assert_client_error(e, 404)
+            self.assert_client_error(e, expect_status_code=404)
 
     def test_head_object_if_match(self):
         size = 1024 * 256
@@ -72,9 +72,7 @@ class ObjectHeadTest(S3TestCase):
             self.fail()  # Non exception occurred is illegal.
         except Exception as e:
             # Error code 412 is legal.
-            self.assert_client_error(
-                error=e,
-                expect_code=412)
+            self.assert_client_error(error=e, expect_status_code=412)
         self.assert_delete_object_result(
             result=self.s3.delete_object(Bucket=env.BUCKET, Key=key))
         self.assert_delete_object_result(
@@ -105,9 +103,7 @@ class ObjectHeadTest(S3TestCase):
             self.fail()  # Non exception occurred is illegal.
         except Exception as e:
             # Error code 304 is legal.
-            self.assert_client_error(
-                error=e,
-                expect_code=304)
+            self.assert_client_error(error=e, expect_status_code=304)
         self.assert_delete_object_result(
             result=self.s3.delete_object(Bucket=env.BUCKET, Key=key))
         self.assert_delete_object_result(
@@ -136,7 +132,7 @@ class ObjectHeadTest(S3TestCase):
             self.fail()  # Non exception occurred is illegal.
         except Exception as e:
             # Error code 304 is legal.
-            self.assert_client_error(error=e, expect_code=304)
+            self.assert_client_error(error=e, expect_status_code=304)
         self.assert_delete_object_result(
             result=self.s3.delete_object(Bucket=env.BUCKET, Key=key))
         self.assert_delete_object_result(
@@ -165,7 +161,7 @@ class ObjectHeadTest(S3TestCase):
         except Exception as e:
             # Error code 412 is legal.
             self.assert_client_error(
-                error=e, expect_code=412)
+                error=e, expect_status_code=412)
         self.assert_delete_object_result(
             result=self.s3.delete_object(Bucket=env.BUCKET, Key=key))
         self.assert_delete_object_result(

--- a/docker/s3tests/test_object_put.py
+++ b/docker/s3tests/test_object_put.py
@@ -146,95 +146,95 @@ class ObjectPutTest(S3TestCase):
         self.assertEqual(response['ResponseMetadata']['HTTPStatusCode'], 200)
         assert 'Contents' not in response
 
-    def test_put_objects_override_no1_256___1kb(self):
+    def test_put_objects_override_scene1___1kb(self):
         """
-        This test uploads 256 file objects with a size of 1KB (override same file)
+        This test uploads 200 file objects with a size of 1KB (override same file)
         :return:
         """
         self.__do_test_put_objects_override(
             file_size=1024,
-            file_num=256)
+            file_num=200)
 
-    def test_put_objects_override_no2_128__10kb(self):
+    def test_put_objects_override_scene2__10kb(self):
         """
-        This test uploads 128 file objects with a size of 10KB (override same file)
+        This test uploads 100 file objects with a size of 10KB (override same file)
         :return:
         """
         self.__do_test_put_objects_override(
             file_size=1024 * 10,
-            file_num=128)
+            file_num=100)
 
-    def test_put_objects_override_no3__64_100kb(self):
+    def test_put_objects_override_scene3_100kb(self):
         """
-        This test uploads 64 file objects with a size of 100KB (override same file)
+        This test uploads 50 file objects with a size of 100KB (override same file)
         :return:
         """
         self.__do_test_put_objects_override(
             file_size=1024 * 100,
-            file_num=64)
+            file_num=50)
 
-    def test_put_objects_override_no4___8___1mb(self):
+    def test_put_objects_override_scene4___1mb(self):
         """
-        This test uploads 8 file objects with a size of 1MB (override same file)
+        This test uploads 10 file objects with a size of 1MB (override same file)
         :return:
         """
         self.__do_test_put_objects_override(
             file_size=1024 * 1024,
-            file_num=8)
+            file_num=10)
 
-    def test_put_objects_override_no5___4__10mb(self):
+    def test_put_objects_override_scene5__10mb(self):
         """
-        This test uploads 4 file objects with a size of 10MB (override same file)
+        This test uploads 5 file objects with a size of 10MB (override same file)
         :return:
         """
         self.__do_test_put_objects_override(
             file_size=1024 * 1024 * 10,
-            file_num=4)
+            file_num=5)
 
-    def test_put_objects_independent_no1_256___1kb(self):
+    def test_put_objects_independent_scene1___1kb(self):
         """
-        This test uploads 256 file objects with a size of 1KB (difference file)
+        This test uploads 200 file objects with a size of 1KB (difference file)
         :return:
         """
         self.__do_test_put_objects_independent(
             file_size=1024,
-            file_num=256)
+            file_num=200)
 
-    def test_put_objects_independent_no2_128__10kb(self):
+    def test_put_objects_independent_scene2__10kb(self):
         """
-        This test uploads 128 file objects with a size of 10KB (difference file)
+        This test uploads 100 file objects with a size of 10KB (difference file)
         :return:
         """
         self.__do_test_put_objects_independent(
             file_size=1024 * 10,
-            file_num=128)
+            file_num=100)
 
-    def test_put_objects_independent_no3__64_100kb(self):
+    def test_put_objects_independent_scene3_100kb(self):
         """
-        This test uploads 64 file objects with a size of 100KB (difference file)
+        This test uploads 50 file objects with a size of 100KB (difference file)
         :return:
         """
         self.__do_test_put_objects_independent(
             file_size=1024 * 100,
-            file_num=64)
+            file_num=50)
 
-    def test_put_objects_independent_no4___8___1mb(self):
+    def test_put_objects_independent_scene4___1mb(self):
         """
-        This test uploads 8 file objects with a size of 1MB (difference file)
+        This test uploads 10 file objects with a size of 1MB (difference file)
         :return:
         """
         self.__do_test_put_objects_independent(
             file_size=1024 * 1024,
-            file_num=8)
+            file_num=10)
 
-    def test_put_objects_independent_no5___4__10mb(self):
+    def test_put_objects_independent_scene5__10mb(self):
         """
-        This test uploads 4 file objects with a size of 10MB (difference file)
+        This test uploads 5 file objects with a size of 10MB (difference file)
         :return:
         """
         self.__do_test_put_objects_independent(
             file_size=1024 * 1024 * 10,
-            file_num=4)
+            file_num=5)
 
     def test_put_object_conflict_scene1(self):
         """
@@ -302,3 +302,33 @@ class ObjectPutTest(S3TestCase):
                     }
                 )
             )
+
+    def test_put_object_with_metadata(self):
+        """
+        This test tests put an object with user-defined metadata.
+        Test count: 10
+        :return:
+        """
+
+        def run():
+            key = KEY_PREFIX + random_string(16)
+            metadata = {
+                random_string(8).lower().capitalize(): random_string(16),
+                random_string(8).lower().capitalize(): random_string(16)
+            }
+            self.assert_put_object_result(
+                result=self.s3.put_object(
+                    Bucket=BUCKET,
+                    Key=key,
+                    Metadata=metadata))
+            self.assert_head_object_result(
+                result=self.s3.head_object(Bucket=BUCKET, Key=key),
+                metadata=metadata
+            )
+            self.assert_delete_objects_result(
+                result=self.s3.delete_objects(
+                    Bucket=BUCKET, Delete={'Objects': [{'Key': key}, {'Key': KEY_PREFIX}]}))
+
+        test_count = 10
+        for _ in range(test_count):
+            run()

--- a/docker/s3tests/test_signature.py
+++ b/docker/s3tests/test_signature.py
@@ -1,0 +1,209 @@
+# Copyright 2020 The ChubaoFS Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+# -*- coding: utf-8 -*-i
+import requests
+
+import env
+from base import S3TestCase, get_env_s3_client, get_env_s3_client_volume_credential
+from base import random_string, random_string_cn, random_bytes, compute_md5
+
+KEY_PREFIX = 'test-signature-%s/' % random_string(8)
+
+
+class SignatureTest(S3TestCase):
+
+    def __test_presign(self, s3, key=None):
+        """
+        :type s3: botocore.client.S3
+        :param s3: S3 client instance
+        :return: None
+        """
+        # Test head a bucket by presigned url.
+        url = s3.generate_presigned_url('head_bucket', Params={'Bucket': env.BUCKET})
+        response = requests.head(url)
+        self.assertEqual(response.status_code, 200)
+        response.close()
+
+        # Test head a bucket by expired presigned url.
+        url = s3.generate_presigned_url('head_bucket', Params={'Bucket': env.BUCKET}, ExpiresIn=-1)
+        response = requests.head(url)
+        self.assertEqual(response.status_code, 403)
+        response.close()
+
+        # Vars for followed tests
+        if key is None:
+            key = KEY_PREFIX + random_string(16)
+        body = random_bytes(1024)
+        expect_md5 = compute_md5(body)
+
+        # Test put an object by presigned url.
+        url = s3.generate_presigned_url('put_object', Params={'Bucket': env.BUCKET, 'Key': key})
+        response = requests.put(url=url, data=body)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue('Etag' in response.headers)
+        expect_etag = response.headers['ETag']
+        response.close()
+
+        # Test head an object by presigned url.
+        url = s3.generate_presigned_url('head_object', Params={'Bucket': env.BUCKET, 'Key': key})
+        response = requests.head(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue('Etag' in response.headers)
+        self.assertEqual(response.headers['ETag'], expect_etag)
+        response.close()
+
+        # Test get an object by presigned url.
+        url = s3.generate_presigned_url('get_object', Params={'Bucket': env.BUCKET, 'Key': key})
+        response = requests.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue('Etag' in response.headers)
+        self.assertEqual(response.headers['ETag'], expect_etag)
+        actual_md5 = compute_md5(response.content)
+        self.assertEqual(actual_md5, expect_md5)
+        response.close()
+
+        # Test delete an object by presigned url.
+        url = s3.generate_presigned_url('delete_object', Params={'Bucket': env.BUCKET, 'Key': key})
+        response = requests.delete(url)
+        self.assertEqual(response.status_code, 204)
+        response.close()
+
+        # Check deletion result
+        url = s3.generate_presigned_url('head_object', Params={'Bucket': env.BUCKET, 'Key': key})
+        response = requests.head(url)
+        self.assertEqual(response.status_code, 404)
+        response.close()
+
+        # Remove key prefix
+        url = s3.generate_presigned_url('delete_object', Params={'Bucket': env.BUCKET, 'Key': KEY_PREFIX})
+        response = requests.delete(url)
+        self.assertEqual(response.status_code, 204)
+        response.close()
+
+    def __test_sign(self, s3, key=None):
+        """
+        :type s3: botocore.client.S3
+        :param s3: S3 client instance
+        :return: None
+        """
+        # Test head a bucket
+        self.assert_head_bucket_result(
+            result=s3.head_bucket(Bucket=env.BUCKET))
+
+        # Vars for followed tests
+        if key is None:
+            key = KEY_PREFIX + random_string(16)
+        body = random_bytes(1024)
+        expect_md5 = compute_md5(body)
+
+        # Test put an object.
+        self.assert_put_object_result(
+            result=s3.put_object(Bucket=env.BUCKET, Key=key, Body=body),
+            etag=expect_md5)
+
+        # Test head an object.
+        self.assert_head_object_result(
+            result=s3.head_object(Bucket=env.BUCKET, Key=key),
+            etag=expect_md5)
+
+        # Test get an object.
+        self.assert_get_object_result(
+            result=s3.get_object(Bucket=env.BUCKET, Key=key),
+            etag=expect_md5,
+            content_length=1024,
+            body_md5=expect_md5)
+
+        # Test delete an object.
+        self.assert_delete_object_result(
+            result=s3.delete_object(Bucket=env.BUCKET, Key=key))
+
+        # Remove key prefix.
+        self.assert_delete_object_result(
+            result=s3.delete_object(Bucket=env.BUCKET, Key=KEY_PREFIX))
+
+    def test_signature_v2_en(self):
+        """
+        This test tests process under singed header with signature algorithm v2.
+        :return: None
+        """
+        self.__test_sign(
+            s3=get_env_s3_client(signature_version='s3'))
+
+    def test_signature_v2_cn(self):
+        """
+         This test tests process under singed header with signature algorithm v2.
+         Key consist by Chinese characters.
+         :return: None
+         """
+        self.__test_sign(
+            s3=get_env_s3_client(signature_version='s3'),
+            key=KEY_PREFIX + random_string_cn(16))
+
+    def test_signature_v2_presign_en(self):
+        """
+        This test tests process under presigned url with signature algorithm v2.
+        :return:
+        """
+        self.__test_presign(
+            s3=get_env_s3_client(signature_version='s3'))
+
+    def test_signature_v2_presign_cn(self):
+        """
+         This test tests process under presigned url with signature algorithm v2.
+         Key consist by Chinese characters.
+         :return:
+         """
+        self.__test_presign(
+            s3=get_env_s3_client(signature_version='s3'),
+            key=KEY_PREFIX + random_string_cn(16))
+
+    def test_signature_v4_en(self):
+        """
+        This test tests process under singed header with signature algorithm v4.
+        :return: None
+        """
+        self.__test_sign(
+            s3=get_env_s3_client())
+
+    def test_signature_v4_cn(self):
+        """
+        This test tests process under singed header with signature algorithm v4.
+        Key consist by Chinese characters.
+        :return: None
+        """
+        self.__test_sign(
+            s3=get_env_s3_client(),
+            key=random_string_cn(16))
+
+    def test_signature_v4_presign_en(self):
+        """
+        This test tests process under presigned url with signature algorithm v4.
+        :return: None
+        """
+        self.__test_presign(
+            s3=get_env_s3_client())
+
+    def test_signature_v4_presign_cn(self):
+        """
+        This test tests process under presigned url with signature algorithm v4.
+        Key consist by Chinese characters.
+        :return: None
+        """
+        self.__test_presign(
+            s3=get_env_s3_client(),
+            key=random_string_cn(16))
+
+    def test_signature_volume_credential(self):
+        self.__test_sign(get_env_s3_client_volume_credential())

--- a/docker/s3tests/test_tagging.py
+++ b/docker/s3tests/test_tagging.py
@@ -1,0 +1,129 @@
+# Copyright 2020 The ChubaoFS Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+# -*- coding: utf-8 -*-i
+
+import env
+from base import S3TestCase, get_env_s3_client
+from base import random_string
+
+KEY_PREFIX = 'test-tagging-%s/' % random_string(8)
+
+empty_tag_set = []
+
+
+def generate_tag_set(size=10, key_length=8, value_length=16):
+    tag_set = []
+    for _ in range(size):
+        tag_set.append({'Key': random_string(key_length), 'Value': random_string(value_length)})
+    return tag_set
+
+
+def encode_tag_set(tag_set):
+    encoded = ''
+    for tag in tag_set:
+        if len(encoded) > 0:
+            encoded += '&'
+        encoded += tag['Key'] + '=' + tag['Value']
+    return encoded
+
+
+class TaggingTest(S3TestCase):
+
+    def __init__(self, case):
+        super(TaggingTest, self).__init__(case)
+        self.s3 = get_env_s3_client()
+
+    def test_object_tagging(self):
+
+        key = KEY_PREFIX + random_string(16)
+        init_tag_set = generate_tag_set()
+        result = self.s3.put_object(Bucket=env.BUCKET, Key=key, Tagging=encode_tag_set(init_tag_set))
+        self.assert_put_object_result(result=result)
+        etag = result['ETag']
+
+        self.assert_head_object_result(
+            result=self.s3.head_object(Bucket=env.BUCKET, Key=key),
+            etag=etag,
+            content_length=0)
+
+        self.assert_get_tagging_result(
+            result=self.s3.get_object_tagging(Bucket=env.BUCKET, Key=key),
+            expect_tag_set=init_tag_set)
+
+        def run():
+            tag_set = generate_tag_set(size=4, key_length=8, value_length=16)
+
+            self.assert_put_tagging_result(
+                result=self.s3.put_object_tagging(
+                    Bucket=env.BUCKET,
+                    Key=key,
+                    Tagging={'TagSet': tag_set}))
+
+            self.assert_get_tagging_result(
+                result=self.s3.get_object_tagging(Bucket=env.BUCKET, Key=key),
+                expect_tag_set=tag_set)
+
+            self.assert_delete_tagging_result(
+                result=self.s3.delete_object_tagging(Bucket=env.BUCKET, Key=key))
+
+            self.assert_get_tagging_result(
+                result=self.s3.get_object_tagging(Bucket=env.BUCKET, Key=key),
+                expect_tag_set=empty_tag_set)
+
+        test_count = 50
+        count = 0
+        while count < test_count:
+            run()
+            count += 1
+
+        # Clean up test data
+        self.assert_delete_objects_result(
+            result=self.s3.delete_objects(
+                Bucket=env.BUCKET,
+                Delete={
+                    'Objects': [
+                        {'Key': key},
+                        {'Key': KEY_PREFIX}
+                    ]
+                }
+            )
+        )
+
+    def test_bucket_tagging(self):
+
+        def run():
+            tag_set = generate_tag_set(size=4, key_length=8, value_length=16)
+
+            self.assert_put_tagging_result(
+                result=self.s3.put_bucket_tagging(
+                    Bucket=env.BUCKET,
+                    Tagging={'TagSet': tag_set}))
+
+            self.assert_get_tagging_result(
+                result=self.s3.get_bucket_tagging(Bucket=env.BUCKET),
+                expect_tag_set=tag_set)
+
+            self.assert_delete_tagging_result(
+                result=self.s3.delete_bucket_tagging(Bucket=env.BUCKET))
+
+            self.assert_get_tagging_result(
+                result=self.s3.get_bucket_tagging(Bucket=env.BUCKET),
+                expect_tag_set=empty_tag_set)
+
+        test_count = 50
+        count = 0
+        while count < test_count:
+            run()
+            count += 1

--- a/docker/s3tests/test_transfer.py
+++ b/docker/s3tests/test_transfer.py
@@ -79,21 +79,21 @@ class TransferTest(S3TestCase):
         self.assert_delete_object_result(
             result=self.s3.delete_object(Bucket=BUCKET, Key=KEY_PREFIX))
 
-    def test_transfer_no1__50mb(self):
+    def test_transfer_scene1__50mb(self):
         """
         This test tests transfer (upload and download) a 50MB size file by using multipart feature.
         :return: None
         """
         self.__test_transfer(size=50 * 1024 * 1024)
 
-    def test_transfer_no2_100mb(self):
+    def test_transfer_scene2_100mb(self):
         """
         This test tests transfer (upload and download) a 100MB size file by using multipart feature.
         :return: None
         """
         self.__test_transfer(size=100 * 1024 * 1024)
 
-    def test_transfer_no3_200mb(self):
+    def test_transfer_scene3_200mb(self):
         """
         This test tests transfer (upload and download) a 200MB size file by using multipart feature.
         :return: None

--- a/docker/s3tests/test_transfer.py
+++ b/docker/s3tests/test_transfer.py
@@ -55,7 +55,6 @@ class TransferTest(S3TestCase):
         # Checking remote file stat
         self.assert_head_object_result(
             result=self.s3.head_object(Bucket=BUCKET, Key=key),
-            etag=expect_md5,
             content_length=size)
 
         # Download parallel

--- a/docker/s3tests/test_transfer.py
+++ b/docker/s3tests/test_transfer.py
@@ -1,0 +1,102 @@
+# Copyright 2020 The ChubaoFS Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+# -*- coding: utf-8 -*-
+import os
+from boto3.s3.transfer import TransferManager, TransferConfig
+
+from base import S3TestCase
+from base import random_string, compute_md5, generate_file, wait_future_done, get_env_s3_client
+from env import BUCKET
+
+KEY_PREFIX = 'test-transfer-%s/' % random_string(8)
+
+
+class TransferTest(S3TestCase):
+
+    def __init__(self, case):
+        super(TransferTest, self).__init__(case)
+        self.s3 = get_env_s3_client()
+        tc = TransferConfig(
+            multipart_threshold=5 * 1024 * 1024,
+            max_concurrency=10,
+            multipart_chunksize=5 * 1024 * 1024,
+            num_download_attempts=5,
+            max_io_queue=100,
+            io_chunksize=262144,
+            use_threads=True
+        )
+        self.tm = TransferManager(self.s3, tc)
+
+    def __test_transfer(self, size):
+        name = random_string(16)
+        key = KEY_PREFIX + name
+        local_filename = os.path.join('/tmp', name)
+        expect_md5 = generate_file(path=local_filename, size=size)
+
+        # Upload parallel
+        f = open(local_filename, 'rb')
+        future = self.tm.upload(fileobj=f, bucket=BUCKET, key=key)
+        result = wait_future_done(future, timeout=90)
+        self.assertTrue(result)
+        f.close()
+
+        # Checking remote file stat
+        self.assert_head_object_result(
+            result=self.s3.head_object(Bucket=BUCKET, Key=key),
+            etag=expect_md5,
+            content_length=size)
+
+        # Download parallel
+        download_filename = local_filename + "_dl"
+        f = open(download_filename, 'wb+')
+        future = self.tm.download(fileobj=f, bucket=BUCKET, key=key)
+        result = wait_future_done(future, timeout=90)
+        self.assertTrue(result)
+        f.flush()
+
+        # Checking download file
+        f.seek(0)
+        actual_md5 = compute_md5(f.read())
+        f.close()
+        self.assertEqual(actual_md5, expect_md5)
+
+        # Remove remote and local files
+        os.remove(local_filename)
+        os.remove(download_filename)
+        self.assert_delete_object_result(
+            result=self.s3.delete_object(Bucket=BUCKET, Key=key))
+        self.assert_delete_object_result(
+            result=self.s3.delete_object(Bucket=BUCKET, Key=KEY_PREFIX))
+
+    def test_transfer_no1__50mb(self):
+        """
+        This test tests transfer (upload and download) a 50MB size file by using multipart feature.
+        :return: None
+        """
+        self.__test_transfer(size=50 * 1024 * 1024)
+
+    def test_transfer_no2_100mb(self):
+        """
+        This test tests transfer (upload and download) a 100MB size file by using multipart feature.
+        :return: None
+        """
+        self.__test_transfer(size=100 * 1024 * 1024)
+
+    def test_transfer_no3_200mb(self):
+        """
+        This test tests transfer (upload and download) a 200MB size file by using multipart feature.
+        :return: None
+        """
+        self.__test_transfer(size=200 * 1024 * 1024)

--- a/docker/script/run_test.sh
+++ b/docker/script/run_test.sh
@@ -106,7 +106,7 @@ show_cluster_info() {
     echo &>> ${tmp_file}
     ${cli} user info ${Owner} &>> ${tmp_file}
     echo &>> ${tmp_file}
-    ${cli} volume info ${Owner} &>> ${tmp_file}
+    ${cli} volume info ${VolName} &>> ${tmp_file}
     echo &>> ${tmp_file}
     cat /tmp/collect_cluster_info | grep -v "Master address"
 }

--- a/docker/script/start_client.sh
+++ b/docker/script/start_client.sh
@@ -105,7 +105,7 @@ show_cluster_info() {
     echo &>> ${tmp_file}
     ${cli} user info ${Owner} &>> ${tmp_file}
     echo &>> ${tmp_file}
-    ${cli} volume info ${Owner} &>> ${tmp_file}
+    ${cli} volume info ${VolName} &>> ${tmp_file}
     echo &>> ${tmp_file}
     cat /tmp/collect_cluster_info | grep -v "Master address"
 }

--- a/master/api_service.go
+++ b/master/api_service.go
@@ -289,9 +289,11 @@ func (m *Server) createDataPartition(w http.ResponseWriter, r *http.Request) {
 		"clusterLastTotalDataPartitions[%v],vol[%v] has %v data partitions previously and %v data partitions now",
 		clusterTotalDataPartitions, volName, lastTotalDataPartitions, len(vol.dataPartitions.partitions))
 	if err != nil {
-		rstMsg = fmt.Sprintf("%v \n err[%v]", rstMsg, err.Error())
+		log.LogErrorf("create data partition fail: volume(%v) err(%v)", volName, err)
+		sendErrReply(w, r, newErrHTTPReply(err))
+		return
 	}
-	sendOkReply(w, r, newSuccessHTTPReply(rstMsg))
+	_ = sendOkReply(w, r, newSuccessHTTPReply(rstMsg))
 }
 
 func (m *Server) getDataPartition(w http.ResponseWriter, r *http.Request) {

--- a/master/cluster.go
+++ b/master/cluster.go
@@ -883,7 +883,7 @@ func (c *Cluster) decommissionDataPartition(offlineAddr string, dp *DataPartitio
 		c.Name, dp.PartitionID, offlineAddr, newAddr, dp.Hosts)
 	return
 errHandler:
-	msg = fmt.Sprintf(errMsg + " clusterID[%v] partitionID:%v  on Node:%v  "+
+	msg = fmt.Sprintf(errMsg+" clusterID[%v] partitionID:%v  on Node:%v  "+
 		"Then Fix It on newHost:%v   Err:%v , PersistenceHosts:%v  ",
 		c.Name, dp.PartitionID, offlineAddr, newAddr, err, dp.Hosts)
 	if err != nil {
@@ -1332,8 +1332,13 @@ func (c *Cluster) createVol(name, owner, zoneName string, mpCount, dpReplicaNum,
 		goto errHandler
 	}
 	for retryCount := 0; readWriteDataPartitions < defaultInitDataPartitionCnt && retryCount < 3; retryCount++ {
-		vol.initDataPartitions(c)
-		readWriteDataPartitions = len(vol.dataPartitions.partitionMap)
+		if err = vol.initDataPartitions(c); err == nil {
+			readWriteDataPartitions = len(vol.dataPartitions.partitionMap)
+			break
+		}
+	}
+	if err != nil {
+		goto errHandler
 	}
 	vol.dataPartitions.readableAndWritableCnt = readWriteDataPartitions
 	vol.updateViewCache(c)

--- a/master/vol.go
+++ b/master/vol.go
@@ -17,11 +17,12 @@ package master
 import (
 	"encoding/json"
 	"fmt"
+	"sync"
+
 	"github.com/chubaofs/chubaofs/proto"
 	"github.com/chubaofs/chubaofs/util"
 	"github.com/chubaofs/chubaofs/util/errors"
 	"github.com/chubaofs/chubaofs/util/log"
-	"sync"
 )
 
 // Vol represents a set of meta partitionMap and data partitionMap
@@ -211,9 +212,9 @@ func (vol *Vol) initMetaPartitions(c *Cluster, count int) (err error) {
 	return
 }
 
-func (vol *Vol) initDataPartitions(c *Cluster) {
+func (vol *Vol) initDataPartitions(c *Cluster) (err error) {
 	// initialize k data partitionMap at a time
-	c.batchCreateDataPartition(vol, defaultInitDataPartitionCnt)
+	err = c.batchCreateDataPartition(vol, defaultInitDataPartitionCnt)
 	return
 }
 

--- a/objectnode/api_handler_bucket.go
+++ b/objectnode/api_handler_bucket.go
@@ -174,22 +174,7 @@ func (o *ObjectNode) listBucketsHandler(w http.ResponseWriter, r *http.Request) 
 // Get bucket location
 // API reference: https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLocation.html
 func (o *ObjectNode) getBucketLocation(w http.ResponseWriter, r *http.Request) {
-	var output = struct {
-		XMLName            xml.Name `xml:"GetBucketLocationOutput"`
-		LocationConstraint string   `xml:"LocationConstraint"`
-	}{
-		LocationConstraint: o.region,
-	}
-	var marshaled []byte
-	var err error
-	if marshaled, err = MarshalXMLEntity(&output); err != nil {
-		log.LogErrorf("getBucketLocation: marshal result fail: requestID(%v) err(%v)", GetRequestID(r), err)
-		ServeInternalStaticErrorResponse(w, r)
-		return
-	}
-	if _, err = w.Write(marshaled); err != nil {
-		log.LogErrorf("getBucketLocation: write response body fail: requestID(%v) err(%v)", GetRequestID(r), err)
-	}
+	_, _ = w.Write(o.encodedRegion)
 	return
 }
 

--- a/objectnode/api_handler_multipart.go
+++ b/objectnode/api_handler_multipart.go
@@ -17,6 +17,7 @@ package objectnode
 import (
 	"net/http"
 	"strconv"
+	"syscall"
 
 	"github.com/chubaofs/chubaofs/util/log"
 )
@@ -146,7 +147,12 @@ func (o *ObjectNode) uploadPartHandler(w http.ResponseWriter, r *http.Request) {
 
 	// handle exception
 	var fsFileInfo *FSFileInfo
-	if fsFileInfo, err = vol.WritePart(param.Object(), uploadId, uint16(partNumberInt), r.Body); err != nil {
+	fsFileInfo, err = vol.WritePart(param.Object(), uploadId, uint16(partNumberInt), r.Body)
+	if err == syscall.ENOENT {
+		errorCode = NoSuchUpload
+		return
+	}
+	if err != nil {
 		log.LogErrorf("uploadPartHandler: write part fail, requestID(%v) err(%v)", GetRequestID(r), err)
 		errorCode = InternalErrorCode(err)
 		return
@@ -233,6 +239,10 @@ func (o *ObjectNode) listPartsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	fsParts, nextMarker, isTruncated, err := vol.ListParts(param.Object(), uploadId, maxPartsInt, partNoMarkerInt)
+	if err == syscall.ENOENT {
+		errorCode = NoSuchUpload
+		return
+	}
 	if err != nil {
 		log.LogErrorf("listPartsHandler: Volume list parts fail, requestID(%v) uploadID(%v) maxParts(%v) partNoMarker(%v) err(%v)",
 			GetRequestID(r), uploadId, maxPartsInt, partNoMarkerInt, err)
@@ -325,6 +335,10 @@ func (o *ObjectNode) completeMultipartUploadHandler(w http.ResponseWriter, r *ht
 	}
 
 	fsFileInfo, err := vol.CompleteMultipart(param.Object(), uploadId)
+	if err == syscall.ENOENT {
+		errorCode = NoSuchUpload
+		return
+	}
 	if err != nil {
 		log.LogErrorf("completeMultipartUploadHandler: complete multipart fail, requestID(%v) uploadID(%v) err(%v)",
 			GetRequestID(r), uploadId, err)
@@ -338,7 +352,7 @@ func (o *ObjectNode) completeMultipartUploadHandler(w http.ResponseWriter, r *ht
 	completeResult := CompleteMultipartResult{
 		Bucket: param.Bucket(),
 		Key:    param.Object(),
-		ETag:   fsFileInfo.ETag,
+		ETag:   wrapUnescapedQuot(fsFileInfo.ETag),
 	}
 
 	var bytes []byte
@@ -402,7 +416,8 @@ func (o *ObjectNode) abortMultipartUploadHandler(w http.ResponseWriter, r *http.
 	}
 
 	// Abort multipart upload
-	if err = vol.AbortMultipart(param.Object(), uploadId); err != nil {
+	err = vol.AbortMultipart(param.Object(), uploadId)
+	if err != nil && err != syscall.ENOENT {
 		log.LogErrorf("abortMultipartUploadHandler: Volume abort multipart fail, requestID(%v) uploadID(%v) err(%v)", GetRequestID(r), uploadId, err)
 		errorCode = InternalErrorCode(err)
 		return

--- a/objectnode/api_handler_object.go
+++ b/objectnode/api_handler_object.go
@@ -206,7 +206,7 @@ func (o *ObjectNode) getObjectHandler(w http.ResponseWriter, r *http.Request) {
 
 	// set response header for GetObject
 	if len(fileInfo.ETag) > 0 {
-		w.Header().Set(HeaderNameETag, fileInfo.ETag)
+		w.Header().Set(HeaderNameETag, wrapUnescapedQuot(fileInfo.ETag))
 	}
 	w.Header().Set(HeaderNameAcceptRange, HeaderValueAcceptRange)
 	w.Header().Set(HeaderNameLastModified, formatTimeRFC1123(fileInfo.ModifyTime))
@@ -315,12 +315,12 @@ func (o *ObjectNode) headObjectHandler(w http.ResponseWriter, r *http.Request) {
 		fileModTime := fileInfo.ModifyTime
 		modifiedTime, err := parseTimeRFC1123(modified)
 		if err != nil {
-			log.LogErrorf("headObjectHandler: parse RFC1123 time fail: requestID(%v) err(%v)", GetRequestID(r), err)
+			log.LogDebugf("headObjectHandler: parse RFC1123 time fail: requestID(%v) err(%v)", GetRequestID(r), err)
 			errorCode = InvalidArgument
 			return
 		}
 		if !fileModTime.After(modifiedTime) {
-			log.LogInfof("headObjectHandler: file modified time not after than specified time: requestID(%v)", GetRequestID(r))
+			log.LogDebugf("headObjectHandler: file modified time not after than specified time: requestID(%v)", GetRequestID(r))
 			errorCode = NotModified
 			return
 		}
@@ -329,7 +329,7 @@ func (o *ObjectNode) headObjectHandler(w http.ResponseWriter, r *http.Request) {
 	// Reference: https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadObject.html#API_HeadObject_RequestSyntax
 	if noneMatch != "" {
 		if noneMatchEtag := strings.Trim(noneMatch, "\""); noneMatchEtag == fileInfo.ETag {
-			log.LogErrorf("headObjectHandler: object eTag(%s) match If-None-Match header value(%s), requestId(%v)",
+			log.LogDebugf("headObjectHandler: object eTag(%s) match If-None-Match header value(%s), requestId(%v)",
 				fileInfo.ETag, noneMatchEtag, GetRequestID(r))
 			errorCode = NotModified
 			return
@@ -341,12 +341,12 @@ func (o *ObjectNode) headObjectHandler(w http.ResponseWriter, r *http.Request) {
 		fileModTime := fileInfo.ModifyTime
 		modifiedTime, err := parseTimeRFC1123(unmodified)
 		if err != nil {
-			log.LogErrorf("headObjectHandler: parse RFC1123 time fail: requestID(%v) err(%v)", GetRequestID(r), err)
+			log.LogDebugf("headObjectHandler: parse RFC1123 time fail: requestID(%v) err(%v)", GetRequestID(r), err)
 			errorCode = InvalidArgument
 			return
 		}
 		if fileModTime.After(modifiedTime) {
-			log.LogInfof("headObjectHandler: file modified time after than specified time: requestID(%v)", GetRequestID(r))
+			log.LogDebugf("headObjectHandler: file modified time after than specified time: requestID(%v)", GetRequestID(r))
 			errorCode = PreconditionFailed
 			return
 		}
@@ -354,7 +354,7 @@ func (o *ObjectNode) headObjectHandler(w http.ResponseWriter, r *http.Request) {
 
 	// set response header
 	if len(fileInfo.ETag) > 0 {
-		w.Header().Set(HeaderNameETag, fileInfo.ETag)
+		w.Header().Set(HeaderNameETag, wrapUnescapedQuot(fileInfo.ETag))
 	}
 	w.Header().Set(HeaderNameAcceptRange, HeaderValueAcceptRange)
 	if len(fileInfo.MIMEType) > 0 {
@@ -974,7 +974,7 @@ func (o *ObjectNode) putObjectHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// set response header
-	w.Header().Set(HeaderNameETag, fsFileInfo.ETag)
+	w.Header().Set(HeaderNameETag, wrapUnescapedQuot(fsFileInfo.ETag))
 	w.Header().Set(HeaderNameContentLength, "0")
 	return
 }

--- a/objectnode/api_handler_object.go
+++ b/objectnode/api_handler_object.go
@@ -945,8 +945,8 @@ func (o *ObjectNode) putObjectHandler(w http.ResponseWriter, r *http.Request) {
 
 	var fsFileInfo *FSFileInfo
 	fsFileInfo, err = vol.WriteObject(param.Object(), r.Body, contentType)
-	if err == syscall.EISDIR || err == syscall.ENOTDIR {
-		errorCode = Conflict
+	if err == syscall.EINVAL {
+		errorCode = ObjectModeConflict
 		return
 	}
 	if err != nil {

--- a/objectnode/auth_signature_v2.go
+++ b/objectnode/auth_signature_v2.go
@@ -88,7 +88,6 @@ type requestAuthInfoV2 struct {
 //  &Signature=GJCqOY0ahf1BdzJDjNnFWB7vfSc%3D
 //
 func parsePresignedV2AuthInfo(r *http.Request) (*requestAuthInfoV2, error) {
-	//
 	ai := new(requestAuthInfoV2)
 	uris := strings.SplitN(r.RequestURI, "?", 2)
 	if len(uris) < 2 {
@@ -96,10 +95,12 @@ func parsePresignedV2AuthInfo(r *http.Request) (*requestAuthInfoV2, error) {
 		return nil, errors.New("uri is invalid")
 	}
 
-	vars := mux.Vars(r)
-	ai.accessKeyId = vars["accessKey"]
-	ai.signature = vars["signature"]
-	ai.expires = vars["expires"]
+	if err := r.ParseForm(); err != nil {
+		return nil, err
+	}
+	ai.accessKeyId = r.FormValue("AWSAccessKeyId")
+	ai.signature = r.FormValue("Signature")
+	ai.expires = r.FormValue("Expires")
 
 	return ai, nil
 }

--- a/objectnode/auth_signature_v4.go
+++ b/objectnode/auth_signature_v4.go
@@ -206,11 +206,8 @@ func (o *ObjectNode) validateUrlBySignatureAlgorithmV4(r *http.Request) (pass bo
 	canonicalQuery := createCanonicalQueryV4(req)
 	canonicalRequestString := createCanonicalRequestString(r.Method, getCanonicalURI(r), canonicalQuery, canonicalHeaderStr, headerNames, payload)
 
-	log.LogDebugf("validateUrlBySignatureAlgorithmV4: canonical request:\n"+
-		"RequestID: %v\n"+
-		"CanonicalRequest:\n%v",
-		GetRequestID(r),
-		canonicalRequestString)
+	log.LogDebugf("canonical request %v: %v",
+		GetRequestID(r), strings.ReplaceAll(canonicalHeaderStr, "\n", "\\n"))
 
 	// build signingKey
 	signingKey := buildSigningKey(SCHEME, secretKey, req.Credential.Date, req.Credential.Region, req.Credential.Service, req.Credential.Request)
@@ -499,11 +496,8 @@ func calculateSignatureV4(r *http.Request, cred credential, secretKey string, si
 	stringToSign := buildStringToSign(SignatureV4Algorithm, timestamp, scope, canonicalRequest)
 	signature := sign(stringToSign, signingKey)
 
-	log.LogDebugf("calculateSignatureV4: canonical request:\n"+
-		"RequestID: %v\n"+
-		"CanonicalRequest:\n%v",
-		GetRequestID(r),
-		canonicalRequest)
+	log.LogDebugf("canonical request %v: %v",
+		GetRequestID(r), strings.ReplaceAll(canonicalRequest, "\n", "\\n"))
 	return hex.EncodeToString(signature)
 }
 

--- a/objectnode/const.go
+++ b/objectnode/const.go
@@ -51,6 +51,7 @@ const (
 	HeaderNameCopyModified        = "x-amz-copy-source-if-modified-since"
 	HeaderNameCopyUnModified      = "x-amz-copy-source-if-unmodified-since"
 	HeaderNameDecodeContentLength = "X-Amz-Decoded-Content-Length"
+	HeaderNameXAmzTagging         = "x-amz-tagging"
 
 	HeaderNameIfMatch           = "If-Match"
 	HeaderNameIfNoneMatch       = "If-None-Match"

--- a/objectnode/const.go
+++ b/objectnode/const.go
@@ -52,6 +52,7 @@ const (
 	HeaderNameCopyUnModified      = "x-amz-copy-source-if-unmodified-since"
 	HeaderNameDecodeContentLength = "X-Amz-Decoded-Content-Length"
 	HeaderNameXAmzTagging         = "x-amz-tagging"
+	HeaderNameXAmzMetaPrefix      = "x-amz-meta-"
 
 	HeaderNameIfMatch           = "If-Match"
 	HeaderNameIfNoneMatch       = "If-None-Match"

--- a/objectnode/const.go
+++ b/objectnode/const.go
@@ -123,3 +123,7 @@ const (
 	DefaultFileMode = 0644
 	DefaultDirMode  = DefaultFileMode | os.ModeDir
 )
+
+const (
+	SplitFileRangeBlockSize = 10 * 1024 * 1024 // 10MB
+)

--- a/objectnode/etag.go
+++ b/objectnode/etag.go
@@ -1,0 +1,139 @@
+// Copyright 2020 The ChubaoFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package objectnode
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"fmt"
+	"math/rand"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+var (
+	regexpEncodedETagValue = regexp.MustCompile("^(\\w)+(-(\\d)+)?(:(\\d)+)?$")
+	regexpEncodedETagParts = [3]*regexp.Regexp{
+		regexp.MustCompile("(\\w)+"),
+		regexp.MustCompile("-(\\d)+"),
+		regexp.MustCompile(":(\\d)+"),
+	}
+	staticDirectoryETagValue = ETagValue{Value: EmptyContentMD5String, PartNum: 0}
+)
+
+type ETagValue struct {
+	Value   string
+	PartNum int
+	TS      time.Time
+}
+
+func (e ETagValue) ETag() string {
+	sb := strings.Builder{}
+	sb.WriteString(e.Value)
+	if e.PartNum > 0 {
+		sb.WriteString("-" + strconv.Itoa(e.PartNum))
+	}
+	return sb.String()
+}
+
+func (e ETagValue) TSUnix() int64 {
+	return e.TS.Unix()
+}
+
+func (e ETagValue) String() string {
+	if !e.Valid() {
+		return "Invalid"
+	}
+	return fmt.Sprintf("%s_%d_%d", e.Value, e.PartNum, e.TS.Unix())
+}
+
+func (e ETagValue) Encode() string {
+	sb := strings.Builder{}
+	sb.WriteString(e.ETag())
+	if ts := e.TS.Unix(); ts > 0 {
+		sb.WriteString(":" + strconv.FormatInt(ts, 10))
+	}
+	return sb.String()
+}
+
+func (e ETagValue) Valid() bool {
+	return len(e.Value) > 0 && e.PartNum >= 0 && e.TS.Unix() >= 0
+}
+
+func DirectoryETagValue() ETagValue {
+	return staticDirectoryETagValue
+}
+
+func NewRandomBytesETagValue(partNum int, ts time.Time) ETagValue {
+	r := rand.New(rand.NewSource(ts.Unix()))
+	tmp := make([]byte, 4*1024)
+	n, _ := r.Read(tmp)
+	md5Hash := md5.New()
+	md5Hash.Write(tmp[:n])
+
+	value := ETagValue{
+		Value:   hex.EncodeToString(md5Hash.Sum(nil)),
+		PartNum: partNum,
+		TS:      ts,
+	}
+	return value
+}
+
+func NewRandomUUIDETagValue(partNum int, ts time.Time) ETagValue {
+	uUID, _ := uuid.NewRandom()
+	md5Hash := md5.New()
+	md5Hash.Write([]byte(uUID.String()))
+
+	value := ETagValue{
+		Value:   hex.EncodeToString(md5Hash.Sum(nil)),
+		PartNum: partNum,
+		TS:      ts,
+	}
+	return value
+}
+
+func ParseETagValue(raw string) ETagValue {
+	value := ETagValue{}
+	if !regexpEncodedETagValue.MatchString(raw) {
+		return value
+	}
+	offset := 0
+	valueLoc := regexpEncodedETagParts[0].FindStringIndex(raw)
+	if len(valueLoc) != 2 {
+		return value
+	}
+	value.Value = raw[valueLoc[0]:valueLoc[1]]
+	offset += valueLoc[1] - valueLoc[0]
+	partNumLoc := regexpEncodedETagParts[1].FindStringIndex(raw[offset:])
+	if len(partNumLoc) == 2 {
+		value.PartNum, _ = strconv.Atoi(raw[offset:][partNumLoc[0]+1 : partNumLoc[1]])
+		offset += partNumLoc[1] - partNumLoc[0]
+	} else {
+		value.PartNum = 0
+	}
+	tsLoc := regexpEncodedETagParts[2].FindStringIndex(raw[offset:])
+	if len(tsLoc) == 2 {
+		unixSec, _ := strconv.ParseInt(raw[offset:][tsLoc[0]+1:tsLoc[1]], 10, 64)
+		value.TS = time.Unix(unixSec, 0)
+		offset += tsLoc[1] - tsLoc[0]
+	} else {
+		value.TS = time.Unix(0, 0)
+	}
+	return value
+}

--- a/objectnode/etag_test.go
+++ b/objectnode/etag_test.go
@@ -1,0 +1,85 @@
+// Copyright 2020 The ChubaoFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package objectnode
+
+import (
+	"testing"
+	"time"
+)
+
+type sample struct {
+	raw       string
+	etagValue ETagValue
+	etag      string
+}
+
+var samples = []sample{
+	{
+		raw: "41f9ede9b03b89d80f3a8460d7792ff6",
+		etagValue: ETagValue{
+			Value:   "41f9ede9b03b89d80f3a8460d7792ff6",
+			PartNum: 0,
+			TS:      time.Unix(0, 0)},
+		etag: "41f9ede9b03b89d80f3a8460d7792ff6",
+	},
+	{
+		raw: "41f9ede9b03b89d80f3a8460d7792ff6-23",
+		etagValue: ETagValue{
+			Value:   "41f9ede9b03b89d80f3a8460d7792ff6",
+			PartNum: 23,
+			TS:      time.Unix(0, 0)},
+		etag: "41f9ede9b03b89d80f3a8460d7792ff6-23",
+	},
+	{
+		raw: "41f9ede9b03b89d80f3a8460d7792ff6:1588562233",
+		etagValue: ETagValue{
+			Value:   "41f9ede9b03b89d80f3a8460d7792ff6",
+			PartNum: 0,
+			TS:      time.Unix(1588562233, 0)},
+		etag: "41f9ede9b03b89d80f3a8460d7792ff6",
+	},
+	{
+		raw: "41f9ede9b03b89d80f3a8460d7792ff6-23:1588562233",
+		etagValue: ETagValue{
+			Value:   "41f9ede9b03b89d80f3a8460d7792ff6",
+			PartNum: 23,
+			TS:      time.Unix(1588562233, 0)},
+		etag: "41f9ede9b03b89d80f3a8460d7792ff6-23",
+	},
+}
+
+func TestParseETagValue(t *testing.T) {
+	for i, sample := range samples {
+		if etagValue := ParseETagValue(sample.raw); etagValue != sample.etagValue {
+			t.Fatalf("result mismatch: index(%v) expect(%v) actual(%v)", i, sample.etagValue, etagValue)
+		}
+	}
+}
+
+func TestETagValue_Encode(t *testing.T) {
+	for i, sample := range samples {
+		if encoded := sample.etagValue.Encode(); encoded != sample.raw {
+			t.Fatalf("result mismatch: index(%v) expect(%v) actual(%v)", i, sample.raw, encoded)
+		}
+	}
+}
+
+func TestETagValue_ETag(t *testing.T) {
+	for i, sample := range samples {
+		if etag := sample.etagValue.ETag(); etag != sample.etag {
+			t.Fatalf("result mismatch: index(%v) expect(%v) actual(%v)", i, sample.etag, etag)
+		}
+	}
+}

--- a/objectnode/fs.go
+++ b/objectnode/fs.go
@@ -28,6 +28,7 @@ type FSFileInfo struct {
 	ETag       string
 	Inode      uint64
 	MIMEType   string
+	Metadata   map[string]string // User-defined metadata
 }
 
 type Prefixes []string

--- a/objectnode/fs_volume.go
+++ b/objectnode/fs_volume.go
@@ -742,6 +742,7 @@ func (v *Volume) WritePart(path string, multipartId string, partId uint16, reade
 	if err = v.mw.AddMultipartPart_ll(multipartId, parentId, partId, size, etag, tempInodeInfo.Inode); err != nil {
 		log.LogErrorf("WritePart: meta add multipart part fail: multipartID(%v) parentID(%v) partID(%v) inode(%v) size(%v) MD5(%v) err(%v)",
 			multipartId, parentId, parentId, tempInodeInfo.Inode, size, etag, err)
+		return nil, err
 	}
 	log.LogDebugf("WritePart: meta add multipart part: multipartID(%v) parentID(%v) partID(%v) inode(%v) size(%v) MD5(%v)",
 		multipartId, parentId, parentId, tempInodeInfo.Inode, size, etag)

--- a/objectnode/fs_volume.go
+++ b/objectnode/fs_volume.go
@@ -923,9 +923,9 @@ func (v *Volume) CompleteMultipart(path string, multipartID string) (fsFileInfo 
 
 func (v *Volume) streamWrite(inode uint64, reader io.Reader, h hash.Hash) (size uint64, err error) {
 	var (
-		buf                   = make([]byte, 128*1024)
+		buf                   = make([]byte, 2*util.BlockSize)
 		readN, writeN, offset int
-		hashBuf               = make([]byte, 128*1024)
+		hashBuf               = make([]byte, 2*util.BlockSize)
 	)
 	for {
 		readN, err = reader.Read(buf)
@@ -1070,7 +1070,7 @@ func (v *Volume) ReadFile(path string, writer io.Writer, offset, size uint64) er
 	}
 
 	var n int
-	var tmp = make([]byte, util.BlockSize)
+	var tmp = make([]byte, 2*util.BlockSize)
 	for {
 		var rest = upper - uint64(offset)
 		if rest == 0 {

--- a/objectnode/result_error.go
+++ b/objectnode/result_error.go
@@ -88,8 +88,9 @@ var (
 	PreconditionFailed                  = &ErrorCode{ErrorCode: "PreconditionFailed", ErrorMessage: "At least one of the preconditions you specified did not hold.", StatusCode: http.StatusPreconditionFailed}
 	MaxContentLength                    = &ErrorCode{ErrorCode: "MaxContentLength", ErrorMessage: "Content-Length is bigger than 20KB.", StatusCode: http.StatusLengthRequired}
 	DuplicatedBucket                    = &ErrorCode{ErrorCode: "CreateBucketFailed", ErrorMessage: "Duplicate bucket name.", StatusCode: http.StatusBadRequest}
-	Conflict                            = &ErrorCode{ErrorCode: "Conflict", ErrorMessage: "Object already exists and type conflicts", StatusCode: http.StatusConflict}
+	ObjectModeConflict                  = &ErrorCode{ErrorCode: "ObjectModeConflict", ErrorMessage: "Object already exists but file mode conflicts", StatusCode: http.StatusConflict}
 	NotModified                         = &ErrorCode{ErrorCode: "MaxContentLength", ErrorMessage: "Not modified.", StatusCode: http.StatusNotModified}
+	NoSuchUpload                        = &ErrorCode{ErrorCode: "NoSuchUpload", ErrorMessage: "The specified upload does not exist.", StatusCode: http.StatusNotFound}
 )
 
 func HttpStatusErrorCode(code int) *ErrorCode {

--- a/objectnode/result_test.go
+++ b/objectnode/result_test.go
@@ -196,7 +196,7 @@ func TestUnmarshalDeleteRequest(t *testing.T) {
 
 func TestMarshalTagging(t *testing.T) {
 	tagging := NewTagging()
-	tagging.TagSet = []*Tag{
+	tagging.TagSet = []Tag{
 		{
 			Key:   "tag1",
 			Value: "val1",

--- a/objectnode/router.go
+++ b/objectnode/router.go
@@ -468,7 +468,7 @@ func (o *ObjectNode) registerApiRouters(router *mux.Router) {
 		// API reference: https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjectTagging.html
 		r.NewRoute().Name(ActionToUniqueRouteName(proto.OSSDeleteObjectTaggingAction)).
 			Methods(http.MethodDelete).
-			Path("/{object:.+").
+			Path("/{object:.+}").
 			Queries("tagging", "").
 			HandlerFunc(o.deleteObjectTaggingHandler)
 

--- a/objectnode/router.go
+++ b/objectnode/router.go
@@ -49,25 +49,6 @@ func (o *ObjectNode) registerApiRouters(router *mux.Router) {
 	}
 
 	var registerBucketHttpGetRouters = func(r *mux.Router) {
-		// Get object with pre-signed auth signature v2
-		// API reference: https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html
-		r.NewRoute().Name(ActionToUniqueRouteName(proto.OSSGetObjectAction)).
-			Methods(http.MethodGet).
-			Path("/{object:.+}").
-			Queries("AWSAccessKeyId", "{accessKey:.+}",
-				"Expires", "{expires:[0-9]+}", "Signature", "{signature:.+}").
-			HandlerFunc(o.getObjectHandler)
-
-		// Get object with pre-signed auth signature v4
-		// API reference: https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html
-		r.NewRoute().Name(ActionToUniqueRouteName(proto.OSSGetObjectAction)).
-			Methods(http.MethodGet).
-			Path("/{object:.+}").
-			Queries("X-Amz-Credential", "{credential:.+}",
-				"X-Amz-Algorithm", "{algorithm:.+}", "X-Amz-Signature", "{signature:.+}",
-				"X-Amz-Date", "{date:.+}", "X-Amz-SignedHeaders", "{signedHeaders:.+}",
-				"X-Amz-Expires", "{expires:[0-9]+}").
-			HandlerFunc(o.getObjectHandler)
 
 		// List parts
 		// API reference: https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListParts.html

--- a/objectnode/server.go
+++ b/objectnode/server.go
@@ -17,6 +17,7 @@ package objectnode
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"regexp"
 	"strings"
@@ -106,6 +107,8 @@ type ObjectNode struct {
 	signatureIgnoredActions proto.Actions // signature ignored actions
 	disabledActions         proto.Actions // disabled actions
 
+	encodedRegion []byte
+
 	control common.Control
 }
 
@@ -180,6 +183,12 @@ func (o *ObjectNode) loadConfig(cfg *config.Config) (err error) {
 	return
 }
 
+func (o *ObjectNode) updateRegion(region string) {
+	o.region = region
+	o.encodedRegion =
+		[]byte(fmt.Sprintf(fmt.Sprintf("<LocationConstraint>%s</LocationConstraint>", o.region)))
+}
+
 func handleStart(s common.Server, cfg *config.Config) (err error) {
 	o, ok := s.(*ObjectNode)
 	if !ok {
@@ -195,7 +204,7 @@ func handleStart(s common.Server, cfg *config.Config) (err error) {
 	if ci, err = o.mc.AdminAPI().GetClusterInfo(); err != nil {
 		return
 	}
-	o.region = ci.Cluster
+	o.updateRegion(ci.Cluster)
 	log.LogInfof("handleStart: get cluster information: region(%v)", o.region)
 
 	// start rest api

--- a/objectnode/util.go
+++ b/objectnode/util.go
@@ -243,3 +243,26 @@ func SplitFileRange(size, blockSize int64) (ranges [][2]int64) {
 	}
 	return ranges
 }
+
+// Checking and parsing user-defined metadata from request header.
+// The optional user-defined metadata names must begin with "x-amz-meta-" to
+// distinguish them from other HTTP headers.
+// Notes:
+// The PUT request header is limited to 8 KB in size. Within the PUT request header,
+// the user-defined metadata is limited to 2 KB in size. The size of user-defined
+// metadata is measured by taking the sum of the number of bytes in the UTF-8 encoding
+// of each key and value.
+// Reference: https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html
+func ParseUserDefinedMetadata(header http.Header) map[string]string {
+	metadata := make(map[string]string)
+	for name, values := range header {
+		if strings.HasPrefix(name, http.CanonicalHeaderKey(HeaderNameXAmzMetaPrefix)) {
+			metaName := strings.ToLower(name[len(HeaderNameXAmzMetaPrefix):])
+			metaValue := strings.Join(values, ",")
+			if !strings.HasPrefix(metaName, "oss:") {
+				metadata[metaName] = metaValue
+			}
+		}
+	}
+	return metadata
+}

--- a/objectnode/util.go
+++ b/objectnode/util.go
@@ -220,3 +220,26 @@ func patternMatch(pattern, key string) bool {
 func wrapUnescapedQuot(src string) string {
 	return "\"" + src + "\""
 }
+
+func SplitFileRange(size, blockSize int64) (ranges [][2]int64) {
+	blocks := size / blockSize
+	if size%blockSize != 0 {
+		blocks += 1
+	}
+	ranges = make([][2]int64, 0, blocks)
+	remain := size
+	aboveRage := [2]int64{0, 0}
+	for remain > 0 {
+		curRange := [2]int64{aboveRage[1], 0}
+		if remain < blockSize {
+			curRange[1] = size
+			remain = 0
+		} else {
+			curRange[1] = blockSize
+			remain -= blockSize
+		}
+		ranges = append(ranges, curRange)
+		aboveRage[0], aboveRage[1] = curRange[0], curRange[1]
+	}
+	return ranges
+}


### PR DESCRIPTION
This pull request brings multiple enhancements and fixes multiple issues.

**1. Fix: parallel-safe issue while batch get xattrs**

**2. Fix: xml response of get bucket location interface**

**3. Enhancement: presigned url fully support**
All s3-compatible object storage interfaces already support presigned url.

**4. Enhancement: partial support user-defined metadata**
The `PutObject` interface supports setting user-defined metadata. 
The `GetObject` and `HeadObject` interfaces can correctly return the stored user-defined metadata.

**5. Enhancement: make ETag versioned**
When ETag stored, it is versioned by encoding, which can make the file system interface and object storage interface more closely integrated.

Referring to the Amazon AWS S3 Developer Guide:
>"Amazon S3 response includes an ETag that uniquely identifies the combined object data. This ETag will not necessarily be an MD5 hash of the object data."

When a new object is written to ChubaoFS through the object storage interface, ChubaoFS calculates the ETag value for it, and uses the modification time of the object as its version information when encoding and storing.

If this file is modified by the file system interface, the ETag of this file will be invalid because the version information will be inconsistent with modification time.

After the object storage interface finds that the ETag is invalid, it will automatically generate a new ETag matching its modification time.

**6. Enhancement: more complete python-based tester for S3-compatible object storage interface.**
Following test have been added into CI workflow:

BucketTest
```
test_get_bucket_location
test_head_bucket
test_list_buckets
```

ObjectHeadTest
```
test_head_object
test_head_object_if_match
test_head_object_if_modified_since
test_head_object_if_none_match
test_head_object_if_unmodified_since
```

ObjectPutTest
```
test_put_directory
test_put_object_conflict_scene1
test_put_object_conflict_scene2
test_put_object_with_metadata
test_put_objects_independent_scene1___1kb
test_put_objects_independent_scene2__10kb
test_put_objects_independent_scene3_100kb
test_put_objects_independent_scene4___1mb
test_put_objects_independent_scene5__10mb
test_put_objects_override_scene1___1kb
test_put_objects_override_scene2__10kb
test_put_objects_override_scene3_100kb
test_put_objects_override_scene4___1mb
test_put_objects_override_scene5__10mb
```

SignatureTest
```
test_signature_v2_cn
test_signature_v2_en
test_signature_v2_presign_cn
test_signature_v2_presign_en
test_signature_v4_cn
test_signature_v4_en
test_signature_v4_presign_cn
test_signature_v4_presign_en
test_signature_volume_credential
```

TaggingTest
```
test_bucket_tagging
test_object_tagging
```

TransferTest
```
test_transfer_scene1__50mb
test_transfer_scene2_100mb
test_transfer_scene3_200mb
```

Details under `docker/s3tests/`

**7. Enhancement: increase buffer size to improve transfer performance**
Increase the buffer size for reading and writing in ObjectNode from`128 KB` to `256 KB`.

**8. Enhancement: support setup tagging when put an object**

**9. Enhancement: improve tagging encoding for storage**
