### PR TITLE
Refactor: PrimaryBack Replication protocol change Chan Size to 1024 on

### DIFF
--- a/repl/const.go
+++ b/repl/const.go
@@ -15,7 +15,7 @@
 package repl
 
 const (
-	RequestChanSize = 10240
+	RequestChanSize = 1024 
 )
 
 const (

--- a/repl/repl_protocol.go
+++ b/repl/repl_protocol.go
@@ -81,8 +81,8 @@ func NewFollowersTransport(addr string) (ft *FollowerTransport, err error) {
 	ft = new(FollowerTransport)
 	ft.addr = addr
 	ft.conn = conn
-	ft.sendCh = make(chan *FollowerPacket, 200)
-	ft.recvCh = make(chan *FollowerPacket, 200)
+	ft.sendCh = make(chan *FollowerPacket, RequestChanSize)
+	ft.recvCh = make(chan *FollowerPacket, RequestChanSize)
 	ft.exitCh = make(chan struct{})
 	go ft.serverWriteToFollower()
 	go ft.serverReadFromFollower()


### PR DESCRIPTION
Refactor: PrimaryBack Replication protocol change Chan Size to 1024 on every socket

Signed-off-by: awzhgw <guowl18702995996@gmail.com>


