### PR TITLE
fixed: the used size alignment of the replica is no longer used as a …

### DIFF
--- a/master/data_partition.go
+++ b/master/data_partition.go
@@ -562,26 +562,6 @@ func (partition *DataPartition) afterCreation(nodeAddr, diskPath string, c *Clus
 	return
 }
 
-// Check if the replica's size is aligned or not.
-func (partition *DataPartition) isReplicaSizeAligned() bool {
-	if len(partition.Replicas) == 0 {
-		return true
-	}
-	used := partition.Replicas[0].Used
-
-	var diff float64
-	for _, replica := range partition.Replicas {
-		tempDiff := math.Abs(float64(replica.Used) - float64(used))
-		if tempDiff > diff {
-			diff = tempDiff
-		}
-	}
-	if diff < float64(util.GB) {
-		return true
-	}
-	return false
-}
-
 // Check if it makes sense to compare the CRC.
 // Note that if loading the data into a data node is not finished, then there is no need to check the CRC.
 func (partition *DataPartition) needsToCompareCRC() (needCompare bool) {

--- a/master/data_partition_check.go
+++ b/master/data_partition_check.go
@@ -37,7 +37,7 @@ func (partition *DataPartition) checkStatus(clusterName string, needLog bool, dp
 	switch len(liveReplicas) {
 	case (int)(partition.ReplicaNum):
 		partition.Status = proto.ReadOnly
-		if partition.checkReplicaStatusOnLiveNode(liveReplicas) == true && partition.isReplicaSizeAligned() && partition.canWrite() {
+		if partition.checkReplicaStatusOnLiveNode(liveReplicas) == true && partition.canWrite() {
 			partition.Status = proto.ReadWrite
 		}
 	default:


### PR DESCRIPTION
…basis for whether partition is writable

Signed-off-by: zhuhyc <zzhniy.163.niy@163.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

 the used size alignment of the replica is no longer used as a basis for whether partition is writable，
avoid making some data partitions read-only when they should be writable

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

N/A

**Special notes for your reviewer**:

N/A

**Release note**:

N/A