### PR TITLE
Fix: multipart part inode release issue

### DIFF
--- a/metanode/partition_op_inode.go
+++ b/metanode/partition_op_inode.go
@@ -15,6 +15,7 @@
 package metanode
 
 import (
+	"encoding/binary"
 	"encoding/json"
 	"time"
 
@@ -231,13 +232,9 @@ func (mp *metaPartition) GetInodeTree() *BTree {
 }
 
 func (mp *metaPartition) DeleteInode(req *proto.DeleteInodeRequest, p *Packet) (err error) {
-	ino := NewInode(req.Inode, 0)
-	encoded, err := ino.Marshal()
-	if err != nil {
-		p.ResultCode = proto.OpErr
-		return
-	}
-	_, err = mp.submit(opFSMInternalDeleteInode, encoded)
+	var bytes = make([]byte, 8)
+	binary.BigEndian.PutUint64(bytes, req.Inode)
+	_, err = mp.submit(opFSMInternalDeleteInode, bytes)
 	if err != nil {
 		p.PacketErrorWithBody(proto.OpAgain, []byte(err.Error()))
 		return


### PR DESCRIPTION
**What this PR does / why we need it**:
The inode of the part in multipart upload is not consistent with the serialization and deserialization logic used when submitting and applying through raft when it is released. 

This results in the inability to successfully clean up useless part inode data structures after users have passed the `CompleteMultipartUpload` via S3-compatible interface.

**Which issue this PR fixes**:
None.

**Special notes for your reviewer**:
Focus on the process of the `InodeDelete_ll` operation in the **SDK** and **MetaNode**.

**Release note**:
None.