### PR TITLE
enhancement: if partition ID less than max partition ID of the vol,do…

### DIFF
--- a/master/cluster_task.go
+++ b/master/cluster_task.go
@@ -221,10 +221,10 @@ func (c *Cluster) checkCorruptMetaPartitions() (inactiveMetaNodes []string, corr
 // check corrupt partitions related to this meta node
 func (c *Cluster) checkCorruptMetaNode(metaNode *MetaNode) (corruptPartitions []*MetaPartition, err error) {
 	var (
-		partition            *MetaPartition
-		mn                   *MetaNode
-		corruptPids          []uint64
-		corruptReplicaNum    uint8
+		partition         *MetaPartition
+		mn                *MetaNode
+		corruptPids       []uint64
+		corruptReplicaNum uint8
 	)
 	metaNode.RLock()
 	defer metaNode.RUnlock()
@@ -241,7 +241,7 @@ func (c *Cluster) checkCorruptMetaNode(metaNode *MetaNode) (corruptPartitions []
 				corruptReplicaNum = corruptReplicaNum + 1
 			}
 		}
-		if corruptReplicaNum > partition.ReplicaNum / 2 {
+		if corruptReplicaNum > partition.ReplicaNum/2 {
 			corruptPartitions = append(corruptPartitions, partition)
 			corruptPids = append(corruptPids, pid)
 		}
@@ -957,6 +957,10 @@ func (c *Cluster) updateInodeIDUpperBound(mp *MetaPartition, mr *proto.MetaParti
 	var vol *Vol
 	if vol, err = c.getVol(mp.volName); err != nil {
 		log.LogWarnf("action[updateInodeIDRange] vol[%v] not found", mp.volName)
+		return
+	}
+	maxPartitionID := vol.maxPartitionID()
+	if mr.PartitionID < maxPartitionID {
 		return
 	}
 	var end uint64


### PR DESCRIPTION
…n't try to split meta partition

Signed-off-by: zhuhyc <zzhniy.163.niy@163.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
If metanode used memory has arrived threshold, only try to split the meta partition which has the max ID
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
N/A
**Special notes for your reviewer**:
N/A
**Release note**:
N/A
