### PR TITLE
fix: retry other addr when OpStreamFollowerRead's ResultCode is not p…

### DIFF
--- a/sdk/data/stream/extent_reader.go
+++ b/sdk/data/stream/extent_reader.go
@@ -104,6 +104,11 @@ func (reader *ExtentReader) checkStreamReply(request *Packet, reply *Packet) (er
 	}
 
 	if reply.ResultCode != proto.OpOk {
+		if request.Opcode == proto.OpStreamFollowerRead {
+			log.LogWarnf("checkStreamReply: ResultCode(%v) NOK, OpStreamFollowerRead return TryOtherAddrError, "+
+				"req(%v) reply(%v)", reply.GetResultMsg(), request, reply)
+			return TryOtherAddrError
+		}
 		err = errors.New(fmt.Sprintf("checkStreamReply: ResultCode(%v) NOK", reply.GetResultMsg()))
 		return
 	}


### PR DESCRIPTION
…roto.OpOk

Signed-off-by: yinlei-jinan <297155992@qq.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
