### PR TITLE
feature: if current process used memory larger than the 60 percent of…

### DIFF
--- a/metanode/metanode.go
+++ b/metanode/metanode.go
@@ -32,6 +32,7 @@ import (
 	"github.com/chubaofs/chubaofs/util/errors"
 	"github.com/chubaofs/chubaofs/util/exporter"
 	"github.com/chubaofs/chubaofs/util/log"
+	"runtime"
 )
 
 var (
@@ -101,6 +102,38 @@ func (m *MetaNode) checkLocalPartitionMatchWithMaster() (err error) {
 	return
 }
 
+func (m *MetaNode) startGcScheduler() {
+	ticker := time.NewTicker(5 * time.Minute)
+	defer func() {
+		ticker.Stop()
+	}()
+	var (
+		pUsed    uint64
+		err      error
+		pMemStat runtime.MemStats
+	)
+
+	for {
+		select {
+		case <-m.httpStopC:
+			return
+		case <-ticker.C:
+
+			pUsed, err = util.GetProcessMemory(os.Getpid())
+			if err != nil {
+				continue
+			}
+			if float64(pUsed) > float64(configTotalMem)*float64(0.6) {
+				runtime.ReadMemStats(&pMemStat)
+				log.LogWarnf("process used memory[%v],heapInuse[%v],totalAlloc[%v],objects[%v]", pUsed, pMemStat.HeapInuse, pMemStat.TotalAlloc, pMemStat.HeapObjects)
+				if float64(pUsed) >= float64(1.5)*float64(pMemStat.HeapInuse) {
+					runtime.GC()
+				}
+			}
+		}
+	}
+}
+
 func doStart(s common.Server, cfg *config.Config) (err error) {
 	m, ok := s.(*MetaNode)
 	if !ok {
@@ -135,6 +168,7 @@ func doStart(s common.Server, cfg *config.Config) (err error) {
 		return
 	}
 	exporter.RegistConsul(m.clusterId, cfg.GetString("role"), cfg)
+	m.startGcScheduler()
 	return
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
if current process used memory larger than the 60 percent of totalMemory which configured by metaNode,call runtime.GC every 5 minutes
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
N/A
**Special notes for your reviewer**:
N/A
**Release note**:
N/A
