### PR TITLE
Fix: Remove timeout limits in master client sdk

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -46,12 +46,12 @@ func setupCommands(cfg *cmd.Config) *cobra.Command {
 		Use:   "completion",
 		Short: "Generate completion bash file",
 		Long: `To use the completion, tool "bash-completion" is demanded,
-  then execute the following command:
-1. $ ./cfs-cli completion   
-   # file "cfs-cli.sh" will be generated under the present working directory
-2. $ echo 'source /usr/share/bash-completion/bash_completion' >> ~/.bashrc
-3. $ echo 'source {path of cfs-cli.sh}' >>~/.bashrc
-4. $ source ~/.bashrc
+then execute the following command:
+   $ ./cfs-cli completion   
+   # Bash completion file "cfs-cli.sh" will be generated under the present working directory
+   $ echo 'source /usr/share/bash-completion/bash_completion' >> ~/.bashrc
+   $ echo 'source {path of cfs-cli.sh}' >>~/.bashrc
+   $ source ~/.bashrc
 `,
 		Example: "cfs-cli completion",
 		Run: func(cmd *cobra.Command, args []string) {
@@ -59,10 +59,11 @@ func setupCommands(cfg *cmd.Config) *cobra.Command {
 				_, _ = fmt.Fprintf(os.Stdout,"generate bash file failed")
 			}
 			_, _ = fmt.Fprintf(os.Stdout, `File "cfs-cli.sh" has been generated successfully under the present working directory,
-  following command to execute:
-1. $ echo 'source /usr/share/bash-completion/bash_completion' >> ~/.bashrc
-2. $ echo 'source {path of cfs-cli.sh}' >>~/.bashrc
-3. $ source ~/.bashrc
+following command to execute:
+   $ # install bash-completion 
+   $ echo 'source /usr/share/bash-completion/bash_completion' >> ~/.bashrc
+   $ echo 'source {path of cfs-cli.sh}' >>~/.bashrc
+   $ source ~/.bashrc
 `)
 		},
 	}

--- a/cli/cmd/datanode.go
+++ b/cli/cmd/datanode.go
@@ -132,7 +132,7 @@ func newDataNodeDecommissionCmd(client *master.MasterClient) *cobra.Command {
 			var nodeAddr string
 			defer func() {
 				if err != nil {
-					errout("decommission data node failed: %v\n", err)
+					errout("decommission data node failed, err[%v]\n", err)
 					os.Exit(1)
 				}
 			}()

--- a/sdk/master/api_admin.go
+++ b/sdk/master/api_admin.go
@@ -40,6 +40,7 @@ func (api *AdminAPI) GetCluster() (cv *proto.ClusterView, err error) {
 }
 func (api *AdminAPI) GetClusterStat() (cs *proto.ClusterStatInfo, err error) {
 	var request = newAPIRequest(http.MethodGet, proto.AdminClusterStat)
+	request.addHeader("isTimeOut", "false")
 	var data []byte
 	if data, err = api.mc.serveRequest(request); err != nil {
 		return

--- a/sdk/master/api_node.go
+++ b/sdk/master/api_node.go
@@ -108,6 +108,7 @@ func (api *NodeAPI) ResponseDataNodeTask(task *proto.AdminTask) (err error) {
 func (api *NodeAPI) DataNodeDecommission(nodeAddr string) (err error) {
 	var request = newAPIRequest(http.MethodGet, proto.DecommissionDataNode)
 	request.addParam("addr", nodeAddr)
+	request.addHeader("isTimeOut", "false")
 	if _, err = api.mc.serveRequest(request); err != nil {
 		return
 	}
@@ -117,6 +118,7 @@ func (api *NodeAPI) DataNodeDecommission(nodeAddr string) (err error) {
 func (api *NodeAPI) MetaNodeDecommission(nodeAddr string) (err error) {
 	var request = newAPIRequest(http.MethodGet, proto.DecommissionMetaNode)
 	request.addParam("addr", nodeAddr)
+	request.addHeader("isTimeOut", "false")
 	if _, err = api.mc.serveRequest(request); err != nil {
 		return
 	}

--- a/sdk/master/client.go
+++ b/sdk/master/client.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -179,7 +180,17 @@ func (c *MasterClient) prepareRequest() (addr string, nodes []string) {
 func (c *MasterClient) httpRequest(method, url string, param, header map[string]string, reqData []byte) (resp *http.Response, err error) {
 	client := http.DefaultClient
 	reader := bytes.NewReader(reqData)
-	client.Timeout = requestTimeout
+	if header["isTimeOut"] != "" {
+		var isTimeOut bool
+		if isTimeOut, err = strconv.ParseBool(header["isTimeOut"]); err != nil {
+			return
+		}
+		if isTimeOut {
+			client.Timeout = requestTimeout
+		}
+	}else {
+		client.Timeout = requestTimeout
+	}
 	var req *http.Request
 	fullUrl := c.mergeRequestUrl(url, param)
 	log.LogDebugf("httpRequest: merge request url: method(%v) url(%v) bodyLength[%v].", method, fullUrl, len(reqData))


### PR DESCRIPTION
Some actions such as decommission datanode may spend more than 30 seconds, remove the limit on these actions.

Signed-off-by: xuxihao <xuxihao3@jd.com>
