### PR TITLE
Fix: parallel-safe issue in conn pool and metanode conn serve

### DIFF
--- a/docker/s3tests/test_object_put.py
+++ b/docker/s3tests/test_object_put.py
@@ -133,7 +133,7 @@ class ObjectPutTest(S3TestCase):
                     marker = next_marker
             if 'IsTruncated' in response:
                 truncated = bool(response['IsTruncated'])
-        assert matches == file_num
+        self.assertEqual(matches, file_num)
         # batch delete objects
         objects = []
         for file_name in file_names:
@@ -144,7 +144,7 @@ class ObjectPutTest(S3TestCase):
         # check deletion result
         response = self.s3.list_objects(Bucket=BUCKET, Prefix=file_name_prefix)
         self.assertEqual(response['ResponseMetadata']['HTTPStatusCode'], 200)
-        assert 'Contents' not in response
+        self.assertFalse('Contents' in response)
 
     def test_put_objects_override_scene1___1kb(self):
         """
@@ -313,8 +313,8 @@ class ObjectPutTest(S3TestCase):
         def run():
             key = KEY_PREFIX + random_string(16)
             metadata = {
-                random_string(8).lower().capitalize(): random_string(16),
-                random_string(8).lower().capitalize(): random_string(16)
+                random_string(8).lower(): random_string(16),
+                random_string(8).lower(): random_string(16)
             }
             self.assert_put_object_result(
                 result=self.s3.put_object(

--- a/docker/script/run_test.sh
+++ b/docker/script/run_test.sh
@@ -247,6 +247,9 @@ run_s3_test() {
     echo -e "\033[32mdone\033[0m"
 
     python3 -m unittest2 discover ${work_path} "*.py" -v
+    if [[ $? -ne 0 ]]; then
+        exit 1
+    fi
 }
 
 check_cluster

--- a/metanode/manager.go
+++ b/metanode/manager.go
@@ -304,14 +304,13 @@ func (m *metadataManager) loadPartitions() (err error) {
 func (m *metadataManager) attachPartition(id uint64, partition MetaPartition) (err error) {
 	fmt.Println(fmt.Sprintf("start load metaPartition %v", id))
 	if err = partition.Start(); err != nil {
-		fmt.Println(fmt.Sprintf("fininsh load metaPartition %v error %v", id, err))
+		log.LogErrorf("load meta partition %v fail: %v", id, err)
 		return
 	}
-	fmt.Println(fmt.Sprintf("fininsh load metaPartition %v", id))
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.partitions[id] = partition
-	log.LogInfof("[attachPartition] load partition: %v success", m.partitions)
+	log.LogInfof("load meta partition %v success", id)
 	return
 }
 
@@ -327,7 +326,7 @@ func (m *metadataManager) detachPartition(id uint64) (err error) {
 }
 
 func (m *metadataManager) createPartition(id uint64, volName string, start,
-end uint64, peers []proto.Peer) (err error) {
+	end uint64, peers []proto.Peer) (err error) {
 	// check partitions
 	if _, err = m.getPartition(id); err == nil {
 		err = errors.NewErrorf("create partition id=%d is exsited!", id)

--- a/metanode/manager_op.go
+++ b/metanode/manager_op.go
@@ -15,12 +15,12 @@
 package metanode
 
 import (
+	"bytes"
 	"encoding/json"
+	"fmt"
 	"net"
 	"os"
 	"runtime"
-	"bytes"
-	"fmt"
 
 	"github.com/chubaofs/chubaofs/proto"
 	"github.com/chubaofs/chubaofs/util"

--- a/metanode/manager_proxy.go
+++ b/metanode/manager_proxy.go
@@ -34,6 +34,8 @@ func (m *metadataManager) serveProxy(conn net.Conn, mp MetaPartition,
 		mConn      *net.TCPConn
 		leaderAddr string
 		err        error
+		reqID      = p.ReqID
+		reqOp      = p.Opcode
 	)
 	if leaderAddr, ok = mp.IsLeader(); ok {
 		return
@@ -63,6 +65,10 @@ func (m *metadataManager) serveProxy(conn net.Conn, mp MetaPartition,
 		p.PacketErrorWithBody(proto.OpErr, []byte(err.Error()))
 		m.connPool.PutConnect(mConn, ForceClosedConnect)
 		goto end
+	}
+	if reqID != p.ReqID || reqOp != p.Opcode {
+		log.LogErrorf("serveProxy: send and received packet mismatch: req(%v_%v) resp(%v_%v)",
+			reqID, reqOp, p.ReqID, p.Opcode)
 	}
 	m.connPool.PutConnect(mConn, NoClosedConnect)
 end:

--- a/metanode/partition_fsmop_multipart.go
+++ b/metanode/partition_fsmop_multipart.go
@@ -37,9 +37,13 @@ func (mp *metaPartition) fsmAppendMultipart(multipart *Multipart) (status uint8)
 	if storedItem == nil {
 		return proto.OpNotExistErr
 	}
-	storedMultipart := storedItem.(*Multipart)
+	storedMultipart, is := storedItem.(*Multipart)
+	if !is {
+		return proto.OpNotExistErr
+	}
 	for _, part := range multipart.Parts() {
-		if !storedMultipart.InsertPart(part, false) {
+		actual, stored := storedMultipart.LoadOrStorePart(part)
+		if !stored && !actual.Equal(part) {
 			return proto.OpExistErr
 		}
 	}

--- a/metanode/server.go
+++ b/metanode/server.go
@@ -80,13 +80,9 @@ func (m *MetaNode) serveConn(conn net.Conn, stopC chan uint8) {
 			}
 			return
 		}
-		// Start a goroutine for packet handling. Do not block connection read goroutine.
-		go func() {
-			if err := m.handlePacket(conn, p, remoteAddr); err != nil {
-				log.LogError("serve operatorPkg: ", err.Error())
-				return
-			}
-		}()
+		if err := m.handlePacket(conn, p, remoteAddr); err != nil {
+			log.LogErrorf("serve handlePacket fail: %v", err)
+		}
 	}
 }
 

--- a/objectnode/api_handler_bucket.go
+++ b/objectnode/api_handler_bucket.go
@@ -62,7 +62,7 @@ func (o *ObjectNode) createBucketHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	//todo parse body
-	w.Header().Set("Location", o.region)
+	w.Header()[HeaderNameLocation] = []string{o.region}
 	return
 }
 

--- a/objectnode/api_handler_multipart.go
+++ b/objectnode/api_handler_multipart.go
@@ -25,8 +25,6 @@ import (
 // Create multipart upload
 // API reference: https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html
 func (o *ObjectNode) createMultipleUploadHandler(w http.ResponseWriter, r *http.Request) {
-	log.LogInfof("createMultipleUploadHandler: init multiple upload, requestID(%v) remote(%v)",
-		GetRequestID(r), r.RemoteAddr)
 
 	var err error
 	var errorCode *ErrorCode
@@ -80,8 +78,8 @@ func (o *ObjectNode) createMultipleUploadHandler(w http.ResponseWriter, r *http.
 	}
 
 	// set response header
-	w.Header().Set(HeaderNameContentType, HeaderValueContentTypeXML)
-	w.Header().Set(HeaderNameContentLength, strconv.Itoa(len(bytes)))
+	w.Header()[HeaderNameContentType] = []string{HeaderValueContentTypeXML}
+	w.Header()[HeaderNameContentLength] = []string{strconv.Itoa(len(bytes))}
 	if _, err = w.Write(bytes); err != nil {
 		log.LogErrorf("createMultipleUploadHandler: write response body fail, requestID(%v) err(%v)",
 			GetRequestID(r), err)
@@ -93,8 +91,6 @@ func (o *ObjectNode) createMultipleUploadHandler(w http.ResponseWriter, r *http.
 // Uploads a part in a multipart upload.
 // API reference: https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html .
 func (o *ObjectNode) uploadPartHandler(w http.ResponseWriter, r *http.Request) {
-	log.LogInfof("uploadPartHandler: upload part, requestID(%v) remote(%v)",
-		GetRequestID(r), r.RemoteAddr)
 
 	var (
 		err       error
@@ -160,8 +156,8 @@ func (o *ObjectNode) uploadPartHandler(w http.ResponseWriter, r *http.Request) {
 	log.LogDebugf("uploadPartHandler: write part, requestID(%v) fsFileInfo(%v)", GetRequestID(r), fsFileInfo)
 
 	// write header to response
-	w.Header().Set(HeaderNameContentLength, "0")
-	w.Header().Set(HeaderNameETag, fsFileInfo.ETag)
+	w.Header()[HeaderNameContentLength] = []string{"0"}
+	w.Header()[HeaderNameETag] = []string{fsFileInfo.ETag}
 	return
 }
 
@@ -281,8 +277,8 @@ func (o *ObjectNode) listPartsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// set response header
-	w.Header().Set(HeaderNameContentType, HeaderValueContentTypeXML)
-	w.Header().Set(HeaderNameContentLength, strconv.Itoa(len(bytes)))
+	w.Header()[HeaderNameContentType] = []string{HeaderValueContentTypeXML}
+	w.Header()[HeaderNameContentLength] = []string{strconv.Itoa(len(bytes))}
 	if _, err = w.Write(bytes); err != nil {
 		log.LogErrorf("listPartsHandler: write response body fail, requestID(%v) err(%v)",
 			GetRequestID(r), err)
@@ -339,6 +335,10 @@ func (o *ObjectNode) completeMultipartUploadHandler(w http.ResponseWriter, r *ht
 		errorCode = NoSuchUpload
 		return
 	}
+	if err == syscall.EINVAL {
+		errorCode = ObjectModeConflict
+		return
+	}
 	if err != nil {
 		log.LogErrorf("completeMultipartUploadHandler: complete multipart fail, requestID(%v) uploadID(%v) err(%v)",
 			GetRequestID(r), uploadId, err)
@@ -364,8 +364,8 @@ func (o *ObjectNode) completeMultipartUploadHandler(w http.ResponseWriter, r *ht
 	}
 
 	// set response header
-	w.Header().Set(HeaderNameContentType, HeaderValueContentTypeXML)
-	w.Header().Set(HeaderNameContentLength, strconv.Itoa(len(bytes)))
+	w.Header()[HeaderNameContentType] = []string{HeaderValueContentTypeXML}
+	w.Header()[HeaderNameContentLength] = []string{strconv.Itoa(len(bytes))}
 	if _, err = w.Write(bytes); err != nil {
 		log.LogErrorf("completeMultipartUploadHandler: write response body fail, requestID(%v) err(%v)", GetRequestID(r), err)
 		return
@@ -520,8 +520,8 @@ func (o *ObjectNode) listMultipartUploadsHandler(w http.ResponseWriter, r *http.
 	}
 
 	// set response header
-	w.Header().Set(HeaderNameContentType, HeaderValueContentTypeXML)
-	w.Header().Set(HeaderNameContentLength, strconv.Itoa(len(bytes)))
+	w.Header()[HeaderNameContentType] = []string{HeaderValueContentTypeXML}
+	w.Header()[HeaderNameContentLength] = []string{strconv.Itoa(len(bytes))}
 	_, _ = w.Write(bytes)
 	return
 }

--- a/objectnode/api_handler_object.go
+++ b/objectnode/api_handler_object.go
@@ -206,12 +206,12 @@ func (o *ObjectNode) getObjectHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// set response header for GetObject
-	w.Header().Set(HeaderNameAcceptRange, HeaderValueAcceptRange)
-	w.Header().Set(HeaderNameLastModified, formatTimeRFC1123(fileInfo.ModifyTime))
+	w.Header()[HeaderNameAcceptRange] = []string{HeaderValueAcceptRange}
+	w.Header()[HeaderNameLastModified] = []string{formatTimeRFC1123(fileInfo.ModifyTime)}
 	if len(fileInfo.MIMEType) > 0 {
-		w.Header().Set(HeaderNameContentType, fileInfo.MIMEType)
+		w.Header()[HeaderNameContentType] = []string{fileInfo.MIMEType}
 	} else {
-		w.Header().Set(HeaderNameContentType, HeaderValueTypeStream)
+		w.Header()[HeaderNameContentType] = []string{HeaderValueTypeStream}
 	}
 
 	//check request is whether contain param : partNumber
@@ -236,25 +236,25 @@ func (o *ObjectNode) getObjectHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		// Header : Accept-Range, Content-Length, Content-Range, ETag, x-amz-mp-parts-count
-		w.Header().Set(HeaderNameContentLength, strconv.Itoa(int(partSize)))
-		w.Header().Set(HeaderNameContentRange, fmt.Sprintf("bytes %d-%d/%d", rangeLower, rangeUpper, fileInfo.Size))
-		w.Header().Set(HeaderNameDownloadPartCount, strconv.Itoa(int(partCount)))
+		w.Header()[HeaderNameContentLength] = []string{strconv.Itoa(int(partSize))}
+		w.Header()[HeaderNameContentRange] = []string{fmt.Sprintf("bytes %d-%d/%d", rangeLower, rangeUpper, fileInfo.Size)}
+		w.Header()[HeaderNameXAmzDownloadPartCount] = []string{strconv.Itoa(int(partCount))}
 		if len(fileInfo.ETag) > 0 && !strings.Contains(fileInfo.ETag, "-") {
-			w.Header().Set(HeaderNameETag, fmt.Sprintf("%s-%d", fileInfo.ETag, partCount))
+			w.Header()[HeaderNameETag] = []string{fmt.Sprintf("%s-%d", fileInfo.ETag, partCount)}
 		}
 	} else {
-		w.Header().Set(HeaderNameContentLength, strconv.FormatUint(contentLength, 10))
+		w.Header()[HeaderNameContentLength] = []string{strconv.FormatUint(contentLength, 10)}
 		if len(fileInfo.ETag) > 0 {
-			w.Header().Set(HeaderNameETag, wrapUnescapedQuot(fileInfo.ETag))
+			w.Header()[HeaderNameETag] = []string{wrapUnescapedQuot(fileInfo.ETag)}
 		}
 		if isRangeRead {
-			w.Header().Set(HeaderNameContentRange, fmt.Sprintf("bytes %d-%d/%d", rangeLower, rangeUpper, fileInfo.Size))
+			w.Header()[HeaderNameContentRange] = []string{fmt.Sprintf("bytes %d-%d/%d", rangeLower, rangeUpper, fileInfo.Size)}
 		}
 	}
 
 	// User-defined metadata
 	for name, value := range fileInfo.Metadata {
-		w.Header().Set(HeaderNameXAmzMetaPrefix+name, value)
+		w.Header()[HeaderNameXAmzMetaPrefix+name] = []string{value}
 	}
 
 	if fileInfo.Mode.IsDir() {
@@ -389,13 +389,13 @@ func (o *ObjectNode) headObjectHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// set response header
-	w.Header().Set(HeaderNameAcceptRange, HeaderValueAcceptRange)
-	w.Header().Set(HeaderNameLastModified, formatTimeRFC1123(fileInfo.ModifyTime))
-	w.Header().Set(HeaderNameContentMD5, EmptyContentMD5String)
+	w.Header()[HeaderNameAcceptRange] = []string{HeaderValueAcceptRange}
+	w.Header()[HeaderNameLastModified] = []string{formatTimeRFC1123(fileInfo.ModifyTime)}
+	w.Header()[HeaderNameContentMD5] = []string{EmptyContentMD5String}
 	if len(fileInfo.MIMEType) > 0 {
-		w.Header().Set(HeaderNameContentType, fileInfo.MIMEType)
+		w.Header()[HeaderNameContentType] = []string{fileInfo.MIMEType}
 	} else {
-		w.Header().Set(HeaderNameContentType, HeaderValueTypeStream)
+		w.Header()[HeaderNameContentType] = []string{HeaderValueTypeStream}
 	}
 
 	// check request is whether contain param : partNumber
@@ -418,22 +418,22 @@ func (o *ObjectNode) headObjectHandler(w http.ResponseWriter, r *http.Request) {
 			errorCode = NoSuchKey
 			return
 		}
-		w.Header().Set(HeaderNameContentLength, strconv.Itoa(int(partSize)))
-		w.Header().Set(HeaderNameContentRange, fmt.Sprintf("bytes %d-%d/%d", rangeLower, rangeUpper, fileInfo.Size))
-		w.Header().Set(HeaderNameDownloadPartCount, strconv.Itoa(int(partCount)))
+		w.Header()[HeaderNameContentLength] = []string{strconv.Itoa(int(partSize))}
+		w.Header()[HeaderNameContentRange] = []string{fmt.Sprintf("bytes %d-%d/%d", rangeLower, rangeUpper, fileInfo.Size)}
+		w.Header()[HeaderNameXAmzDownloadPartCount] = []string{strconv.Itoa(int(partCount))}
 		if len(fileInfo.ETag) > 0 && !strings.Contains(fileInfo.ETag, "-") {
-			w.Header().Set(HeaderNameETag, fmt.Sprintf("%s-%d", fileInfo.ETag, partCount))
+			w.Header()[HeaderNameETag] = []string{fmt.Sprintf("%s-%d", fileInfo.ETag, partCount)}
 		}
 	} else {
-		w.Header().Set(HeaderNameContentLength, strconv.Itoa(int(fileInfo.Size)))
+		w.Header()[HeaderNameContentLength] = []string{strconv.Itoa(int(fileInfo.Size))}
 		if len(fileInfo.ETag) > 0 {
-			w.Header().Set(HeaderNameETag, wrapUnescapedQuot(fileInfo.ETag))
+			w.Header()[HeaderNameETag] = []string{wrapUnescapedQuot(fileInfo.ETag)}
 		}
 	}
 
 	// User-defined metadata
 	for name, value := range fileInfo.Metadata {
-		w.Header().Set(HeaderNameXAmzMetaPrefix+name, value)
+		w.Header()[HeaderNameXAmzMetaPrefix+name] = []string{value}
 	}
 	return
 }
@@ -547,8 +547,8 @@ func (o *ObjectNode) deleteObjectsHandler(w http.ResponseWriter, r *http.Request
 	}
 
 	// set response header
-	w.Header().Set(HeaderNameContentType, HeaderValueContentTypeXML)
-	w.Header().Set(HeaderNameContentLength, strconv.Itoa(len(bytesRes)))
+	w.Header()[HeaderNameContentType] = []string{HeaderValueContentTypeXML}
+	w.Header()[HeaderNameContentLength] = []string{strconv.Itoa(len(bytesRes))}
 	if _, err = w.Write(bytesRes); err != nil {
 		log.LogErrorf("deleteObjectsHandler: write response body fail: requestID(%v) err(%v)", GetRequestID(r), err)
 	}
@@ -556,7 +556,7 @@ func (o *ObjectNode) deleteObjectsHandler(w http.ResponseWriter, r *http.Request
 }
 
 func parseCopySourceInfo(r *http.Request) (sourceBucket, sourceObject string) {
-	var copySource = r.Header.Get(HeaderNameCopySource)
+	var copySource = r.Header.Get(HeaderNameXAmzCopySource)
 	if strings.HasPrefix(copySource, "/") {
 		copySource = copySource[1:]
 	}
@@ -611,15 +611,15 @@ func (o *ObjectNode) copyObjectHandler(w http.ResponseWriter, r *http.Request) {
 	contentDisposition := r.Header.Get(HeaderNameContentDisposition)
 
 	// metadata directive, direct object node use source file metadata or recreate metadata for target file
-	metadataDirective := r.Header.Get(HeaderNameMetadataDirective)
+	metadataDirective := r.Header.Get(HeaderNameXAmzMetadataDirective)
 	// metadata directive default value is COPY
 	if len(metadataDirective) == 0 {
 		metadataDirective = MetadataDirectiveCopy
 	}
-	var opt = &PutObjectOption{
-		MIMEType: contentType,
-		Disposition:contentDisposition,
-		Metadata: metadata,
+	var opt = &PutFileOption{
+		MIMEType:    contentType,
+		Disposition: contentDisposition,
+		Metadata:    metadata,
 	}
 
 	sourceBucket, sourceObject := parseCopySourceInfo(r)
@@ -654,10 +654,10 @@ func (o *ObjectNode) copyObjectHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// get header
-	copyMatch := r.Header.Get(HeaderNameCopyMatch)
-	noneMatch := r.Header.Get(HeaderNameCopyNoneMatch)
-	modified := r.Header.Get(HeaderNameCopyModified)
-	unModified := r.Header.Get(HeaderNameCopyUnModified)
+	copyMatch := r.Header.Get(HeaderNameXAmzCopyMatch)
+	noneMatch := r.Header.Get(HeaderNameXAmzCopyNoneMatch)
+	modified := r.Header.Get(HeaderNameXAmzCopyModified)
+	unModified := r.Header.Get(HeaderNameXAmzCopyUnModified)
 
 	// response 412
 	if modified != "" {
@@ -742,8 +742,8 @@ func (o *ObjectNode) copyObjectHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// set response header
-	w.Header().Set(HeaderNameContentType, HeaderValueContentTypeXML)
-	w.Header().Set(HeaderNameContentLength, strconv.Itoa(len(bytes)))
+	w.Header()[HeaderNameContentType] = []string{HeaderValueContentTypeXML}
+	w.Header()[HeaderNameContentLength] = []string{strconv.Itoa(len(bytes))}
 	_, _ = w.Write(bytes)
 	return
 }
@@ -793,14 +793,15 @@ func (o *ObjectNode) getBucketV1Handler(w http.ResponseWriter, r *http.Request) 
 		maxKeysInt = uint64(MaxKeys)
 	}
 
-	listBucketRequest := &ListBucketRequestV1{
-		prefix:    prefix,
-		delimiter: delimiter,
-		marker:    marker,
-		maxKeys:   maxKeysInt,
+	var option = &ListFilesV1Option{
+		Prefix:    prefix,
+		Delimiter: delimiter,
+		Marker:    marker,
+		MaxKeys:   maxKeysInt,
 	}
 
-	fsFileInfos, nextMarker, isTruncated, prefixes, err := vol.ListFilesV1(listBucketRequest)
+	var result *ListFilesV1Result
+	result, err = vol.ListFilesV1(option)
 	if err != nil {
 		log.LogErrorf("getBucketV1Handler: list file fail: requestID(%v) volume(%v) err(%v)",
 			getRequestIP(r), vol.name, err)
@@ -809,31 +810,29 @@ func (o *ObjectNode) getBucketV1Handler(w http.ResponseWriter, r *http.Request) 
 	}
 
 	// get owner
-	bucketOwner := NewBucketOwner(vol)
-	var contents = make([]*Content, 0)
-	if len(fsFileInfos) > 0 {
-		for _, fsFileInfo := range fsFileInfos {
-			if fsFileInfo.Mode == 0 {
-				// Invalid file mode, which means that the inode of the file may not exist.
-				// Record and filter out the file.
-				log.LogWarnf("getBucketV2Handler: invalid file found: volume(%v) path(%v) inode(%v)",
-					vol.Name(), fsFileInfo.Path, fsFileInfo.Inode)
-				continue
-			}
-			content := &Content{
-				Key:          fsFileInfo.Path,
-				LastModified: formatTimeISO(fsFileInfo.ModifyTime),
-				ETag:         wrapUnescapedQuot(fsFileInfo.ETag),
-				Size:         int(fsFileInfo.Size),
-				StorageClass: StorageClassStandard,
-				Owner:        bucketOwner,
-			}
-			contents = append(contents, content)
+	var bucketOwner = NewBucketOwner(vol)
+	var contents = make([]*Content, 0, len(result.Files))
+	for _, file := range result.Files {
+		if file.Mode == 0 {
+			// Invalid file mode, which means that the inode of the file may not exist.
+			// Record and filter out the file.
+			log.LogWarnf("getBucketV2Handler: invalid file found: volume(%v) path(%v) inode(%v)",
+				vol.Name(), file.Path, file.Inode)
+			continue
 		}
+		content := &Content{
+			Key:          file.Path,
+			LastModified: formatTimeISO(file.ModifyTime),
+			ETag:         wrapUnescapedQuot(file.ETag),
+			Size:         int(file.Size),
+			StorageClass: StorageClassStandard,
+			Owner:        bucketOwner,
+		}
+		contents = append(contents, content)
 	}
 
 	var commonPrefixes = make([]*CommonPrefix, 0)
-	for _, prefix := range prefixes {
+	for _, prefix := range result.CommonPrefixes {
 		commonPrefix := &CommonPrefix{
 			Prefix: prefix,
 		}
@@ -846,8 +845,8 @@ func (o *ObjectNode) getBucketV1Handler(w http.ResponseWriter, r *http.Request) 
 		Marker:         marker,
 		MaxKeys:        int(maxKeysInt),
 		Delimiter:      delimiter,
-		IsTruncated:    isTruncated,
-		NextMarker:     nextMarker,
+		IsTruncated:    result.Truncated,
+		NextMarker:     result.NextMarker,
 		Contents:       contents,
 		CommonPrefixes: commonPrefixes,
 	}
@@ -861,8 +860,8 @@ func (o *ObjectNode) getBucketV1Handler(w http.ResponseWriter, r *http.Request) 
 	}
 
 	// set response header
-	w.Header().Set(HeaderNameContentType, HeaderValueContentTypeXML)
-	w.Header().Set(HeaderNameContentLength, strconv.Itoa(len(bytes)))
+	w.Header()[HeaderNameContentType] = []string{HeaderValueContentTypeXML}
+	w.Header()[HeaderNameContentLength] = []string{strconv.Itoa(len(bytes))}
 	_, _ = w.Write(bytes)
 
 	return
@@ -929,16 +928,17 @@ func (o *ObjectNode) getBucketV2Handler(w http.ResponseWriter, r *http.Request) 
 		fetchOwnerBool = false
 	}
 
-	request := &ListBucketRequestV2{
-		delimiter:  delimiter,
-		maxKeys:    maxKeysInt,
-		prefix:     prefix,
-		contToken:  contToken,
-		fetchOwner: fetchOwnerBool,
-		startAfter: startAfter,
+	var option = &ListFilesV2Option{
+		Delimiter:  delimiter,
+		MaxKeys:    maxKeysInt,
+		Prefix:     prefix,
+		ContToken:  contToken,
+		FetchOwner: fetchOwnerBool,
+		StartAfter: startAfter,
 	}
 
-	fsFileInfos, keyCount, nextToken, isTruncated, prefixes, err := vol.ListFilesV2(request)
+	var result *ListFilesV2Result
+	result, err = vol.ListFilesV2(option)
 	if err != nil {
 		log.LogErrorf("getBucketV2Handler: list files fail: requestID(%v) err(%v)", GetRequestID(r), err)
 		errorCode = InternalErrorCode(err)
@@ -951,20 +951,20 @@ func (o *ObjectNode) getBucketV2Handler(w http.ResponseWriter, r *http.Request) 
 	}
 
 	var contents = make([]*Content, 0)
-	if len(fsFileInfos) > 0 {
-		for _, fsFileInfo := range fsFileInfos {
-			if fsFileInfo.Mode == 0 {
+	if len(result.Files) > 0 {
+		for _, file := range result.Files {
+			if file.Mode == 0 {
 				// Invalid file mode, which means that the inode of the file may not exist.
 				// Record and filter out the file.
 				log.LogWarnf("getBucketV2Handler: invalid file found: volume(%v) path(%v) inode(%v)",
-					vol.Name(), fsFileInfo.Path, fsFileInfo.Inode)
+					vol.Name(), file.Path, file.Inode)
 				continue
 			}
 			content := &Content{
-				Key:          fsFileInfo.Path,
-				LastModified: formatTimeISO(fsFileInfo.ModifyTime),
-				ETag:         wrapUnescapedQuot(fsFileInfo.ETag),
-				Size:         int(fsFileInfo.Size),
+				Key:          file.Path,
+				LastModified: formatTimeISO(file.ModifyTime),
+				ETag:         wrapUnescapedQuot(file.ETag),
+				Size:         int(file.Size),
 				StorageClass: StorageClassStandard,
 				Owner:        bucketOwner,
 			}
@@ -973,7 +973,7 @@ func (o *ObjectNode) getBucketV2Handler(w http.ResponseWriter, r *http.Request) 
 	}
 
 	var commonPrefixes = make([]*CommonPrefix, 0)
-	for _, prefix := range prefixes {
+	for _, prefix := range result.CommonPrefixes {
 		commonPrefix := &CommonPrefix{
 			Prefix: prefix,
 		}
@@ -984,11 +984,11 @@ func (o *ObjectNode) getBucketV2Handler(w http.ResponseWriter, r *http.Request) 
 		Name:           param.Bucket(),
 		Prefix:         prefix,
 		Token:          contToken,
-		NextToken:      nextToken,
-		KeyCount:       keyCount,
+		NextToken:      result.NextToken,
+		KeyCount:       result.KeyCount,
 		MaxKeys:        maxKeysInt,
 		Delimiter:      delimiter,
-		IsTruncated:    isTruncated,
+		IsTruncated:    result.Truncated,
 		Contents:       contents,
 		CommonPrefixes: commonPrefixes,
 	}
@@ -1002,8 +1002,8 @@ func (o *ObjectNode) getBucketV2Handler(w http.ResponseWriter, r *http.Request) 
 	}
 
 	// set response header
-	w.Header().Set(HeaderNameContentType, HeaderValueContentTypeXML)
-	w.Header().Set(HeaderNameContentLength, strconv.Itoa(len(bytes)))
+	w.Header()[HeaderNameContentType] = []string{HeaderValueContentTypeXML}
+	w.Header()[HeaderNameContentLength] = []string{strconv.Itoa(len(bytes))}
 	if _, err = w.Write(bytes); err != nil {
 		log.LogErrorf("getBucketVeHandler: write response body fail, requestID(%v) err(%v)", GetRequestID(r), err)
 	}
@@ -1070,7 +1070,7 @@ func (o *ObjectNode) putObjectHandler(w http.ResponseWriter, r *http.Request) {
 		GetRequestID(r), getRequestIP(r), vol.Name(), param.Object(), contentType)
 
 	var fsFileInfo *FSFileInfo
-	var opt = &PutObjectOption{
+	var opt = &PutFileOption{
 		MIMEType: contentType,
 		Tagging:  tagging,
 		Metadata: metadata,
@@ -1105,8 +1105,8 @@ func (o *ObjectNode) putObjectHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// set response header
-	w.Header().Set(HeaderNameETag, wrapUnescapedQuot(fsFileInfo.ETag))
-	w.Header().Set(HeaderNameContentLength, "0")
+	w.Header()[HeaderNameETag] = []string{wrapUnescapedQuot(fsFileInfo.ETag)}
+	w.Header()[HeaderNameContentLength] = []string{"0"}
 	return
 }
 

--- a/objectnode/api_middleware.go
+++ b/objectnode/api_middleware.go
@@ -62,8 +62,8 @@ func (o *ObjectNode) traceMiddleware(next http.Handler) http.Handler {
 
 		// store request ID to context and write to header
 		SetRequestID(r, requestID)
-		w.Header().Set(HeaderNameRequestId, requestID)
-		w.Header().Set(HeaderNameServer, HeaderValueServer)
+		w.Header()[HeaderNameXAmzRequestId] = []string{requestID}
+		w.Header()[HeaderNameServer] = []string{HeaderValueServer}
 
 		var action = ActionFromRouteName(mux.CurrentRoute(r).GetName())
 		SetRequestAction(r, action)
@@ -185,7 +185,7 @@ func (o *ObjectNode) policyCheckMiddleware(next http.Handler) http.Handler {
 //   request → [pre-handle] → [next handler] → response
 func (o *ObjectNode) contentMiddleware(next http.Handler) http.Handler {
 	var handlerFunc http.HandlerFunc = func(w http.ResponseWriter, r *http.Request) {
-		if len(r.Header) > 0 && len(r.Header.Get(http.CanonicalHeaderKey(HeaderNameDecodeContentLength))) > 0 {
+		if len(r.Header) > 0 && len(r.Header.Get(http.CanonicalHeaderKey(HeaderNameXAmzDecodeContentLength))) > 0 {
 			r.Body = NewClosableChunkedReader(r.Body)
 			log.LogDebugf("contentMiddleware: chunk reader inited: requestID(%v)", GetRequestID(r))
 		}
@@ -225,10 +225,10 @@ func (o *ObjectNode) expectMiddleware(next http.Handler) http.Handler {
 func (o *ObjectNode) corsMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// write access control allow headers
-		w.Header().Set(HeaderNameAccessControlAllowOrigin, "*")
-		w.Header().Set(HeaderNameAccessControlAllowHeaders, "*")
-		w.Header().Set(HeaderNameAccessControlAllowMethods, "*")
-		w.Header().Set(HeaderNameAccessControlMaxAge, "0")
+		w.Header()[HeaderNameAccessControlAllowOrigin] = []string{"*"}
+		w.Header()[HeaderNameAccessControlAllowHeaders] = []string{"*"}
+		w.Header()[HeaderNameAccessControlAllowMethods] = []string{"*"}
+		w.Header()[HeaderNameAccessControlMaxAge] = []string{"0"}
 		next.ServeHTTP(w, r)
 	})
 }

--- a/objectnode/auth_signature_v4.go
+++ b/objectnode/auth_signature_v4.go
@@ -464,7 +464,7 @@ func buildSigningKey(scheme, secret, date, region, service, terminator string) [
 
 func getContentHash(headers http.Header) (contentHash string) {
 	for headerName := range headers {
-		if strings.ToLower(headerName) == strings.ToLower(HeaderNameContentHash) {
+		if strings.ToLower(headerName) == strings.ToLower(HeaderNameXAmzContentHash) {
 			contentHash = headers.Get(headerName)
 			break
 		}

--- a/objectnode/const.go
+++ b/objectnode/const.go
@@ -16,7 +16,9 @@ package objectnode
 
 import "os"
 
-type OSSOperation string
+const (
+	MaxRetry = 3
+)
 
 const (
 	HeaderNameServer             = "Server"
@@ -24,8 +26,8 @@ const (
 	HeaderNameLastModified       = "Last-Modified"
 	HeaderNameETag               = "ETag"
 	HeaderNameDate               = "Date"
-	HeaderNameContentMD5         = "content-md5"
-	HeaderNameContentEnc         = "content-encoding"
+	HeaderNameContentMD5         = "Content-MD5"
+	HeaderNameContentEnc         = "Content-Encoding"
 	HeaderNameContentType        = "Content-Type"
 	HeaderNameContentLength      = "Content-Length"
 	HeaderNameContentRange       = "Content-Range"
@@ -35,6 +37,7 @@ const (
 	HeaderNameRange              = "Range"
 	HeaderNameExpect             = "Expect"
 	HeaderNameXForwardedExpect   = "X-Forwarded-Expect"
+	HeaderNameLocation           = "Location"
 
 	// Headers for CORS validation
 	HeaderNameAccessControlAllowOrigin  = "Access-Control-Allow-Origin"
@@ -42,19 +45,19 @@ const (
 	HeaderNameAccessControlAllowHeaders = "Access-Control-Allow-Headers"
 	HeaderNameAccessControlMaxAge       = "Access-Control-Max-Age"
 
-	HeaderNameStartDate           = "x-amz-date"
-	HeaderNameRequestId           = "x-amz-request-id"
-	HeaderNameContentHash         = "X-Amz-Content-SHA256"
-	HeaderNameCopySource          = "X-Amz-Copy-Source"
-	HeaderNameCopyMatch           = "x-amz-copy-source-if-match"
-	HeaderNameCopyNoneMatch       = "x-amz-copy-source-if-none-match"
-	HeaderNameCopyModified        = "x-amz-copy-source-if-modified-since"
-	HeaderNameCopyUnModified      = "x-amz-copy-source-if-unmodified-since"
-	HeaderNameDecodeContentLength = "X-Amz-Decoded-Content-Length"
-	HeaderNameXAmzTagging         = "x-amz-tagging"
-	HeaderNameXAmzMetaPrefix      = "x-amz-meta-"
-	HeaderNameDownloadPartCount   = "x-amz-mp-parts-count"
-	HeaderNameMetadataDirective   = "x-amz-metadata-directive"
+	HeaderNameXAmzStartDate           = "x-amz-date"
+	HeaderNameXAmzRequestId           = "x-amz-request-id"
+	HeaderNameXAmzContentHash         = "x-amz-content-sha256"
+	HeaderNameXAmzCopySource          = "x-amz-copy-source"
+	HeaderNameXAmzCopyMatch           = "x-amz-copy-source-if-match"
+	HeaderNameXAmzCopyNoneMatch       = "x-amz-copy-source-if-none-match"
+	HeaderNameXAmzCopyModified        = "x-amz-copy-source-if-modified-since"
+	HeaderNameXAmzCopyUnModified      = "x-amz-copy-source-if-unmodified-since"
+	HeaderNameXAmzDecodeContentLength = "x-amz-decoded-content-length"
+	HeaderNameXAmzTagging             = "x-amz-tagging"
+	HeaderNameXAmzMetaPrefix          = "x-amz-meta-"
+	HeaderNameXAmzDownloadPartCount   = "x-amz-mp-parts-count"
+	HeaderNameXAmzMetadataDirective   = "x-amz-metadata-directive"
 
 	HeaderNameIfMatch           = "If-Match"
 	HeaderNameIfNoneMatch       = "If-None-Match"

--- a/objectnode/fs_volume.go
+++ b/objectnode/fs_volume.go
@@ -109,11 +109,42 @@ func (v *Volume) storeACL(p *AccessControlPolicy) {
 	return
 }
 
-type PutObjectOption struct {
+type PutFileOption struct {
 	MIMEType    string
 	Disposition string
 	Tagging     *Tagging
 	Metadata    map[string]string
+}
+
+type ListFilesV1Option struct {
+	Prefix    string
+	Delimiter string
+	Marker    string
+	MaxKeys   uint64
+}
+
+type ListFilesV1Result struct {
+	Files          []*FSFileInfo
+	NextMarker     string
+	Truncated      bool
+	CommonPrefixes []string
+}
+
+type ListFilesV2Option struct {
+	Delimiter  string
+	MaxKeys    uint64
+	Prefix     string
+	ContToken  string
+	FetchOwner bool
+	StartAfter string
+}
+
+type ListFilesV2Result struct {
+	Files          []*FSFileInfo
+	KeyCount       uint64
+	NextToken      string
+	Truncated      bool
+	CommonPrefixes []string
 }
 
 // Volume is a high-level encapsulation of meta sdk and data sdk methods.
@@ -314,15 +345,13 @@ func (v *Volume) OSSSecure() (accessKey, secretKey string) {
 // ListFilesV1 returns file and directory entry list information that meets the parameters.
 // It supports parameters such as prefix, delimiter, and paging.
 // It is a data plane logical encapsulation of the object storage interface ListObjectsV1.
-func (v *Volume) ListFilesV1(request *ListBucketRequestV1) ([]*FSFileInfo, string, bool, []string, error) {
-	//prefix, delimiter, marker string, maxKeys uint64
+func (v *Volume) ListFilesV1(opt *ListFilesV1Option) (result *ListFilesV1Result, err error) {
 
-	marker := request.marker
-	prefix := request.prefix
-	maxKeys := request.maxKeys
-	delimiter := request.delimiter
+	marker := opt.Marker
+	prefix := opt.Prefix
+	maxKeys := opt.MaxKeys
+	delimiter := opt.Delimiter
 
-	var err error
 	var infos []*FSFileInfo
 	var prefixes Prefixes
 
@@ -330,32 +359,35 @@ func (v *Volume) ListFilesV1(request *ListBucketRequestV1) ([]*FSFileInfo, strin
 	if err != nil {
 		log.LogErrorf("ListFilesV1: list fail: volume(%v) prefix(%v) marker(%v) delimiter(%v) maxKeys(%v) err(%v)",
 			v.name, prefix, marker, delimiter, maxKeys, err)
-		return nil, "", false, nil, err
+		return
 	}
 
-	var nextMarker string
-	var isTruncated bool
-
+	result = &ListFilesV1Result{
+		CommonPrefixes: prefixes,
+	}
 	if len(infos) > int(maxKeys) {
-		nextMarker = infos[maxKeys].Path
-		infos = infos[:maxKeys]
-		isTruncated = true
+		result.NextMarker = infos[maxKeys].Path
+		result.Files = infos[:maxKeys]
+		result.Truncated = true
+	} else {
+		result.NextMarker = ""
+		result.Files = infos
+		result.Truncated = false
 	}
 
-	return infos, nextMarker, isTruncated, prefixes, nil
+	return
 }
 
 // ListFilesV2 returns file and directory entry list information that meets the parameters.
 // It supports parameters such as prefix, delimiter, and paging.
 // It is a data plane logical encapsulation of the object storage interface ListObjectsV2.
-func (v *Volume) ListFilesV2(request *ListBucketRequestV2) ([]*FSFileInfo, uint64, string, bool, []string, error) {
-	delimiter := request.delimiter
-	maxKeys := request.maxKeys
-	prefix := request.prefix
-	contToken := request.contToken
-	startAfter := request.startAfter
+func (v *Volume) ListFilesV2(opt *ListFilesV2Option) (result *ListFilesV2Result, err error) {
+	delimiter := opt.Delimiter
+	maxKeys := opt.MaxKeys
+	prefix := opt.Prefix
+	contToken := opt.ContToken
+	startAfter := opt.StartAfter
 
-	var err error
 	var infos []*FSFileInfo
 	var prefixes Prefixes
 
@@ -363,22 +395,26 @@ func (v *Volume) ListFilesV2(request *ListBucketRequestV2) ([]*FSFileInfo, uint6
 	if err != nil {
 		log.LogErrorf("ListFilesV2: list fail: volume(%v) prefix(%v) startAfter(%v) contToken(%v) delimiter(%v) maxKeys(%v) err(%v)",
 			v.name, prefix, startAfter, contToken, delimiter, maxKeys, err)
-		return nil, 0, "", false, nil, err
+		return
 	}
 
-	var keyCount uint64
-	var nextToken string
-	var isTruncated bool
+	result = &ListFilesV2Result{
+		CommonPrefixes: prefixes,
+	}
 
-	keyCount = uint64(len(infos))
 	if len(infos) > int(maxKeys) {
-		nextToken = infos[maxKeys].Path
-		infos = infos[:maxKeys]
-		isTruncated = true
-		keyCount = maxKeys
+		result.NextToken = infos[maxKeys].Path
+		result.Files = infos[:maxKeys]
+		result.Truncated = true
+		result.KeyCount = maxKeys
+	} else {
+		result.NextToken = ""
+		result.Files = infos
+		result.Truncated = false
+		result.KeyCount = uint64(len(infos))
 	}
 
-	return infos, keyCount, nextToken, isTruncated, prefixes, nil
+	return
 }
 
 // WriteObject creates or updates target path objects and data.
@@ -394,7 +430,7 @@ func (v *Volume) ListFilesV2(request *ListBucketRequestV2) ([]*FSFileInfo, uint6
 // but actual is a directory.
 // An syscall.EINVAL error is returned indicating that a part of the target path expected to be a directory
 // but actual is a file.
-func (v *Volume) PutObject(path string, reader io.Reader, opt *PutObjectOption) (fsInfo *FSFileInfo, err error) {
+func (v *Volume) PutObject(path string, reader io.Reader, opt *PutFileOption) (fsInfo *FSFileInfo, err error) {
 	defer func() {
 		// Audit behavior
 		log.LogInfof("Audit: PutObject: volume(%v) path(%v) err(%v)", v.name, path, err)
@@ -579,9 +615,9 @@ func (v *Volume) PutObject(path string, reader io.Reader, opt *PutObjectOption) 
 					v.name, path, invisibleTempDataInode.Inode, name, value, err)
 				return nil, err
 			}
-			log.LogErrorf("PutObject: store user-defined metadata: "+
-				"volume(%v) path(%v) inode(%v) key(%v) value(%v) err(%v)",
-				v, name, path, invisibleTempDataInode.Inode, name, value)
+			log.LogDebugf("PutObject: store user-defined metadata: "+
+				"volume(%v) path(%v) inode(%v) key(%v) value(%v)",
+				v.name, path, invisibleTempDataInode.Inode, name, value)
 		}
 	}
 
@@ -678,11 +714,12 @@ func (v *Volume) InitMultipart(path string) (multipartID string, err error) {
 }
 
 func (v *Volume) WritePart(path string, multipartId string, partId uint16, reader io.Reader) (*FSFileInfo, error) {
+	var exist bool
 	var err error
 	defer func() {
 		// Audit behavior
-		log.LogInfof("Audit: WritePart: volume(%v) path(%v) multipartID(%v) partID(%v) err(%v)",
-			v.name, path, multipartId, partId, err)
+		log.LogInfof("Audit: WritePart: volume(%v) path(%v) multipartID(%v) partID(%v) exist(%v) err(%v)",
+			v.name, path, multipartId, partId, exist, err)
 	}()
 	var parentId uint64
 	var fInfo *FSFileInfo
@@ -700,16 +737,30 @@ func (v *Volume) WritePart(path string, multipartId string, partId uint16, reade
 			multipartId, parentId, err)
 		return nil, err
 	}
-	log.LogDebugf("WritePart: meta create temp file inode: multipartID(%v) partID(%v) inode(%v)",
-		multipartId, parentId, tempInodeInfo.Inode)
+	log.LogDebugf("WritePart: meta create temp file inode: volume(%v) path(%v) multipartID(%v) partID(%v) inode(%v)",
+		v.name, path, multipartId, partId, tempInodeInfo.Inode)
+
+	defer func() {
+		// An error has caused the entire process to fail. Delete the inode and release the written data.
+		if err != nil || exist {
+			log.LogWarnf("PutObject: unlink part inode: volume(%v) path(%v) multipartID(%v) partID(%v) inode(%v)",
+				v.name, path, multipartId, partId, tempInodeInfo.Inode)
+			_, _ = v.mw.InodeUnlink_ll(tempInodeInfo.Inode)
+			log.LogWarnf("PutObject: evict part inode: volume(%v) path(%v) multipartID(%v) partID(%v) inode(%v)",
+				v.name, path, multipartId, partId, tempInodeInfo.Inode)
+			_ = v.mw.Evict(tempInodeInfo.Inode)
+		}
+	}()
 
 	if err = v.ec.OpenStream(tempInodeInfo.Inode); err != nil {
-		log.LogErrorf("WritePart: data open stream fail, inode(%v) err(%v)", tempInodeInfo.Inode, err)
+		log.LogErrorf("WritePart: data open stream fail: volume(%v) path(%v) multipartID(%v) partID(%v) inode(%v) err(%v)",
+			v.name, path, multipartId, partId, tempInodeInfo.Inode, err)
 		return nil, err
 	}
 	defer func() {
 		if closeErr := v.ec.CloseStream(tempInodeInfo.Inode); closeErr != nil {
-			log.LogErrorf("WritePart: data close stream fail, inode(%v) err(%v)", tempInodeInfo.Inode, closeErr)
+			log.LogErrorf("WritePart: data close stream fail: volume(%v) path(%v) multipartID(%v) partID(%v) inode(%v) err(%v)",
+				v.name, path, multipartId, partId, tempInodeInfo.Inode, closeErr)
 		}
 	}()
 
@@ -728,25 +779,24 @@ func (v *Volume) WritePart(path string, multipartId string, partId uint16, reade
 
 	// flush
 	if err = v.ec.Flush(tempInodeInfo.Inode); err != nil {
-		log.LogErrorf("WritePart: data flush inode fail, inode(%v) err(%v)", tempInodeInfo.Inode, err)
-		return nil, err
-	}
-
-	// save temp file MD5
-	if err = v.mw.XAttrSet_ll(tempInodeInfo.Inode, []byte(XAttrKeyOSSETag), []byte(etag)); err != nil {
-		log.LogErrorf("WritePart: meta set xattr fail, inode(%v) key(%v) val(%v) err(%v)",
-			tempInodeInfo, XAttrKeyOSSETag, etag, err)
+		log.LogErrorf("WritePart: data flush inode fail: volume(%v) inode(%v) err(%v)", v.name, tempInodeInfo.Inode, err)
 		return nil, err
 	}
 
 	// update temp file inode to meta with session
-	if err = v.mw.AddMultipartPart_ll(multipartId, parentId, partId, size, etag, tempInodeInfo.Inode); err != nil {
-		log.LogErrorf("WritePart: meta add multipart part fail: multipartID(%v) parentID(%v) partID(%v) inode(%v) size(%v) MD5(%v) err(%v)",
-			multipartId, parentId, parentId, tempInodeInfo.Inode, size, etag, err)
+	err = v.mw.AddMultipartPart_ll(multipartId, parentId, partId, size, etag, tempInodeInfo.Inode)
+	if err == syscall.EEXIST {
+		// Result success but cleanup data.
+		err = nil
+		exist = true
+	}
+	if err != nil {
+		log.LogErrorf("WritePart: meta add multipart part fail: volume(%v) path(%v) multipartID(%v) partID(%v) parentID(%v) inode(%v) size(%v) MD5(%v) err(%v)",
+			v.name, path, multipartId, partId, parentId, tempInodeInfo.Inode, size, etag, err)
 		return nil, err
 	}
-	log.LogDebugf("WritePart: meta add multipart part: multipartID(%v) parentID(%v) partID(%v) inode(%v) size(%v) MD5(%v)",
-		multipartId, parentId, parentId, tempInodeInfo.Inode, size, etag)
+	log.LogDebugf("WritePart: meta add multipart part: volume(%v) path(%v) multipartID(%v) partID(%v) parentID(%v) inode(%v) size(%v) MD5(%v)",
+		v.name, path, multipartId, partId, parentId, tempInodeInfo.Inode, size, etag)
 
 	// create file info
 	fInfo = &FSFileInfo{
@@ -810,15 +860,15 @@ func (v *Volume) AbortMultipart(path string, multipartID string) (err error) {
 }
 
 func (v *Volume) CompleteMultipart(path string, multipartID string) (fsFileInfo *FSFileInfo, err error) {
-	log.LogInfof("CompleteMultipart: volume(%v) path(%v) multipartID(%v)",
-		v.name, path, multipartID)
-	var parentId uint64
+	defer func() {
+		log.LogInfof("Audit: CompleteMultipart: volume(%v) path(%v) multipartID(%v) err(%v)",
+			v.name, path, multipartID, err)
+	}()
 
-	dirs, filename := splitPath(path)
-	// process path
-	if parentId, err = v.lookupDirectories(dirs, true); err != nil {
-		log.LogErrorf("CompleteMultipart: lookup directories fail, multipartID(%v) path(%v) dirs(%v) err(%v)",
-			multipartID, path, dirs, err)
+	var parentId uint64
+	if parentId, err = v.recursiveMakeDirectory(path); err != nil {
+		log.LogErrorf("PutObject: recursive make directory fail: volume(%v) path(%v) err(%v)",
+			v.name, path, err)
 		return
 	}
 
@@ -837,17 +887,19 @@ func (v *Volume) CompleteMultipart(path string, multipartID string) (fsFileInfo 
 	// create inode for complete data
 	var completeInodeInfo *proto.InodeInfo
 	if completeInodeInfo, err = v.mw.InodeCreate_ll(DefaultFileMode, 0, 0, nil); err != nil {
-		log.LogErrorf("CompleteMultipart: meta inode create fail: volume(%v) err(%v)", v.name, err)
+		log.LogErrorf("CompleteMultipart: meta inode create fail: volume(%v) path(%v) multipartID(%v) err(%v)",
+			v.name, path, multipartID, err)
 		return
 	}
-	log.LogDebugf("CompleteMultipart: meta inode create: inode(%v)", completeInodeInfo.Inode)
+	log.LogDebugf("CompleteMultipart: meta inode create: volume(%v) path(%v) multipartID(%v) inode(%v)",
+		v.name, path, multipartID, completeInodeInfo.Inode)
 	defer func() {
 		if err != nil {
-			log.LogWarnf("CompleteMultipart: destroy inode: volume(%v) inode(%v)",
-				v.name, completeInodeInfo.Inode)
+			log.LogWarnf("CompleteMultipart: destroy inode: volume(%v) path(%v) multipartID(%v) inode(%v)",
+				v.name, path, multipartID, completeInodeInfo.Inode)
 			if deleteErr := v.mw.InodeDelete_ll(completeInodeInfo.Inode); deleteErr != nil {
-				log.LogErrorf("CompleteMultipart: meta delete complete inode fail: volume(%v) inode(%v) err(%v)",
-					v.name, completeInodeInfo.Inode, err)
+				log.LogErrorf("CompleteMultipart: meta delete complete inode fail: volume(%v) path(%v) multipartID(%v) inode(%v) err(%v)",
+					v.name, path, multipartID, completeInodeInfo.Inode, err)
 			}
 		}
 	}()
@@ -859,8 +911,8 @@ func (v *Volume) CompleteMultipart(path string, multipartID string) (fsFileInfo 
 	for _, part := range parts {
 		var eks []proto.ExtentKey
 		if _, _, eks, err = v.mw.GetExtents(part.Inode); err != nil {
-			log.LogErrorf("CompleteMultipart: meta get extents fail: volume(%v) inode(%v) err(%v)",
-				v.name, part.Inode, err)
+			log.LogErrorf("CompleteMultipart: meta get extents fail: volume(%v) path(%v) multipartID(%v) partID(%v) inode(%v) err(%v)",
+				v.name, path, multipartID, part.ID, part.Inode, err)
 			return
 		}
 		// recompute offsets of extent keys
@@ -883,14 +935,18 @@ func (v *Volume) CompleteMultipart(path string, multipartID string) (fsFileInfo 
 		}
 		md5Val = hex.EncodeToString(md5Hash.Sum(nil))
 	}
-	log.LogDebugf("CompleteMultipart: merge parts: numParts(%v) MD5(%v)", len(parts), md5Val)
+	log.LogDebugf("CompleteMultipart: merge parts: volume(%v) path(%v) multipartID(%v) numParts(%v) MD5(%v)",
+		v.name, path, multipartID, len(parts), md5Val)
 
 	if err = v.mw.AppendExtentKeys(completeInodeInfo.Inode, completeExtentKeys); err != nil {
-		log.LogErrorf("CompleteMultipart: meta append extent keys fail: inode(%v) err(%v)", completeInodeInfo.Inode, err)
+		log.LogErrorf("CompleteMultipart: meta append extent keys fail: volume(%v) path(%v) multipartID(%v) inode(%v) err(%v)",
+			v.name, path, multipartID, completeInodeInfo.Inode, err)
 		return
 	}
 
 	var (
+		pathItems = NewPathIterator(path).ToSlice()
+		filename  = pathItems[len(pathItems)-1].Name
 		existMode uint32
 	)
 	_, existMode, err = v.mw.Lookup_ll(parentId, filename)
@@ -901,22 +957,22 @@ func (v *Volume) CompleteMultipart(path string, multipartID string) (fsFileInfo 
 
 	if err == syscall.ENOENT {
 		if err = v.applyInodeToNewDentry(parentId, filename, completeInodeInfo.Inode); err != nil {
-			log.LogErrorf("CompleteMultipart: apply inode to new dentry fail: parentID(%v) name(%v) inode(%v) err(%v)",
-				parentId, filename, completeInodeInfo.Inode, err)
+			log.LogErrorf("CompleteMultipart: apply inode to new dentry fail: volume(%v) path(%v) multipartID(%v) parentID(%v) name(%v) inode(%v) err(%v)",
+				v.name, path, multipartID, parentId, filename, completeInodeInfo.Inode, err)
 			return
 		}
-		log.LogDebugf("CompleteMultipart: apply inode to new dentry: parentID(%v) name(%v) inode(%v)",
-			parentId, filename, completeInodeInfo.Inode)
+		log.LogDebugf("CompleteMultipart: apply inode to new dentry: volume(%v) path(%v) multipartID(%v) parentID(%v) name(%v) inode(%v)",
+			v.name, path, multipartID, parentId, filename, completeInodeInfo.Inode)
 	} else {
 		if os.FileMode(existMode).IsDir() {
-			log.LogErrorf("CompleteMultipart: target mode conflict: parentID(%v) name(%v) mode(%v)",
-				parentId, filename, os.FileMode(existMode).String())
-			err = syscall.EEXIST
+			log.LogErrorf("CompleteMultipart: target mode conflict: volume(%v) path(%v) multipartID(%v) parentID(%v) name(%v) mode(%v)",
+				v.name, path, multipartID, parentId, filename, os.FileMode(existMode).String())
+			err = syscall.EINVAL
 			return
 		}
 		if err = v.applyInodeToExistDentry(parentId, filename, completeInodeInfo.Inode); err != nil {
-			log.LogErrorf("CompleteMultipart: apply inode to exist dentry fail: parentID(%v) name(%v) inode(%v) err(%v)",
-				parentId, filename, completeInodeInfo.Inode, err)
+			log.LogErrorf("CompleteMultipart: apply inode to exist dentry fail: volume(%v) path(%v) multipartID(%v) parentID(%v) name(%v) inode(%v) err(%v)",
+				v.name, path, multipartID, parentId, filename, completeInodeInfo.Inode, err)
 			return
 		}
 	}
@@ -1187,15 +1243,24 @@ func (v *Volume) ObjectMeta(path string) (info *FSFileInfo, err error) {
 	// process path
 	var inode uint64
 	var mode os.FileMode
-	if _, inode, _, mode, err = v.recursiveLookupTarget(path); err != nil {
-		return
-	}
-
-	// read file data
 	var inoInfo *proto.InodeInfo
-	if inoInfo, err = v.mw.InodeGet_ll(inode); err != nil {
-		log.LogWarnf("ObjectMeta: get inode fail: volume(%v) path(%v) inode(%v)", v.name, path, inode)
-		return
+
+	var retry = 0
+	for {
+		if _, inode, _, mode, err = v.recursiveLookupTarget(path); err != nil {
+			return
+		}
+
+		inoInfo, err = v.mw.InodeGet_ll(inode)
+		if err == syscall.ENOENT && retry < MaxRetry {
+			retry++
+			continue
+		}
+		if err != nil {
+			log.LogErrorf("ObjectMeta: get inode fail: volume(%v) path(%v) inode(%v) retry(%v) err(%v)", v.name, path, inode, retry, err)
+			return
+		}
+		break
 	}
 
 	var etagValue ETagValue
@@ -1673,8 +1738,8 @@ func (v *Volume) supplyListFileInfo(fileInfos []*FSFileInfo) (err error) {
 		i := sort.Search(len(xattrs), func(i int) bool {
 			return xattrs[i].Inode >= fileInfo.Inode
 		})
+		var etagValue ETagValue
 		if i >= 0 && i < len(xattrs) && xattrs[i].Inode == fileInfo.Inode {
-			var etagValue ETagValue
 			etagRaw, etagInvalidRaw := xattrs[i].Get(XAttrKeyOSSETag), xattrs[i].Get(XAttrKeyOSSETagInvalid)
 			if len(etagRaw) != 0 {
 				etagValue = ParseETagValue(string(etagRaw))
@@ -1682,17 +1747,17 @@ func (v *Volume) supplyListFileInfo(fileInfos []*FSFileInfo) (err error) {
 			if len(etagInvalidRaw) != 0 {
 				etagValue = ParseETagValue(string(etagInvalidRaw))
 			}
-			if !etagValue.Valid() || etagValue.TS.Before(fileInfo.ModifyTime) {
-				// The ETag is invalid or outdated then generate a new ETag and make update.
-				if etagValue, err = v.updateETag(fileInfo.Inode, fileInfo.Size, fileInfo.ModifyTime); err != nil {
-					log.LogErrorf("supplyListFileInfo: update ETag fail: volume(%v) path(%v) inode(%v) err(%v)",
-						v.name, fileInfo.Path, fileInfo.Inode, err)
-				}
-				log.LogDebugf("supplyListFileInfo: update ETag: volume(%v) path(%v) inode(%v) etagValue(%v)",
-					v.name, fileInfo.Path, fileInfo.Inode, etagValue)
-			}
-			fileInfo.ETag = etagValue.ETag()
 		}
+		if !etagValue.Valid() || etagValue.TS.Before(fileInfo.ModifyTime) {
+			// The ETag is invalid or outdated then generate a new ETag and make update.
+			if etagValue, err = v.updateETag(fileInfo.Inode, fileInfo.Size, fileInfo.ModifyTime); err != nil {
+				log.LogErrorf("supplyListFileInfo: update ETag fail: volume(%v) path(%v) inode(%v) err(%v)",
+					v.name, fileInfo.Path, fileInfo.Inode, err)
+			}
+			log.LogDebugf("supplyListFileInfo: update ETag: volume(%v) path(%v) inode(%v) etagValue(%v)",
+				v.name, fileInfo.Path, fileInfo.Inode, etagValue)
+		}
+		fileInfo.ETag = etagValue.ETag()
 	}
 	return
 }
@@ -1771,6 +1836,7 @@ func (v *Volume) ListParts(path, uploadId string, maxParts, partNumberMarker uin
 	multipartInfo, err := v.mw.GetMultipart_ll(uploadId, parentId)
 	if err != nil {
 		log.LogErrorf("ListPart: get multipart upload fail: volume(%v) uploadID(%v) err(%v)", v.name, uploadId, err)
+		return
 	}
 
 	sessionParts := multipartInfo.Parts
@@ -1798,7 +1864,7 @@ func (v *Volume) ListParts(path, uploadId string, maxParts, partNumberMarker uin
 	return parts, nextMarker, isTruncated, nil
 }
 
-func (v *Volume) CopyFile(sv *Volume, sourcePath, targetPath, metaDirective string, opt *PutObjectOption) (info *FSFileInfo, err error) {
+func (v *Volume) CopyFile(sv *Volume, sourcePath, targetPath, metaDirective string, opt *PutFileOption) (info *FSFileInfo, err error) {
 	defer func() {
 		log.LogInfof("Audit: copy file: source path(%v) target path(%v) err(%v)",
 			sourcePath, targetPath, err)

--- a/objectnode/result.go
+++ b/objectnode/result.go
@@ -214,22 +214,6 @@ type CopyResult struct {
 	ETag         string   `xml:"ETag,omitempty"`
 }
 
-type ListBucketRequestV1 struct {
-	prefix    string
-	delimiter string
-	marker    string
-	maxKeys   uint64
-}
-
-type ListBucketRequestV2 struct {
-	delimiter  string
-	maxKeys    uint64
-	prefix     string
-	contToken  string
-	fetchOwner bool
-	startAfter string
-}
-
 type ListBucketResultV2 struct {
 	XMLName        xml.Name        `xml:"ListBucketResult"`
 	Name           string          `xml:"Name"`

--- a/objectnode/result_error.go
+++ b/objectnode/result_error.go
@@ -44,7 +44,7 @@ func (code ErrorCode) ServeResponse(w http.ResponseWriter, r *http.Request) erro
 	if marshaled, err = xml.Marshal(&xmlError); err != nil {
 		return err
 	}
-	w.Header().Set(HeaderNameContentType, HeaderValueContentTypeXML)
+	w.Header()[HeaderNameContentType] = []string{HeaderValueContentTypeXML}
 	w.WriteHeader(code.StatusCode)
 	if _, err = w.Write(marshaled); err != nil {
 		return err
@@ -53,7 +53,7 @@ func (code ErrorCode) ServeResponse(w http.ResponseWriter, r *http.Request) erro
 }
 
 func ServeInternalStaticErrorResponse(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set(HeaderNameContentType, HeaderValueContentTypeXML)
+	w.Header()[HeaderNameContentType] = []string{HeaderValueContentTypeXML}
 	w.WriteHeader(http.StatusInternalServerError)
 	sb := strings.Builder{}
 	sb.WriteString(xml.Header)
@@ -91,8 +91,8 @@ var (
 	ObjectModeConflict                  = &ErrorCode{ErrorCode: "ObjectModeConflict", ErrorMessage: "Object already exists but file mode conflicts", StatusCode: http.StatusConflict}
 	NotModified                         = &ErrorCode{ErrorCode: "MaxContentLength", ErrorMessage: "Not modified.", StatusCode: http.StatusNotModified}
 	NoSuchUpload                        = &ErrorCode{ErrorCode: "NoSuchUpload", ErrorMessage: "The specified upload does not exist.", StatusCode: http.StatusNotFound}
-	OverMaxRecordSize					= &ErrorCode{ErrorCode: "OverMaxRecordSize", ErrorMessage: "The length of a record in the input or result is greater than maxCharsPerRecord of 1 MB.", StatusCode: http.StatusBadRequest}
-	CopySourceSizeTooLarge				= &ErrorCode{ErrorCode: "InvalidRequest", ErrorMessage: "The specified copy source is larger than the maximum allowable size for a copy source: 5368709120", StatusCode: http.StatusBadRequest}
+	OverMaxRecordSize                   = &ErrorCode{ErrorCode: "OverMaxRecordSize", ErrorMessage: "The length of a record in the input or result is greater than maxCharsPerRecord of 1 MB.", StatusCode: http.StatusBadRequest}
+	CopySourceSizeTooLarge              = &ErrorCode{ErrorCode: "InvalidRequest", ErrorMessage: "The specified copy source is larger than the maximum allowable size for a copy source: 5368709120", StatusCode: http.StatusBadRequest}
 )
 
 func HttpStatusErrorCode(code int) *ErrorCode {

--- a/objectnode/router.go
+++ b/objectnode/router.go
@@ -294,7 +294,7 @@ func (o *ObjectNode) registerApiRouters(router *mux.Router) {
 		r.NewRoute().Name(ActionToUniqueRouteName(proto.OSSUploadPartCopyAction)).
 			Methods(http.MethodPut).
 			Path("/{object:.+}").
-			HeadersRegexp(HeaderNameCopySource, ".*?(\\/|%2F).*?").
+			HeadersRegexp(HeaderNameXAmzCopySource, ".*?(\\/|%2F).*?").
 			Queries("partNumber", "{partNumber:[0-9]+}", "uploadId", "{uploadId:.*}").
 			HandlerFunc(o.unsupportedOperationHandler)
 
@@ -311,7 +311,7 @@ func (o *ObjectNode) registerApiRouters(router *mux.Router) {
 		r.NewRoute().Name(ActionToUniqueRouteName(proto.OSSCopyObjectAction)).
 			Methods(http.MethodPut).
 			Path("/{object:.+}").
-			HeadersRegexp(HeaderNameCopySource, ".*?(\\/|%2F).*?").
+			HeadersRegexp(HeaderNameXAmzCopySource, ".*?(\\/|%2F).*?").
 			HandlerFunc(o.copyObjectHandler)
 
 		// Put object tagging

--- a/objectnode/signer.go
+++ b/objectnode/signer.go
@@ -31,7 +31,7 @@ var TERMINATOR = "aws4_request"
 
 func getStartTime(headers http.Header) string {
 	for headerName := range headers {
-		if strings.ToLower(headerName) == strings.ToLower(HeaderNameStartDate) {
+		if strings.ToLower(headerName) == strings.ToLower(HeaderNameXAmzStartDate) {
 			return headers.Get(headerName)
 		}
 	}

--- a/objectnode/util.go
+++ b/objectnode/util.go
@@ -257,7 +257,7 @@ func ParseUserDefinedMetadata(header http.Header) map[string]string {
 	metadata := make(map[string]string)
 	for name, values := range header {
 		if strings.HasPrefix(name, http.CanonicalHeaderKey(HeaderNameXAmzMetaPrefix)) &&
-			name != http.CanonicalHeaderKey(HeaderNameMetadataDirective) {
+			name != http.CanonicalHeaderKey(HeaderNameXAmzMetadataDirective) {
 			metaName := strings.ToLower(name[len(HeaderNameXAmzMetaPrefix):])
 			metaValue := strings.Join(values, ",")
 			if !strings.HasPrefix(metaName, "oss:") {


### PR DESCRIPTION
There are several enhancements and fixes included in this pull request.
1. Fix: parallel-safe issue in conn pool and metanode conn serve. (**High-priority**)
2. Fix: nil pointer issue when list parts for non-exist uploadId.
3. Enhancement: validate read size while read from connect.
4. Enhancement: clean up useless data on failure while upload part. (**High-priority**)
5. Enhancement: generate `ETag` if do not exist when listing.
6. Enhancement: include error message when formatting packet to string.
7. Enhancement: improve compatile with old version SDK.
8. Enhancement:  success when retry add exist multipart part.
