### PR TITLE
fixed: golang freeosmemory can free memory to kernel timely on 4.5+ k…

### DIFF
--- a/client/fuse.go
+++ b/client/fuse.go
@@ -228,6 +228,10 @@ func startDaemon() error {
 	}
 
 	env := os.Environ()
+
+	// add GODEBUG=madvdontneed=1 environ, to make sysUnused uses madvise(MADV_DONTNEED) to signal the kernel that a
+	// range of allocated memory contains unneeded data.
+	env = append(env, "GODEBUG=madvdontneed=1")
 	err = daemonize.Run(cmdPath, args, env, os.Stdout)
 	if err != nil {
 		return fmt.Errorf("startDaemon failed: daemon start failed, cmd(%v) args(%v) env(%v) err(%v)\n", cmdPath, args, env, err)


### PR DESCRIPTION
…ernels

Signed-off-by: yinlei-jinan <297155992@qq.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
