### PR TITLE
fix :  Redirect error log to file

### DIFF
--- a/vendor/github.com/tiglabs/raft/util/log/log.go
+++ b/vendor/github.com/tiglabs/raft/util/log/log.go
@@ -144,7 +144,6 @@ func (lw *logWriter) rotateFile(logDir, logFile, module string, rotate bool) {
 	lw.out = file
 
 	if err == nil && logFile == errLogFileName {
-		os.Stderr = file
 		if f, e := file.Stat(); e == nil && f.Size() == 0 {
 			// Write header.
 			var buf bytes.Buffer


### PR DESCRIPTION
Signed-off-by: zhuhyc <zzhniy.163.niy@163.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Redirect os.Stderr to log file in the main fuction, other code should not redirect os.Stderr to log file again

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
N/A
**Special notes for your reviewer**:
N/A
**Release note**:
N/A
