### PR TITLE
enhancement: add 'Expires' and 'Cache-Control' when putObject

### DIFF
--- a/objectnode/const.go
+++ b/objectnode/const.go
@@ -38,6 +38,8 @@ const (
 	HeaderNameExpect             = "Expect"
 	HeaderNameXForwardedExpect   = "X-Forwarded-Expect"
 	HeaderNameLocation           = "Location"
+	HeaderNameCacheControl       = "Cache-Control"
+	HeaderNameExpires            = "Expires"
 
 	// Headers for CORS validation
 	Origin                                = "Origin"
@@ -99,6 +101,11 @@ const (
 	ParamPartNoMarker   = "part-number-marker"
 	ParamPartMaxUploads = "max-uploads"
 	ParamPartDelimiter  = "delimiter"
+
+	ParamResponseCacheControl       = "response-cache-control"
+	ParamResponseContentType        = "response-content-type"
+	ParamResponseContentDisposition = "response-content-disposition"
+	ParamResponseExpires            = "response-expires"
 )
 
 const (
@@ -113,13 +120,15 @@ const (
 
 // XAttr keys for ObjectNode compatible feature
 const (
-	XAttrKeyOSSETag        = "oss:etag"
-	XAttrKeyOSSTagging     = "oss:tagging"
-	XAttrKeyOSSPolicy      = "oss:policy"
-	XAttrKeyOSSACL         = "oss:acl"
-	XAttrKeyOSSMIME        = "oss:mime"
-	XAttrKeyOSSDISPOSITION = "oss:disposition"
-	XAttrKeyOSSCORS        = "oss:cors"
+	XAttrKeyOSSETag         = "oss:etag"
+	XAttrKeyOSSTagging      = "oss:tagging"
+	XAttrKeyOSSPolicy       = "oss:policy"
+	XAttrKeyOSSACL          = "oss:acl"
+	XAttrKeyOSSMIME         = "oss:mime"
+	XAttrKeyOSSDISPOSITION  = "oss:disposition"
+	XAttrKeyOSSCORS         = "oss:cors"
+	XAttrKeyOSSCacheControl = "oss:cache"
+	XAttrKeyOSSExpires      = "oss:expires"
 
 	// Deprecated
 	XAttrKeyOSSETagDeprecated = "oss:tag"
@@ -127,6 +136,9 @@ const (
 
 const (
 	AMZTimeFormat = "2006-01-02T15:04:05.000Z"
+	RFC1123Format = "Mon, 02 Jan 2006 15:04:05 GMT"
+	RFC850Format  = "Monday, 02-Jan-06 15:04:05 GMT"
+	ANSICFormat   = "Mon Jan  2 15:04:05 2006"
 )
 
 const (

--- a/objectnode/fs.go
+++ b/objectnode/fs.go
@@ -21,15 +21,17 @@ import (
 )
 
 type FSFileInfo struct {
-	Path        string
-	Size        int64
-	Mode        os.FileMode
-	ModifyTime  time.Time
-	ETag        string
-	Inode       uint64
-	MIMEType    string
-	Disposition string
-	Metadata    map[string]string // User-defined metadata
+	Path         string
+	Size         int64
+	Mode         os.FileMode
+	ModifyTime   time.Time
+	ETag         string
+	Inode        uint64
+	MIMEType     string
+	Disposition  string
+	CacheControl string
+	Expires      string
+	Metadata     map[string]string // User-defined metadata
 }
 
 type Prefixes []string

--- a/objectnode/result_error.go
+++ b/objectnode/result_error.go
@@ -93,6 +93,7 @@ var (
 	NoSuchUpload                        = &ErrorCode{ErrorCode: "NoSuchUpload", ErrorMessage: "The specified upload does not exist.", StatusCode: http.StatusNotFound}
 	OverMaxRecordSize                   = &ErrorCode{ErrorCode: "OverMaxRecordSize", ErrorMessage: "The length of a record in the input or result is greater than maxCharsPerRecord of 1 MB.", StatusCode: http.StatusBadRequest}
 	CopySourceSizeTooLarge              = &ErrorCode{ErrorCode: "InvalidRequest", ErrorMessage: "The specified copy source is larger than the maximum allowable size for a copy source: 5368709120", StatusCode: http.StatusBadRequest}
+	InvalidCacheArgument                = &ErrorCode{ErrorCode: "InvalidCacheArgument", ErrorMessage: "Invalid Cache-Control or Expires Argument", StatusCode: http.StatusBadRequest}
 )
 
 func HttpStatusErrorCode(code int) *ErrorCode {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add 'Expires' and 'Cache-Control' when putObject/copyObject/getObject/headObject.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
