### PR TITLE
enhance: limit the tiny buffer pool memory consumption

### DIFF
--- a/proto/packet.go
+++ b/proto/packet.go
@@ -31,8 +31,9 @@ import (
 )
 
 var (
-	GRequestID = int64(1)
-	Buffers    = buf.NewBufferPool()
+	GRequestID  = int64(1)
+	Buffers     = buf.NewBufferPool()
+	TinyBuffers = buf.NewTinyBufferPool()
 )
 
 // GenerateRequestID generates the request ID.
@@ -382,7 +383,7 @@ func (p *Packet) GetOpMsg() (m string) {
 	case OpGetMetaNodeParams:
 		m = "OpGetMetaNodeParams"
 	case OpBatchDeleteExtent:
-		m="OpBatchDeleteExtent"
+		m = "OpBatchDeleteExtent"
 	}
 	return
 }
@@ -639,7 +640,7 @@ func (p *Packet) GetUniqueLogId() (m string) {
 			return m
 		}
 	} else if p.Opcode == OpReadTinyDeleteRecord || p.Opcode == OpNotifyReplicasToRepair || p.Opcode == OpDataNodeHeartbeat ||
-		p.Opcode==OpLoadDataPartition || p.Opcode==OpBatchDeleteExtent {
+		p.Opcode == OpLoadDataPartition || p.Opcode == OpBatchDeleteExtent {
 		p.mesg += fmt.Sprintf("Opcode(%v)", p.GetOpMsg())
 		return
 	} else if p.Opcode == OpBroadcastMinAppliedID || p.Opcode == OpGetAppliedId {
@@ -670,7 +671,7 @@ func (p *Packet) setPacketPrefix() {
 			return
 		}
 	} else if p.Opcode == OpReadTinyDeleteRecord || p.Opcode == OpNotifyReplicasToRepair || p.Opcode == OpDataNodeHeartbeat ||
-		p.Opcode==OpLoadDataPartition || p.Opcode==OpBatchDeleteExtent {
+		p.Opcode == OpLoadDataPartition || p.Opcode == OpBatchDeleteExtent {
 		p.mesg += fmt.Sprintf("Opcode(%v)", p.GetOpMsg())
 		return
 	} else if p.Opcode == OpBroadcastMinAppliedID || p.Opcode == OpGetAppliedId {
@@ -698,11 +699,11 @@ func (p *Packet) IsForwardPkt() bool {
 func (p *Packet) LogMessage(action, remote string, start int64, err error) (m string) {
 	if err == nil {
 		m = fmt.Sprintf("id[%v] isPrimaryBackReplLeader[%v] remote[%v] "+
-			" cost[%v] ",p.GetUniqueLogId(),p.IsForwardPkt(), remote,(time.Now().UnixNano()-start)/1e6 )
+			" cost[%v] ", p.GetUniqueLogId(), p.IsForwardPkt(), remote, (time.Now().UnixNano()-start)/1e6)
 
 	} else {
 		m = fmt.Sprintf("id[%v] isPrimaryBackReplLeader[%v] remote[%v]"+
-			", err[%v]", p.GetUniqueLogId(), p.IsForwardPkt(),remote, err.Error())
+			", err[%v]", p.GetUniqueLogId(), p.IsForwardPkt(), remote, err.Error())
 	}
 
 	return

--- a/sdk/data/stream/packet.go
+++ b/sdk/data/stream/packet.go
@@ -48,7 +48,7 @@ func NewWritePacket(inode uint64, fileOffset, storeMode int) *Packet {
 	p.inode = inode
 	p.KernelOffset = uint64(fileOffset)
 	if storeMode == proto.TinyExtentType {
-		p.Data, _ = proto.Buffers.Get(util.DefaultTinySizeLimit)
+		p.Data = proto.TinyBuffers.Get().([]byte)
 	} else {
 		p.Data, _ = proto.Buffers.Get(util.BlockSize)
 	}


### PR DESCRIPTION
Use sync Pool and rate limiter to limit the memory usage.

Signed-off-by: Shuoran Liu <shuoranliu@gmail.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
