### PR TITLE
Fix: metanode freeInode bug and optimize delete speed

### DIFF
--- a/metanode/free_list.go
+++ b/metanode/free_list.go
@@ -64,3 +64,10 @@ func (fl *freeList) Remove(ino uint64) {
 		delete(fl.index, ino)
 	}
 }
+
+
+func (fl *freeList)Len() int {
+	fl.Lock()
+	defer fl.Unlock()
+	return len(fl.index)
+}

--- a/metanode/manager_op.go
+++ b/metanode/manager_op.go
@@ -68,6 +68,8 @@ func (m *metadataManager) opMasterHeartbeat(conn net.Conn, p *Packet,
 			Status:      proto.ReadWrite,
 			MaxInodeID:  mConf.Cursor,
 			VolName:     mConf.VolName,
+			InodeCnt:    uint64(partition.GetInodeTree().Len()),
+			DentryCnt:   uint64(partition.GetDentryTree().Len()),
 		}
 		addr, isLeader := partition.IsLeader()
 		if addr == "" {

--- a/metanode/partition.go
+++ b/metanode/partition.go
@@ -591,6 +591,7 @@ func (mp *metaPartition) ResponseLoadMetaPartition(p *Packet) (err error) {
 		DoCompare:   true,
 	}
 	resp.MaxInode = mp.GetCursor()
+	resp.InodeCount=uint64(mp.getInodeTree().Len())
 	resp.DentryCount = uint64(mp.dentryTree.Len())
 	resp.ApplyID = mp.applyID
 	if err != nil {

--- a/metanode/partition_free_list.go
+++ b/metanode/partition_free_list.go
@@ -187,20 +187,7 @@ func (mp *metaPartition) deleteMarkedInodes(inoSlice []uint64) {
 }
 
 func (mp *metaPartition) syncToRaftFollowersFreeInode(hasDeleteInodes []byte) (err error) {
-	raftPeers := mp.GetPeers()
-	raftPeersError := make([]error, len(raftPeers))
-	wg := new(sync.WaitGroup)
-	for index, target := range raftPeers {
-		wg.Add(1)
-		raftPeersError[index] = mp.notifyRaftFollowerToFreeInodes(wg, target, hasDeleteInodes)
-	}
-	wg.Wait()
-	for index := 0; index < len(raftPeersError); index++ {
-		if raftPeersError[index] != nil {
-			err = raftPeersError[index]
-			return
-		}
-	}
+	_,err=mp.submit(opFSMInternalDeleteInode,hasDeleteInodes)
 
 	return
 }

--- a/proto/admin_proto.go
+++ b/proto/admin_proto.go
@@ -269,6 +269,8 @@ type MetaPartitionReport struct {
 	MaxInodeID  uint64
 	IsLeader    bool
 	VolName     string
+	InodeCnt    uint64
+	DentryCnt   uint64
 }
 
 // MetaNodeHeartbeatResponse defines the response to the meta node heartbeat request.
@@ -352,6 +354,7 @@ type MetaPartitionLoadResponse struct {
 	ApplyID     uint64
 	MaxInode    uint64
 	DentryCount uint64
+	InodeCount  uint64
 	Addr        string
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
1. When metanode is in freeInode, use tcp protocol to notify follower, there is a serious bug, if follower is down and restarted at this time, a part of freeInodes is lost, so here is changed to use raft protocol

2. optimize metanode delete inode speed 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
