### PR TITLE
Fix: isssue in metapartition apply raft snapshot

### DIFF
--- a/metanode/partition_fsm.go
+++ b/metanode/partition_fsm.go
@@ -250,6 +250,8 @@ func (mp *metaPartition) ApplySnapshot(peers []raftproto.Peer, iter raftproto.Sn
 			mp.applyID = appIndexID
 			mp.inodeTree = inodeTree
 			mp.dentryTree = dentryTree
+			mp.extendTree = extendTree
+			mp.multipartTree = multipartTree
 			mp.config.Cursor = cursor
 			err = nil
 			// store message


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix the problem that metapartion does not switch extend and multipart to
the latest valid data after applying raft snapshot.