### PR TITLE
Refactor: metaNode Batch delete extent on over write

### DIFF
--- a/metanode/packet.go
+++ b/metanode/packet.go
@@ -46,7 +46,7 @@ func NewPacketToDeleteExtent(dp *DataPartition, ext *proto.ExtentKey) *Packet {
 }
 
 // NewPacketToBatchDeleteExtent returns a new packet to batch delete the extent.
-func NewPacketToBatchDeleteExtent(dp *DataPartition, exts []*proto.ExtentKey) *Packet {
+func NewPacketToBatchDeleteExtent(dp *DataPartition, exts []proto.ExtentKey) *Packet {
 	p := new(Packet)
 	p.Magic = proto.ProtoMagic
 	p.Opcode = proto.OpBatchDeleteExtent

--- a/metanode/partition_delete_extents.go
+++ b/metanode/partition_delete_extents.go
@@ -87,8 +87,12 @@ func (mp *metaPartition)forceDeleteExtents(needDeleteExtents []proto.ExtentKey){
 	for partitionID,extents:=range extentsByPartition {
 		if occurErrors[partitionID]!=nil {
 			mp.extDelCh<-extents
+			log.LogErrorf("forceDeleteExtents on dataPartition(%v) error(%v) cnt(%v)",partitionID,occurErrors[partitionID],len(extents))
+		}else {
+			log.LogInfof("forceDeleteExtents on dataPartition(%v) successDelete cnt(%v)",partitionID,len(extents))
 		}
 	}
+	log.LogInfof("forceDeleteExtents success Delete Extent Cnt(%v)",len(needDeleteExtents))
 }
 
 

--- a/metanode/partition_delete_extents.go
+++ b/metanode/partition_delete_extents.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/chubaofs/chubaofs/proto"
@@ -43,6 +44,54 @@ func (mp *metaPartition) startToDeleteExtents() {
 	go mp.appendDelExtentsToFile(fileList)
 	go mp.deleteExtentsFromList(fileList)
 }
+
+
+func (mp *metaPartition)divideExtentsByPartition(deleteExtents []proto.ExtentKey)(deleteExtentsByPartition map[uint64][]proto.ExtentKey){
+	deleteExtentsByPartition=make(map[uint64][]proto.ExtentKey)
+	for _,ext:=range deleteExtents{
+		exts, ok := deleteExtentsByPartition[ext.PartitionId]
+		if !ok {
+			exts = make([]proto.ExtentKey, 0)
+		}
+		exts = append(exts, ext)
+		deleteExtentsByPartition[ext.PartitionId] = exts
+	}
+
+	return
+}
+
+func (mp *metaPartition) startDeleteExtentsByPartition(deleteExtentsByPartition map[uint64][]proto.ExtentKey)(occurErrors map[uint64]error) {
+	//wait all Partition do BatchDeleteExtents fininsh
+	var (
+		wg sync.WaitGroup
+		lock sync.Mutex
+	)
+	occurErrors = make(map[uint64]error)
+	for partitionID, extents := range deleteExtentsByPartition {
+		wg.Add(1)
+		go func(partitionID uint64, needDelExtents []proto.ExtentKey) {
+			perr := mp.doBatchDeleteExtentsByPartition(partitionID, needDelExtents)
+			lock.Lock()
+			occurErrors[partitionID] = perr
+			lock.Unlock()
+			wg.Done()
+		}(partitionID, extents)
+	}
+	wg.Wait()
+	return
+}
+
+func (mp *metaPartition)forceDeleteExtents(needDeleteExtents []proto.ExtentKey){
+	extentsByPartition :=mp.divideExtentsByPartition(needDeleteExtents)
+	occurErrors:=mp.startDeleteExtentsByPartition(extentsByPartition)
+	for partitionID,extents:=range extentsByPartition {
+		if occurErrors[partitionID]!=nil {
+			mp.extDelCh<-extents
+		}
+	}
+}
+
+
 
 func (mp *metaPartition) appendDelExtentsToFile(fileList *synclist.SyncList) {
 	defer func() {
@@ -246,6 +295,7 @@ func (mp *metaPartition) deleteExtentsFromList(fileList *synclist.SyncList) {
 		}
 		buff := bytes.NewBuffer(buf)
 		cursor += uint64(n)
+		needDeleteExtents:=make([]proto.ExtentKey,0)
 		for {
 			if buff.Len() == 0 {
 				break
@@ -258,15 +308,13 @@ func (mp *metaPartition) deleteExtentsFromList(fileList *synclist.SyncList) {
 			if err = ek.UnmarshalBinary(buff); err != nil {
 				panic(err)
 			}
-			// delete dataPartition
-			if err = mp.doDeleteMarkedInodes(&ek); err != nil {
-				eks := make([]proto.ExtentKey, 0)
-				eks = append(eks, ek)
-				mp.extDelCh <- eks
-				log.LogWarnf("[deleteExtentsFromList] partitionId=%d, %s",
-					mp.config.PartitionId, err.Error())
+			needDeleteExtents=append(needDeleteExtents,ek)
+			if len(needDeleteExtents)>BatchCounts{
+				mp.forceDeleteExtents(needDeleteExtents)
+				needDeleteExtents=make([]proto.ExtentKey,0)
 			}
 		}
+		mp.forceDeleteExtents(needDeleteExtents)
 		buff.Reset()
 		buff.WriteString(fmt.Sprintf("%s %d", fileName, cursor))
 		if _, err = mp.submit(opFSMInternalDelExtentCursor, buff.Bytes()); err != nil {

--- a/metanode/partition_free_list.go
+++ b/metanode/partition_free_list.go
@@ -30,7 +30,7 @@ import (
 const (
 	AsyncDeleteInterval      = 10 * time.Second
 	UpdateVolTicket          = 2 * time.Minute
-	BatchCounts              = 500
+	BatchCounts              = 512
 	OpenRWAppendOpt          = os.O_CREATE | os.O_RDWR | os.O_APPEND
 	TempFileValidTime        = 86400 //units: sec
 	DeleteInodeFileExtension = "INODE_DEL"

--- a/metanode/partition_free_list.go
+++ b/metanode/partition_free_list.go
@@ -154,26 +154,9 @@ func (mp *metaPartition) deleteWorker() {
 }
 
 // delete Extents by Partition,and find all successDelete inode
-func (mp *metaPartition) batchDeleteExtentsByPartition(partitionDeleteExtents map[uint64][]*proto.ExtentKey, allInodes []*Inode) (shouldCommit []*Inode) {
-	occurErrors := make(map[uint64]error)
+func (mp *metaPartition) batchDeleteExtentsByPartition(partitionDeleteExtents map[uint64][]proto.ExtentKey, allInodes []*Inode) (shouldCommit []*Inode) {
 	shouldCommit = make([]*Inode, 0, BatchCounts)
-	var (
-		wg   sync.WaitGroup
-		lock sync.Mutex
-	)
-
-	//wait all Partition do BatchDeleteExtents fininsh
-	for partitionID, extents := range partitionDeleteExtents {
-		wg.Add(1)
-		go func(partitionID uint64, extents []*proto.ExtentKey) {
-			perr := mp.doBatchDeleteExtentsByPartition(partitionID, extents)
-			lock.Lock()
-			occurErrors[partitionID] = perr
-			lock.Unlock()
-			wg.Done()
-		}(partitionID, extents)
-	}
-	wg.Wait()
+	occurErrors:=mp.startDeleteExtentsByPartition(partitionDeleteExtents)
 
 	//range AllNode,find all Extents delete success on inode,it must to be append shouldCommit
 	for i := 0; i < len(allInodes); i++ {
@@ -205,7 +188,7 @@ func (mp *metaPartition) deleteMarkedInodes(inoSlice []uint64) {
 	}()
 	shouldCommit := make([]*Inode, 0, BatchCounts)
 	allDeleteExtents := make(map[string]uint64)
-	deleteExtentsByPartition := make(map[uint64][]*proto.ExtentKey)
+	deleteExtentsByPartition := make(map[uint64][]proto.ExtentKey)
 	allInodes := make([]*Inode, 0)
 	for _, ino := range inoSlice {
 		ref := &Inode{Inode: ino}
@@ -214,17 +197,16 @@ func (mp *metaPartition) deleteMarkedInodes(inoSlice []uint64) {
 			continue
 		}
 		inode.Extents.Range(func(ek proto.ExtentKey) bool {
-			ext := &ek
-			_, ok := allDeleteExtents[ext.GetExtentKey()]
+			_, ok := allDeleteExtents[ek.GetExtentKey()]
 			if !ok {
-				allDeleteExtents[ext.GetExtentKey()] = inode.Inode
+				allDeleteExtents[ek.GetExtentKey()] = inode.Inode
 			}
-			exts, ok := deleteExtentsByPartition[ext.PartitionId]
+			exts, ok := deleteExtentsByPartition[ek.PartitionId]
 			if !ok {
-				exts = make([]*proto.ExtentKey, 0)
+				exts = make([]proto.ExtentKey, 0)
 			}
-			exts = append(exts, ext)
-			deleteExtentsByPartition[ext.PartitionId] = exts
+			exts = append(exts, ek)
+			deleteExtentsByPartition[ek.PartitionId] = exts
 			return true
 		})
 		allInodes = append(allInodes, inode)
@@ -331,7 +313,7 @@ func (mp *metaPartition) doDeleteMarkedInodes(ext *proto.ExtentKey) (err error) 
 	return
 }
 
-func (mp *metaPartition) doBatchDeleteExtentsByPartition(partitionID uint64, exts []*proto.ExtentKey) (err error) {
+func (mp *metaPartition) doBatchDeleteExtentsByPartition(partitionID uint64, exts []proto.ExtentKey) (err error) {
 	// get the data node view
 	dp := mp.vol.GetPartition(partitionID)
 	if dp == nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Refactor: metaNode Batch delete extent on over write

When an overWrite occurs, metanode uses batchDeleteExtent to send to the datanode to delete the extent, which can greatly save datanode io

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #


