### PR TITLE
Fix: DataNode When dp synchronizes tiny Extent DeleteRecord every tim…

### DIFF
--- a/datanode/partition.go
+++ b/datanode/partition.go
@@ -676,6 +676,7 @@ func (dp *DataPartition) doStreamFixTinyDeleteRecord(repairTask *DataPartitionRe
 	)
 	if !isFullSync {
 		localTinyDeleteFileSize = dp.extentStore.LoadTinyDeleteFileOffset()
+	} else {
 		dp.FullSyncTinyDeleteTime = time.Now().Unix()
 	}
 


### PR DESCRIPTION
Signed-off-by: awzhgw <guowl18702995996@gmail.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Fix: DataNode When dp synchronizes tiny Extent DeleteRecord every time, the original design is to synchronize the entire amount every 1 day. Now due to a bug, the full synchronization every time causes the network card to be full. .


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
