### PR TITLE
Enhancement: improve metadata persist

### DIFF
--- a/metanode/const.go
+++ b/metanode/const.go
@@ -155,6 +155,9 @@ const (
 	// interval of persisting in-memory data
 	intervalToPersistData = time.Minute * 5
 	intervalToSyncCursor  = time.Minute * 1
+
+	// The minimum gap of the last ApplyID that triggered the current ApplyID of the persistent data.
+	gapToPersistData = 1000
 )
 
 const (

--- a/metanode/inode.go
+++ b/metanode/inode.go
@@ -19,9 +19,10 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
-	"github.com/chubaofs/chubaofs/proto"
 	"io"
 	"sync"
+
+	"github.com/chubaofs/chubaofs/proto"
 )
 
 const (
@@ -173,6 +174,35 @@ func (i *Inode) Marshal() (result []byte, err error) {
 	return
 }
 
+func (i *Inode) WriteTo(writer io.Writer, reuse *bytes.Buffer) (err error) {
+	var buff = reuse
+	if buff == nil {
+		buff = bytes.NewBuffer(nil)
+	} else {
+		buff.Reset()
+	}
+	if err = i.WriteKeyTo(buff); err != nil {
+		return
+	}
+	if err = binary.Write(writer, binary.BigEndian, uint32(buff.Len())); err != nil {
+		return
+	}
+	if _, err = buff.WriteTo(writer); err != nil {
+		return
+	}
+	buff.Reset()
+	if err = i.WriteValueTo(buff); err != nil {
+		return
+	}
+	if err = binary.Write(writer, binary.BigEndian, uint32(buff.Len())); err != nil {
+		return
+	}
+	if _, err = buff.WriteTo(writer); err != nil {
+		return
+	}
+	return
+}
+
 // Unmarshal unmarshals the inode.
 func (i *Inode) Unmarshal(raw []byte) (err error) {
 	var (
@@ -258,6 +288,11 @@ func (i *Inode) MarshalKey() (k []byte) {
 	return
 }
 
+func (i *Inode) WriteKeyTo(writer io.Writer) (err error) {
+	err = binary.Write(writer, binary.BigEndian, &i.Inode)
+	return
+}
+
 // UnmarshalKey unmarshals the exporterKey from bytes.
 func (i *Inode) UnmarshalKey(k []byte) (err error) {
 	i.Inode = binary.BigEndian.Uint64(k)
@@ -323,6 +358,58 @@ func (i *Inode) MarshalValue() (val []byte) {
 
 	val = buff.Bytes()
 	i.RUnlock()
+	return
+}
+
+func (i *Inode) WriteValueTo(writer io.Writer) (err error) {
+	i.RLock()
+	defer i.RUnlock()
+	if err = binary.Write(writer, binary.BigEndian, &i.Type); err != nil {
+		return
+	}
+	if err = binary.Write(writer, binary.BigEndian, &i.Uid); err != nil {
+		return
+	}
+	if err = binary.Write(writer, binary.BigEndian, &i.Gid); err != nil {
+		return
+	}
+	if err = binary.Write(writer, binary.BigEndian, &i.Size); err != nil {
+		return
+	}
+	if err = binary.Write(writer, binary.BigEndian, &i.Generation); err != nil {
+		return
+	}
+	if err = binary.Write(writer, binary.BigEndian, &i.CreateTime); err != nil {
+		return
+	}
+	if err = binary.Write(writer, binary.BigEndian, &i.AccessTime); err != nil {
+		return
+	}
+	if err = binary.Write(writer, binary.BigEndian, &i.ModifyTime); err != nil {
+		return
+	}
+	// write SymLink
+	symSize := uint32(len(i.LinkTarget))
+	if err = binary.Write(writer, binary.BigEndian, &symSize); err != nil {
+		return
+	}
+	if _, err = writer.Write(i.LinkTarget); err != nil {
+		return
+	}
+
+	if err = binary.Write(writer, binary.BigEndian, &i.NLink); err != nil {
+		return
+	}
+	if err = binary.Write(writer, binary.BigEndian, &i.Flag); err != nil {
+		return
+	}
+	if err = binary.Write(writer, binary.BigEndian, &i.Reserved); err != nil {
+		return
+	}
+	// marshal ExtentsKey
+	if err = i.Extents.WriteTo(writer); err != nil {
+		return
+	}
 	return
 }
 

--- a/metanode/partition.go
+++ b/metanode/partition.go
@@ -214,6 +214,8 @@ type metaPartition struct {
 	extReset      chan struct{}
 	vol           *Vol
 	manager       *metadataManager
+
+	persistedApplyID uint64
 }
 
 // Start starts a meta partition.
@@ -504,7 +506,10 @@ func (mp *metaPartition) store(sm *storeMsg) (err error) {
 		_ = os.Rename(backupDir, snapshotDir)
 		return
 	}
-	err = os.RemoveAll(backupDir)
+	if err = os.RemoveAll(backupDir); err != nil {
+		return
+	}
+	mp.updatePersistedApplyID(sm.applyIndex)
 	return
 }
 

--- a/metanode/partition_fsm.go
+++ b/metanode/partition_fsm.go
@@ -39,13 +39,12 @@ func (mp *metaPartition) Apply(command []byte, index uint64) (resp interface{}, 
 	msg := &MetaItem{}
 	defer func() {
 		if err == nil {
-			mp.uploadApplyID(index)
+			mp.updateApplyID(index)
 		}
 	}()
 	if err = msg.UnmarshalJson(command); err != nil {
 		return
 	}
-
 	switch msg.Op {
 	case opFSMCreateInode:
 		ino := NewInode(0, 0)
@@ -196,7 +195,7 @@ func (mp *metaPartition) Apply(command []byte, index uint64) (resp interface{}, 
 func (mp *metaPartition) ApplyMemberChange(confChange *raftproto.ConfChange, index uint64) (resp interface{}, err error) {
 	defer func() {
 		if err == nil {
-			mp.uploadApplyID(index)
+			mp.updateApplyID(index)
 		}
 	}()
 	req := &proto.MetaPartitionDecommissionRequest{}
@@ -390,6 +389,10 @@ func (mp *metaPartition) submit(op uint32, data []byte) (resp interface{}, err e
 	return
 }
 
-func (mp *metaPartition) uploadApplyID(applyId uint64) {
+func (mp *metaPartition) updateApplyID(applyId uint64) {
 	atomic.StoreUint64(&mp.applyID, applyId)
+}
+
+func (mp *metaPartition) updatePersistedApplyID(applyId uint64) {
+	atomic.StoreUint64(&mp.persistedApplyID, applyId)
 }

--- a/metanode/partition_store_ticket.go
+++ b/metanode/partition_store_ticket.go
@@ -16,6 +16,7 @@ package metanode
 
 import (
 	"encoding/binary"
+	"sync/atomic"
 	"time"
 
 	"github.com/chubaofs/chubaofs/cmd/common"
@@ -110,6 +111,10 @@ func (mp *metaPartition) startSchedule(curIndex uint64) {
 				}
 			case <-timer.C:
 				if mp.applyID <= curIndex {
+					timer.Reset(intervalToPersistData)
+					continue
+				}
+				if atomic.LoadUint64(&mp.persistedApplyID)-curIndex < gapToPersistData {
 					timer.Reset(intervalToPersistData)
 					continue
 				}

--- a/metanode/sorted_extents.go
+++ b/metanode/sorted_extents.go
@@ -3,6 +3,7 @@ package metanode
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"sync"
 
 	"github.com/chubaofs/chubaofs/proto"
@@ -43,6 +44,18 @@ func (se *SortedExtents) MarshalBinary() ([]byte, error) {
 		data = append(data, ekdata...)
 	}
 	return data, nil
+}
+
+func (se *SortedExtents) WriteTo(writer io.Writer) (err error) {
+	se.RLock()
+	defer se.RUnlock()
+
+	for _, ek := range se.eks {
+		if err = ek.WriteTo(writer); err != nil {
+			return
+		}
+	}
+	return
 }
 
 func (se *SortedExtents) UnmarshalBinary(data []byte) error {

--- a/proto/extent_key.go
+++ b/proto/extent_key.go
@@ -19,6 +19,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"io"
 
 	"github.com/chubaofs/chubaofs/util/btree"
 )
@@ -82,6 +83,28 @@ func (k *ExtentKey) MarshalBinary() ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
+func (k *ExtentKey) WriteTo(writer io.Writer) (err error) {
+	if err = binary.Write(writer, binary.BigEndian, k.FileOffset); err != nil {
+		return
+	}
+	if err = binary.Write(writer, binary.BigEndian, k.PartitionId); err != nil {
+		return
+	}
+	if err = binary.Write(writer, binary.BigEndian, k.ExtentId); err != nil {
+		return
+	}
+	if err = binary.Write(writer, binary.BigEndian, k.ExtentOffset); err != nil {
+		return
+	}
+	if err = binary.Write(writer, binary.BigEndian, k.Size); err != nil {
+		return
+	}
+	if err = binary.Write(writer, binary.BigEndian, k.CRC); err != nil {
+		return
+	}
+	return
+}
+
 // UnmarshalBinary unmarshals the binary format of the extent key.
 func (k *ExtentKey) UnmarshalBinary(buf *bytes.Buffer) (err error) {
 	if err = binary.Read(buf, binary.BigEndian, &k.FileOffset); err != nil {
@@ -113,7 +136,7 @@ func (k *ExtentKey) UnMarshal(m string) (err error) {
 
 // TODO remove
 func (k *ExtentKey) GetExtentKey() (m string) {
-	return fmt.Sprintf("%v_%v_%v_%v_%v", k.PartitionId,k.FileOffset, k.ExtentId, k.ExtentOffset,k.Size)
+	return fmt.Sprintf("%v_%v_%v_%v_%v", k.PartitionId, k.FileOffset, k.ExtentId, k.ExtentOffset, k.Size)
 }
 
 type TinyExtentDeleteRecord struct {


### PR DESCRIPTION
**What this PR does / why we need it**:

1. Reduce the number of heap memory applications by reusing buffers when
persisting metadata.
2. Before persisting, compare the current ApplyID with the last successfully
persisted ApplyID, and then trigger the persistence when the gap exceeds 1000.

