### PR TITLE
Fix: use synclist to replace list for partition_delete_extents to avoid list concurrent access panic

### DIFF
--- a/metanode/partition_delete_extents.go
+++ b/metanode/partition_delete_extents.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/chubaofs/chubaofs/proto"
 	"github.com/chubaofs/chubaofs/util/log"
+	"github.com/chubaofs/chubaofs/util/synclist"
 )
 
 const (
@@ -38,12 +39,12 @@ const (
 var extentsFileHeader = []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x08}
 
 func (mp *metaPartition) startToDeleteExtents() {
-	fileList := list.New()
+	fileList := synclist.New()
 	go mp.appendDelExtentsToFile(fileList)
 	go mp.deleteExtentsFromList(fileList)
 }
 
-func (mp *metaPartition) appendDelExtentsToFile(fileList *list.List) {
+func (mp *metaPartition) appendDelExtentsToFile(fileList *synclist.SyncList) {
 	defer func() {
 		if r := recover(); r != nil {
 			log.LogErrorf(fmt.Sprintf("appendDelExtentsToFile(%v) appendDelExtentsToFile panic (%v)", mp.config.PartitionId, r))
@@ -137,7 +138,7 @@ LOOP:
 }
 
 // Delete all the extents of a file.
-func (mp *metaPartition) deleteExtentsFromList(fileList *list.List) {
+func (mp *metaPartition) deleteExtentsFromList(fileList *synclist.SyncList) {
 	defer func() {
 		if r := recover(); r != nil {
 			log.LogErrorf(fmt.Sprintf("deleteExtentsFromList(%v) deleteExtentsFromList panic (%v)", mp.config.PartitionId, r))

--- a/util/synclist/synclist.go
+++ b/util/synclist/synclist.go
@@ -1,0 +1,122 @@
+// Copyright 2018 The Chubao Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package synclist
+
+import (
+	"container/list"
+	"sync"
+)
+
+type SyncList struct {
+	list.List
+	mu sync.RWMutex
+}
+
+func New() *SyncList {
+	l := new(SyncList)
+	l.Init()
+	return l
+}
+
+func (l *SyncList) Init() *SyncList {
+	l.mu.Lock()
+	l.List.Init()
+	l.mu.Unlock()
+	return l
+}
+
+func (l *SyncList) Remove(e *list.Element) interface{} {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.List.Remove(e)
+}
+
+func (l *SyncList) PushFront(v interface{}) *list.Element {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.List.PushFront(v)
+}
+
+func (l *SyncList) Back() *list.Element {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	return l.List.Back()
+}
+
+func (l *SyncList) PushBack(v interface{}) *list.Element {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.List.PushBack(v)
+}
+
+func (l *SyncList) InsertBefore(v interface{}, mark *list.Element) *list.Element {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.List.InsertBefore(v, mark)
+}
+
+func (l *SyncList) InsertAfter(v interface{}, mark *list.Element) *list.Element {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.List.InsertAfter(v, mark)
+}
+
+func (l *SyncList) Len() int {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	return l.List.Len()
+}
+
+func (l *SyncList) Front() *list.Element {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	return l.List.Front()
+}
+
+func (l *SyncList) MoveToFront(e *list.Element) {
+	l.mu.Lock()
+	l.List.MoveToFront(e)
+	l.mu.Unlock()
+}
+
+func (l *SyncList) MoveToBack(e *list.Element) {
+	l.mu.Lock()
+	l.List.MoveToBack(e)
+	l.mu.Unlock()
+}
+
+func (l *SyncList) MoveBefore(e, mark *list.Element) {
+	l.mu.Lock()
+	l.List.MoveBefore(e, mark)
+	l.mu.Unlock()
+}
+
+func (l *SyncList) MoveAfter(e, mark *list.Element) {
+	l.mu.Lock()
+	l.List.MoveAfter(e, mark)
+	l.mu.Unlock()
+}
+
+func (l *SyncList) PushBackList(other *SyncList) {
+	l.mu.Lock()
+	l.List.PushBackList(&other.List)
+	l.mu.Unlock()
+}
+
+func (l *SyncList) PushFrontList(other *SyncList) {
+	l.mu.Lock()
+	l.List.PushFrontList(&other.List)
+	l.mu.Unlock()
+}

--- a/util/synclist/synclist_test.go
+++ b/util/synclist/synclist_test.go
@@ -1,0 +1,80 @@
+// Copyright 2018 The Chubao Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package synclist
+
+import (
+	"sync"
+	"testing"
+)
+
+/*
+func TestListPushBach(t *testing.T) {
+	l := list.New()
+
+	wg := sync.WaitGroup{}
+	for j := 0; j < 50; j += 1 {
+		go func() {
+			wg.Add(1)
+			for i := 0; i < 1000; i += 1 {
+				println("pushback: ", i)
+				l.PushBack(i)
+			}
+			wg.Done()
+		}()
+	}
+	for j := 0; j < 60; j += 1 {
+		go func() {
+			wg.Add(1)
+			for i := 0; i < 1000; i += 1 {
+				if f := l.Front(); f != nil {
+					println("remove: ", f.Value)
+					l.Remove(f)
+				}
+			}
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+}
+*/
+
+func TestSyncPushBach(t *testing.T) {
+	l := New()
+
+	wg := sync.WaitGroup{}
+	for j := 0; j < 50; j += 1 {
+		go func() {
+			wg.Add(1)
+			for i := 0; i < 1000; i += 1 {
+				println("pushback: ", i)
+				l.PushBack(i)
+			}
+			wg.Done()
+		}()
+	}
+	for j := 0; j < 60; j += 1 {
+		go func() {
+			wg.Add(1)
+			for i := 0; i < 1000; i += 1 {
+				if f := l.Front(); f != nil {
+					println("remove: ", f.Value)
+					l.Remove(f)
+				}
+			}
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
Signed-off-by: zhuzhengyi1 <zhuzhengyi@jd.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
