### PR TITLE
Enhancement: Reset raft peers of DataNode & MetaNode.

### DIFF
--- a/cli/cmd/datanode.go
+++ b/cli/cmd/datanode.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 	"sort"
 	"strings"
@@ -37,6 +38,7 @@ func newDataNodeCmd(client *master.MasterClient) *cobra.Command {
 		newDataNodeListCmd(client),
 		newDataNodeInfoCmd(client),
 		newDataNodeDecommissionCmd(client),
+		newResetDataNodeCmd(client),
 	)
 	return cmd
 }
@@ -45,7 +47,8 @@ const (
 	cmdDataNodeListShort             = "List information of data nodes"
 	cmdDataNodeInfoShort             = "Show information of a data node"
 	cmdDataNodeDecommissionInfoShort = "decommission partitions in a data node to others"
-)
+	cmdResetDataNodeShort            = "Reset corrupt data partitions related to this node"
+	)
 
 func newDataNodeListCmd(client *master.MasterClient) *cobra.Command {
 	var optFilterStatus string
@@ -142,6 +145,42 @@ func newDataNodeDecommissionCmd(client *master.MasterClient) *cobra.Command {
 			}
 			stdout("Decommission data node successfully\n")
 
+		},
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			if len(args) != 0 {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+			return validDataNodes(client, toComplete), cobra.ShellCompDirectiveNoFileComp
+		},
+	}
+	return cmd
+}
+
+func newResetDataNodeCmd(client *master.MasterClient) *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:   CliOpReset + " [ADDRESS]",
+		Short: cmdResetDataNodeShort,
+		Long: `If more than half replicas of a partition are on the corrupt nodes, the few remaining replicas can 
+not reach an agreement with one leader. In this case, you can use the "reset" command to fix the problem. This command
+is used to reset all the corrupt partitions related to a chosen corrupt node. However this action may lead to data 
+loss, be careful to do this.`,
+		Args: cobra.MinimumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			var (
+				address string
+				confirm     string
+				err         error
+			)
+			address = args[0]
+			stdout(fmt.Sprintf("The action may risk the danger of losing data, please confirm(y/n):"))
+			_, _ = fmt.Scanln(&confirm)
+			if "y" != confirm && "yes" != confirm {
+				return
+			}
+			if err = client.AdminAPI().ResetCorruptDataNode(address); err != nil {
+				stdout("%v\n", err)
+				return
+			}
 		},
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			if len(args) != 0 {

--- a/cli/cmd/metanode.go
+++ b/cli/cmd/metanode.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 	"sort"
 	"strings"
@@ -38,6 +39,7 @@ func newMetaNodeCmd(client *master.MasterClient) *cobra.Command {
 		newMetaNodeListCmd(client),
 		newMetaNodeInfoCmd(client),
 		newMetaNodeDecommissionCmd(client),
+		newResetMetaNodeCmd(client),
 	)
 	return cmd
 }
@@ -46,6 +48,7 @@ const (
 	cmdMetaNodeListShort             = "List information of meta nodes"
 	cmdMetaNodeInfoShort             = "Show information of meta nodes"
 	cmdMetaNodeDecommissionInfoShort = "Decommission partitions in a meta node to other nodes"
+	cmdResetMetaNodeShort            = "Reset corrupt meta partitions related to this node"
 )
 
 func newMetaNodeListCmd(client *master.MasterClient) *cobra.Command {
@@ -142,6 +145,42 @@ func newMetaNodeDecommissionCmd(client *master.MasterClient) *cobra.Command {
 			}
 			stdout("Decommission meta node successfully\n")
 
+		},
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			if len(args) != 0 {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+			return validMetaNodes(client, toComplete), cobra.ShellCompDirectiveNoFileComp
+		},
+	}
+	return cmd
+}
+
+func newResetMetaNodeCmd(client *master.MasterClient) *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:   CliOpReset + " [ADDRESS]",
+		Short: cmdResetMetaNodeShort,
+		Long: `If more than half replicas of a partition are on the corrupt nodes, the few remaining replicas can 
+not reach an agreement with one leader. In this case, you can use the "reset" command to fix the problem. This command
+is used to reset all the corrupt partitions related to a chosen corrupt node. However this action may lead to data 
+loss, be careful to do this.`,
+		Args: cobra.MinimumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			var (
+				address string
+				confirm     string
+				err         error
+			)
+			address = args[0]
+			stdout(fmt.Sprintf("The action may risk the danger of losing data, please confirm(y/n):"))
+			_, _ = fmt.Scanln(&confirm)
+			if "y" != confirm && "yes" != confirm {
+				return
+			}
+			if err = client.AdminAPI().ResetCorruptMetaNode(address); err != nil {
+				stdout("%v\n", err)
+				return
+			}
 		},
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			if len(args) != 0 {

--- a/cli/cmd/metapartition.go
+++ b/cli/cmd/metapartition.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"fmt"
 	"github.com/chubaofs/chubaofs/proto"
 	"github.com/chubaofs/chubaofs/sdk/master"
 	"github.com/spf13/cobra"
@@ -35,6 +36,7 @@ func newMetaPartitionCmd(client *master.MasterClient) *cobra.Command {
 	cmd.AddCommand(
 		newMetaPartitionGetCmd(client),
 		newListCorruptMetaPartitionCmd(client),
+		newResetMetaPartitionCmd(client),
 		newMetaPartitionDecommissionCmd(client),
 		newMetaPartitionReplicateCmd(client),
 		newMetaPartitionDeleteReplicaCmd(client),
@@ -45,6 +47,7 @@ func newMetaPartitionCmd(client *master.MasterClient) *cobra.Command {
 const (
 	cmdMetaPartitionGetShort              = "Display detail information of a meta partition"
 	cmdCheckCorruptMetaPartitionShort     = "Check out corrupt meta partitions"
+	cmdResetMetaPartitionShort        = "Reset corrupt meta partition"
 	cmdMetaPartitionDecommissionShort     = "Decommission a replication of the meta partition to a new address"
 	cmdMetaPartitionReplicateShort        = "Add a replication of the meta partition on a new address"
 	cmdMetaPartitionDeleteReplicaShort    = "Delete a replication of the meta partition on a fixed address"
@@ -166,6 +169,40 @@ func newMetaPartitionDecommissionCmd(client *master.MasterClient) *cobra.Command
 				return nil, cobra.ShellCompDirectiveNoFileComp
 			}
 			return validMetaNodes(client, toComplete), cobra.ShellCompDirectiveNoFileComp
+		},
+	}
+	return cmd
+}
+
+func newResetMetaPartitionCmd(client *master.MasterClient) *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:   CliOpReset + " [META PARTITION ID]",
+		Short: cmdResetMetaPartitionShort,
+		Long: `If more than half replicas of a partition are on the corrupt nodes, the few remaining replicas can 
+not reach an agreement with one leader. In this case, you can use the "metapartition reset" command
+to fix the problem, however this action may lead to data loss, be careful to do this.`,
+		Args: cobra.MinimumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			var (
+				confirm     string
+				partitionID uint64
+				err         error
+			)
+
+			partitionID, err = strconv.ParseUint(args[0], 10, 64)
+			if err != nil {
+				stdout("%v\n", err)
+				return
+			}
+			stdout(fmt.Sprintf("The action may risk the danger of losing meta data, please confirm(y/n):"))
+			_, _ = fmt.Scanln(&confirm)
+			if "y" != confirm && "yes" != confirm {
+				return
+			}
+			if err = client.AdminAPI().ResetMetaPartition(partitionID); err != nil {
+				stdout("%v\n", err)
+				return
+			}
 		},
 	}
 	return cmd

--- a/datanode/const.go
+++ b/datanode/const.go
@@ -53,6 +53,7 @@ const (
 	ActionDecommissionPartition         = "ActionDecommissionPartition"
 	ActionAddDataPartitionRaftMember    = "ActionAddDataPartitionRaftMember"
 	ActionRemoveDataPartitionRaftMember = "ActionRemoveDataPartitionRaftMember"
+	ActionResetDataPartitionRaftMember  = "ActionResetDataPartitionRaftMember"
 	ActionDataPartitionTryToLeader      = "ActionDataPartitionTryToLeader"
 
 	ActionCreateDataPartition        = "ActionCreateDataPartition"

--- a/datanode/partition.go
+++ b/datanode/partition.go
@@ -778,3 +778,9 @@ func (dp *DataPartition) ChangeRaftMember(changeType raftProto.ConfChangeType, p
 	resp, err = dp.raftPartition.ChangeMember(changeType, peer, context)
 	return
 }
+
+// ResetRaftMember is a wrapper function of changing the raft member.
+func (dp *DataPartition) ResetRaftMember(peers []raftProto.Peer, context []byte) (err error) {
+	err = dp.raftPartition.ResetMember(peers, context)
+	return
+}

--- a/docker/script/start_client.sh
+++ b/docker/script/start_client.sh
@@ -75,7 +75,7 @@ ensure_node_writable() {
     for i in $(seq 1 300) ; do
         ${cli} ${node} list &> /tmp/cli_${node}_list;
         res=`cat /tmp/cli_${node}_list | grep "Yes" | grep "Active" | wc -l`
-        if [[ ${res} -eq 4 ]]; then
+        if [[ ${res} -ge 3 ]]; then
             echo -e "\033[32mdone\033[0m"
             return
         fi

--- a/master/data_partition.go
+++ b/master/data_partition.go
@@ -119,6 +119,12 @@ func (partition *DataPartition) createTaskToRemoveRaftMember(removePeer proto.Pe
 	return
 }
 
+func (partition *DataPartition) createTaskToResetRaftMembers(newPeers []proto.Peer, address string) (task *proto.AdminTask, err error) {
+	task = proto.NewAdminTask(proto.OpResetDataPartitionRaftMember, address, newResetDataPartitionRaftMemberRequest(partition.PartitionID, newPeers))
+	partition.resetTaskID(task)
+	return
+}
+
 func (partition *DataPartition) createTaskToCreateDataPartition(addr string, dataPartitionSize uint64, peers []proto.Peer, hosts []string, createType int) (task *proto.AdminTask) {
 
 	task = proto.NewAdminTask(proto.OpCreateDataPartition, addr, newCreateDataPartitionRequest(
@@ -496,7 +502,7 @@ func (partition *DataPartition) update(action, volName string, newPeers []proto.
 		return errors.Trace(err, "action[%v] update partition[%v] vol[%v] failed", action, partition.PartitionID, volName)
 	}
 	msg := fmt.Sprintf("action[%v] success,vol[%v] partitionID:%v "+
-		"oldHosts:%v newHosts:%v,oldPees[%v],newPeers[%v]",
+		"oldHosts:%v, newHosts:%v, oldPeers[%v], newPeers[%v]",
 		action, volName, partition.PartitionID, orgHosts, partition.Hosts, oldPeers, partition.Peers)
 	log.LogInfo(msg)
 	return

--- a/master/http_server.go
+++ b/master/http_server.go
@@ -155,6 +155,12 @@ func (m *Server) registerAPIRoutes(router *mux.Router) {
 	router.NewRoute().Methods(http.MethodGet, http.MethodPost).
 		Path(proto.AdminDiagnoseMetaPartition).
 		HandlerFunc(m.diagnoseMetaPartition)
+	router.NewRoute().Methods(http.MethodGet, http.MethodPost).
+		Path(proto.AdminResetMetaPartition).
+		HandlerFunc(m.resetMetaPartition)
+	router.NewRoute().Methods(http.MethodGet, http.MethodPost).
+		Path(proto.AdminResetCorruptMetaNode).
+		HandlerFunc(m.resetCorruptMetaNode)
 
 	// data partition management APIs
 	router.NewRoute().Methods(http.MethodGet).
@@ -172,6 +178,9 @@ func (m *Server) registerAPIRoutes(router *mux.Router) {
 	router.NewRoute().Methods(http.MethodGet, http.MethodPost).
 		Path(proto.AdminDiagnoseDataPartition).
 		HandlerFunc(m.diagnoseDataPartition)
+	router.NewRoute().Methods(http.MethodGet, http.MethodPost).
+		Path(proto.AdminResetDataPartition).
+		HandlerFunc(m.resetDataPartition)
 	router.NewRoute().Methods(http.MethodGet).
 		Path(proto.ClientDataPartitions).
 		HandlerFunc(m.getDataPartitions)
@@ -203,6 +212,9 @@ func (m *Server) registerAPIRoutes(router *mux.Router) {
 	router.NewRoute().Methods(http.MethodGet, http.MethodPost).
 		Path(proto.DecommissionDataNode).
 		HandlerFunc(m.decommissionDataNode)
+	router.NewRoute().Methods(http.MethodGet, http.MethodPost).
+		Path(proto.AdminResetCorruptDataNode).
+		HandlerFunc(m.resetCorruptDataNode)
 	router.NewRoute().Methods(http.MethodGet).
 		Path(proto.GetDataNode).
 		HandlerFunc(m.getDataNode)

--- a/master/meta_partition.go
+++ b/master/meta_partition.go
@@ -21,9 +21,9 @@ import (
 	"github.com/chubaofs/chubaofs/proto"
 	"github.com/chubaofs/chubaofs/util/errors"
 	"github.com/chubaofs/chubaofs/util/log"
+	"math"
 	"strings"
 	"time"
-	"math"
 )
 
 // MetaReplica defines the replica of a meta partition
@@ -556,6 +556,13 @@ func (mp *MetaPartition) createTaskToRemoveRaftMember(removePeer proto.Peer) (t 
 	}
 	req := &proto.RemoveMetaPartitionRaftMemberRequest{PartitionId: mp.PartitionID, RemovePeer: removePeer}
 	t = proto.NewAdminTask(proto.OpRemoveMetaPartitionRaftMember, mr.Addr, req)
+	resetMetaPartitionTaskID(t, mp.PartitionID)
+	return
+}
+
+func (mp *MetaPartition) createTaskToResetRaftMembers(newPeers []proto.Peer, address string) (t *proto.AdminTask, err error) {
+	req := &proto.ResetMetaPartitionRaftMemberRequest{PartitionId: mp.PartitionID, NewPeers: newPeers}
+	t = proto.NewAdminTask(proto.OpResetMetaPartitionRaftMember, address, req)
 	resetMetaPartitionTaskID(t, mp.PartitionID)
 	return
 }

--- a/master/mocktest/data_server.go
+++ b/master/mocktest/data_server.go
@@ -133,6 +133,9 @@ func (mds *MockDataServer) serveConn(rc net.Conn) {
 	case proto.OpRemoveDataPartitionRaftMember:
 		err = mds.handleRemoveDataPartitionRaftMember(conn, req, adminTask)
 		fmt.Printf("data node [%v] remove data partition raft member,id[%v],err:%v\n", mds.TcpAddr, adminTask.ID, err)
+	case proto.OpResetDataPartitionRaftMember:
+		err = mds.handleResetDataPartitionRaftMember(conn, req, adminTask)
+		fmt.Printf("data node [%v] reset data partition raft member,id[%v],err:%v\n", mds.TcpAddr, adminTask.ID, err)
 	case proto.OpDataPartitionTryToLeader:
 		err = mds.handleTryToLeader(conn, req, adminTask)
 		fmt.Printf("data node [%v] try to leader,id[%v],err:%v\n", mds.TcpAddr, adminTask.ID, err)
@@ -147,6 +150,11 @@ func (mds *MockDataServer) handleAddDataPartitionRaftMember(conn net.Conn, p *pr
 }
 
 func (mds *MockDataServer) handleRemoveDataPartitionRaftMember(conn net.Conn, p *proto.Packet, adminTask *proto.AdminTask) (err error) {
+	responseAckOKToMaster(conn, p, nil)
+	return
+}
+
+func (mds *MockDataServer) handleResetDataPartitionRaftMember(conn net.Conn, p *proto.Packet, adminTask *proto.AdminTask) (err error) {
 	responseAckOKToMaster(conn, p, nil)
 	return
 }

--- a/master/mocktest/meta_server.go
+++ b/master/mocktest/meta_server.go
@@ -132,6 +132,9 @@ func (mms *MockMetaServer) serveConn(rc net.Conn) {
 	case proto.OpRemoveMetaPartitionRaftMember:
 		err = mms.handleRemoveMetaPartitionRaftMember(conn, req, adminTask)
 		fmt.Printf("meta node [%v] remove data partition raft member,id[%v],err:%v\n", mms.TcpAddr, adminTask.ID, err)
+	case proto.OpResetMetaPartitionRaftMember:
+		err = mms.handleResetMetaPartitionRaftMember(conn, req, adminTask)
+		fmt.Printf("meta node [%v] reset data partition raft member,id[%v],err:%v\n", mms.TcpAddr, adminTask.ID, err)
 	case proto.OpMetaPartitionTryToLeader:
 		err = mms.handleTryToLeader(conn, req, adminTask)
 		fmt.Printf("meta node [%v] try to leader,id[%v],err:%v\n", mms.TcpAddr, adminTask.ID, err)
@@ -146,6 +149,11 @@ func (mms *MockMetaServer) handleAddMetaPartitionRaftMember(conn net.Conn, p *pr
 }
 
 func (mms *MockMetaServer) handleRemoveMetaPartitionRaftMember(conn net.Conn, p *proto.Packet, adminTask *proto.AdminTask) (err error) {
+	responseAckOKToMaster(conn, p, nil)
+	return
+}
+
+func (mms *MockMetaServer) handleResetMetaPartitionRaftMember(conn net.Conn, p *proto.Packet, adminTask *proto.AdminTask) (err error) {
 	responseAckOKToMaster(conn, p, nil)
 	return
 }

--- a/master/operate_util.go
+++ b/master/operate_util.go
@@ -63,6 +63,14 @@ func newRemoveDataPartitionRaftMemberRequest(ID uint64, removePeer proto.Peer) (
 	return
 }
 
+func newResetDataPartitionRaftMemberRequest(ID uint64, newPeers []proto.Peer) (req *proto.ResetDataPartitionRaftMemberRequest) {
+	req = &proto.ResetDataPartitionRaftMemberRequest{
+		PartitionId: ID,
+		NewPeers:    newPeers,
+	}
+	return
+}
+
 func newLoadDataPartitionMetricRequest(ID uint64) (req *proto.LoadDataPartitionRequest) {
 	req = &proto.LoadDataPartitionRequest{
 		PartitionId: ID,

--- a/metanode/manager.go
+++ b/metanode/manager.go
@@ -130,6 +130,8 @@ func (m *metadataManager) HandleMetadataOperation(conn net.Conn, p *Packet,
 		err = m.opAddMetaPartitionRaftMember(conn, p, remoteAddr)
 	case proto.OpRemoveMetaPartitionRaftMember:
 		err = m.opRemoveMetaPartitionRaftMember(conn, p, remoteAddr)
+	case proto.OpResetMetaPartitionRaftMember:
+		err = m.opResetMetaPartitionMember(conn, p, remoteAddr)
 	case proto.OpMetaPartitionTryToLeader:
 		err = m.opMetaPartitionTryToLeader(conn, p, remoteAddr)
 	case proto.OpMetaBatchInodeGet:

--- a/metanode/partition.go
+++ b/metanode/partition.go
@@ -174,6 +174,8 @@ type OpPartition interface {
 	ResponseLoadMetaPartition(p *Packet) (err error)
 	PersistMetadata() (err error)
 	ChangeMember(changeType raftproto.ConfChangeType, peer raftproto.Peer, context []byte) (resp interface{}, err error)
+	ResetMember(peers []raftproto.Peer, context []byte) (err error)
+	ApplyResetMember(req *proto.ResetMetaPartitionRaftMemberRequest) (updated bool, err error)
 	Reset() (err error)
 	UpdatePartition(req *UpdatePartitionReq, resp *UpdatePartitionResp) (err error)
 	DeleteRaft() error
@@ -555,6 +557,12 @@ func (mp *metaPartition) nextInodeID() (inodeId uint64, err error) {
 // ChangeMember changes the raft member with the specified one.
 func (mp *metaPartition) ChangeMember(changeType raftproto.ConfChangeType, peer raftproto.Peer, context []byte) (resp interface{}, err error) {
 	resp, err = mp.raftPartition.ChangeMember(changeType, peer, context)
+	return
+}
+
+// ResetMebmer reset the raft members with new peers, be carefull !
+func (mp *metaPartition) ResetMember(peers []raftproto.Peer, context []byte) (err error) {
+	err = mp.raftPartition.ResetMember(peers, context)
 	return
 }
 

--- a/metanode/partition_fsmop.go
+++ b/metanode/partition_fsmop.go
@@ -17,6 +17,7 @@ package metanode
 import (
 	"encoding/json"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -136,6 +137,52 @@ func (mp *metaPartition) confRemoveNode(req *proto.MetaPartitionDecommissionRequ
 	}
 	log.LogInfof("Fininsh RemoveRaftNode  PartitionID(%v) nodeID(%v)  do RaftLog (%v) ",
 		req.PartitionID, mp.config.NodeId, string(data))
+	return
+}
+
+func (mp *metaPartition) ApplyResetMember(req *proto.ResetMetaPartitionRaftMemberRequest) (updated bool, err error) {
+	var (
+		newPeerIndexes []int
+		newPeers       []proto.Peer
+	)
+	data, _ := json.Marshal(req)
+	updated = true
+	log.LogInfof("Start ResetRaftNode  PartitionID(%v) nodeID(%v)  do RaftLog (%v) ",
+		req.PartitionId, mp.config.NodeId, string(data))
+	if len(req.NewPeers) >= len(mp.config.Peers) {
+		log.LogErrorf("NoUpdate ResetRaftNode  PartitionID(%v) nodeID(%v)  do RaftLog (%v) ",
+			req.PartitionId, mp.config.NodeId, string(data))
+		return
+	}
+	for _, peer := range req.NewPeers {
+		flag := false
+		for index, p := range mp.config.Peers {
+			if peer.ID == p.ID {
+				flag = true
+				newPeerIndexes = append(newPeerIndexes, index)
+				break
+			}
+		}
+		if !flag {
+			updated = false
+			log.LogErrorf("ResetRaftNode must be old node, PartitionID(%v) nodeID(%v)  do RaftLog (%v) ",
+				req.PartitionId, mp.config.NodeId, string(data))
+			return
+		}
+	}
+	if !updated {
+		log.LogInfof("NoUpdate ResetRaftNode  PartitionID(%v) nodeID(%v)  do RaftLog (%v) ",
+			req.PartitionId, mp.config.NodeId, string(data))
+		return
+	}
+	newPeers = make([]proto.Peer, len(newPeerIndexes))
+	sort.Ints(newPeerIndexes)
+	for i, index := range newPeerIndexes {
+		newPeers[i] = mp.config.Peers[index]
+	}
+	mp.config.Peers = newPeers
+	log.LogInfof("Finish ResetRaftNode  PartitionID(%v) nodeID(%v)  do RaftLog (%v) ",
+		req.PartitionId, mp.config.NodeId, string(data))
 	return
 }
 

--- a/proto/admin_proto.go
+++ b/proto/admin_proto.go
@@ -23,6 +23,8 @@ const (
 	AdminCreateDataPartition       = "/dataPartition/create"
 	AdminDecommissionDataPartition = "/dataPartition/decommission"
 	AdminDiagnoseDataPartition     = "/dataPartition/diagnose"
+	AdminResetDataPartition        = "/dataPartition/reset"
+	AdminResetCorruptDataNode      = "/dataNode/reset"
 	AdminDeleteDataReplica         = "/dataReplica/delete"
 	AdminAddDataReplica            = "/dataReplica/add"
 	AdminDeleteVol                 = "/vol/delete"
@@ -50,18 +52,20 @@ const (
 	RemoveRaftNode = "/raftNode/remove"
 
 	// Node APIs
-	AddDataNode                    = "/dataNode/add"
-	DecommissionDataNode           = "/dataNode/decommission"
-	DecommissionDisk               = "/disk/decommission"
-	GetDataNode                    = "/dataNode/get"
-	AddMetaNode                    = "/metaNode/add"
-	DecommissionMetaNode           = "/metaNode/decommission"
-	GetMetaNode                    = "/metaNode/get"
-	AdminLoadMetaPartition         = "/metaPartition/load"
-	AdminDiagnoseMetaPartition     = "/metaPartition/diagnose"
-	AdminDecommissionMetaPartition = "/metaPartition/decommission"
-	AdminAddMetaReplica            = "/metaReplica/add"
-	AdminDeleteMetaReplica         = "/metaReplica/delete"
+	AddDataNode                         = "/dataNode/add"
+	DecommissionDataNode                = "/dataNode/decommission"
+	DecommissionDisk                    = "/disk/decommission"
+	GetDataNode                         = "/dataNode/get"
+	AddMetaNode                         = "/metaNode/add"
+	DecommissionMetaNode                = "/metaNode/decommission"
+	GetMetaNode                         = "/metaNode/get"
+	AdminLoadMetaPartition              = "/metaPartition/load"
+	AdminDiagnoseMetaPartition          = "/metaPartition/diagnose"
+	AdminResetMetaPartition             = "/metaPartition/reset"
+	AdminResetCorruptMetaNode           = "/metaNode/reset"
+	AdminDecommissionMetaPartition      = "/metaPartition/decommission"
+	AdminAddMetaReplica                 = "/metaReplica/add"
+	AdminDeleteMetaReplica              = "/metaReplica/delete"
 
 	// Operation response
 	GetMetaNodeTaskResponse = "/metaNode/response" // Method: 'POST', ContentType: 'application/json'
@@ -178,6 +182,12 @@ type RemoveDataPartitionRaftMemberRequest struct {
 	RemovePeer  Peer
 }
 
+// ResetDataPartitionRaftMemberRequest defines the request of reset raftMembers of a data partition.
+type ResetDataPartitionRaftMemberRequest struct {
+	PartitionId uint64
+	NewPeers    []Peer
+}
+
 // AddMetaPartitionRaftMemberRequest defines the request of add raftMember a meta partition.
 type AddMetaPartitionRaftMemberRequest struct {
 	PartitionId uint64
@@ -188,6 +198,12 @@ type AddMetaPartitionRaftMemberRequest struct {
 type RemoveMetaPartitionRaftMemberRequest struct {
 	PartitionId uint64
 	RemovePeer  Peer
+}
+
+// ResetMetaPartitionRaftMemberRequest defines the request of reset raftMembers of a meta partition.
+type ResetMetaPartitionRaftMemberRequest struct {
+	PartitionId uint64
+	NewPeers    []Peer
 }
 
 // LoadDataPartitionRequest defines the request of loading a data partition.

--- a/proto/errors.go
+++ b/proto/errors.go
@@ -81,6 +81,9 @@ var (
 	ErrInvalidAccessKey                = errors.New("invalid access key")
 	ErrInvalidSecretKey                = errors.New("invalid secret key")
 	ErrIsOwner                         = errors.New("user owns the volume")
+	ErrBadReplicaNoMoreThanHalf        = errors.New("live replica num more than half, can not be reset")
+	ErrNoLiveReplicas                  = errors.New("no live replicas to reset")
+
 )
 
 // http response error code and error message definitions
@@ -144,6 +147,8 @@ const (
 	ErrCodeInvalidAccessKey
 	ErrCodeInvalidSecretKey
 	ErrCodeIsOwner
+	ErrCodeBadReplicaNoMoreThanHalf
+	ErrCodeNoLiveReplicas
 )
 
 // Err2CodeMap error map to code
@@ -205,6 +210,8 @@ var Err2CodeMap = map[error]int32{
 	ErrInvalidAccessKey:                ErrCodeInvalidAccessKey,
 	ErrInvalidSecretKey:                ErrCodeInvalidSecretKey,
 	ErrIsOwner:                         ErrCodeIsOwner,
+	ErrBadReplicaNoMoreThanHalf:        ErrCodeBadReplicaNoMoreThanHalf,
+	ErrNoLiveReplicas:                  ErrCodeNoLiveReplicas,
 }
 
 func ParseErrorCode(code int32) error {
@@ -273,4 +280,6 @@ var code2ErrMap = map[int32]error{
 	ErrCodeInvalidAccessKey:                ErrInvalidAccessKey,
 	ErrCodeInvalidSecretKey:                ErrInvalidSecretKey,
 	ErrCodeIsOwner:                         ErrIsOwner,
+	ErrCodeBadReplicaNoMoreThanHalf:        ErrBadReplicaNoMoreThanHalf,
+	ErrCodeNoLiveReplicas:                  ErrNoLiveReplicas,
 }

--- a/proto/packet.go
+++ b/proto/packet.go
@@ -111,6 +111,7 @@ const (
 	OpMetaPartitionTryToLeader      uint8 = 0x48
 	OpSetMetaNodeParams             uint8 = 0x49
 	OpGetMetaNodeParams             uint8 = 0x4A
+	OpResetMetaPartitionRaftMember  uint8 = 0x4B
 
 	// Operations: Master -> DataNode
 	OpCreateDataPartition           uint8 = 0x60
@@ -123,6 +124,7 @@ const (
 	OpAddDataPartitionRaftMember    uint8 = 0x67
 	OpRemoveDataPartitionRaftMember uint8 = 0x68
 	OpDataPartitionTryToLeader      uint8 = 0x69
+	OpResetDataPartitionRaftMember  uint8 = 0x6A
 
 	// Operations: MultipartInfo
 	OpCreateMultipart  uint8 = 0x70
@@ -343,10 +345,14 @@ func (p *Packet) GetOpMsg() (m string) {
 		m = "OpRemoveDataPartitionRaftMember"
 	case OpAddDataPartitionRaftMember:
 		m = "OpAddDataPartitionRaftMember"
+	case OpResetDataPartitionRaftMember:
+		m = "OpResetDataPartitionRaftMember"
 	case OpAddMetaPartitionRaftMember:
 		m = "OpAddMetaPartitionRaftMember"
 	case OpRemoveMetaPartitionRaftMember:
 		m = "OpRemoveMetaPartitionRaftMember"
+	case OpResetMetaPartitionRaftMember:
+		m = "OpResetMetaPartitionRaftMember"
 	case OpMetaPartitionTryToLeader:
 		m = "OpMetaPartitionTryToLeader"
 	case OpDataPartitionTryToLeader:

--- a/raftstore/partition.go
+++ b/raftstore/partition.go
@@ -40,6 +40,8 @@ type Partition interface {
 	// ChaneMember submits member change event and information to raft log.
 	ChangeMember(changeType proto.ConfChangeType, peer proto.Peer, context []byte) (resp interface{}, err error)
 
+	// ResetMember reset members directly with no submit, be carefully calling this method. It is used only when dead replicas > live ones and can no longer be alive
+	ResetMember(peers []proto.Peer, context []byte) (err error)
 	// Stop removes the raft partition from raft server and shuts down this partition.
 	Stop() error
 
@@ -86,6 +88,11 @@ func (p *partition) ChangeMember(changeType proto.ConfChangeType, peer proto.Pee
 	}
 	future := p.raft.ChangeMember(p.id, changeType, peer, context)
 	resp, err = future.Response()
+	return
+}
+
+func (p *partition) ResetMember(peers []proto.Peer, context []byte) (err error) {
+	err = p.raft.ResetMember(p.id, peers, context)
 	return
 }
 

--- a/sdk/master/api_admin.go
+++ b/sdk/master/api_admin.go
@@ -79,6 +79,25 @@ func (api *AdminAPI) DiagnoseDataPartition() (diagnosis *proto.DataPartitionDiag
 	return
 }
 
+func (api *AdminAPI) ResetDataPartition(partitionID uint64) (err error) {
+	var request = newAPIRequest(http.MethodGet, proto.AdminResetDataPartition)
+	request.addParam("id", strconv.Itoa(int(partitionID)))
+	if _, err = api.mc.serveRequest(request); err != nil {
+		return
+	}
+	return
+}
+
+func (api *AdminAPI) ResetCorruptDataNode(nodeAddr string) (err error) {
+	var request = newAPIRequest(http.MethodGet, proto.AdminResetCorruptDataNode)
+	request.addParam("addr", nodeAddr)
+	request.addHeader("isTimeOut", "false")
+	if _, err = api.mc.serveRequest(request); err != nil {
+		return
+	}
+	return
+}
+
 func (api *AdminAPI) DiagnoseMetaPartition() (diagnosis *proto.MetaPartitionDiagnosis, err error) {
 	var buf []byte
 	var request = newAPIRequest(http.MethodGet, proto.AdminDiagnoseMetaPartition)
@@ -87,6 +106,24 @@ func (api *AdminAPI) DiagnoseMetaPartition() (diagnosis *proto.MetaPartitionDiag
 	}
 	diagnosis = &proto.MetaPartitionDiagnosis{}
 	if err = json.Unmarshal(buf, &diagnosis); err != nil {
+		return
+	}
+	return
+}
+func (api *AdminAPI) ResetMetaPartition( partitionID uint64) (err error) {
+	var request = newAPIRequest(http.MethodGet, proto.AdminResetMetaPartition)
+	request.addParam("id", strconv.Itoa(int(partitionID)))
+	if _, err = api.mc.serveRequest(request); err != nil {
+		return
+	}
+	return
+}
+
+func (api *AdminAPI) ResetCorruptMetaNode(nodeAddr string) (err error) {
+	var request = newAPIRequest(http.MethodGet, proto.AdminResetCorruptMetaNode)
+	request.addParam("addr", nodeAddr)
+	request.addHeader("isTimeOut", "false")
+	if _, err = api.mc.serveRequest(request); err != nil {
 		return
 	}
 	return

--- a/vendor/github.com/tiglabs/raft/README.md
+++ b/vendor/github.com/tiglabs/raft/README.md
@@ -11,7 +11,7 @@ go get -u github.com/tiglabs/raft
 
 ## Features
 
-The CoreOS etc/raft implementation has been modified to add the following features.
+The CoreOS etcd/raft implementation has been modified to add the following features.
 
 - multi-raft support    
 - snapshot manager   

--- a/vendor/github.com/tiglabs/raft/errors.go
+++ b/vendor/github.com/tiglabs/raft/errors.go
@@ -27,6 +27,7 @@ var (
 	ErrStopped       = errors.New("raft is already shutdown.")
 	ErrSnapping      = errors.New("raft is doing snapshot.")
 	ErrRetryLater    = errors.New("retry later")
+	ErrPeersEmpty    = errors.New("peers are nil or empty")
 )
 
 type FatalError struct {

--- a/vendor/github.com/tiglabs/raft/proto/proto.go
+++ b/vendor/github.com/tiglabs/raft/proto/proto.go
@@ -127,6 +127,11 @@ type ConfChange struct {
 	Context []byte
 }
 
+type ResetPeers struct {
+	NewPeers []Peer
+	Context  []byte
+}
+
 type HeartbeatContext []uint64
 
 func (t MsgType) String() string {

--- a/vendor/github.com/tiglabs/raft/raft_fsm.go
+++ b/vendor/github.com/tiglabs/raft/raft_fsm.go
@@ -280,6 +280,44 @@ func (r *raftFsm) applyConfChange(cc *proto.ConfChange) {
 	}
 }
 
+func (r *raftFsm) applyResetPeer(rp *proto.ResetPeers) {
+	if r.state == stateLeader {
+		logger.Warn("raft[%v] ignore reset peers in case of leader exists", r.id)
+		return
+	}
+	if len(rp.NewPeers) > len(r.replicas)/2 {
+		logger.Warn("raft[%v] ignore reset more than half of old peers", r.id)
+		return
+	}
+
+	for _, peer := range rp.NewPeers {
+		replica, ok := r.replicas[peer.ID]
+		if !ok {
+			logger.Info("raft[%v] ignore reset peer[%v], current[%v]", r.id, peer.String(), replica.peer.String())
+			return
+		} else if replica.peer.PeerID != peer.PeerID {
+			if logger.IsEnableInfo() {
+				logger.Info("raft[%v] ignore reset peer[%v], current[%v]", r.id, peer.String(), replica.peer.String())
+			}
+			return
+		}
+	}
+	r.reset(r.term+1, 0, false)
+	r.acks = nil
+	for _, replica := range r.replicas {
+		flag := false
+		for _, peer := range rp.NewPeers {
+			if replica.peer.ID == peer.ID {
+				flag = true
+			}
+		}
+		if !flag {
+			delete(r.replicas, replica.peer.ID)
+		}
+	}
+
+}
+
 func (r *raftFsm) addPeer(peer proto.Peer) {
 	r.pendingConf = false
 	if _, ok := r.replicas[peer.ID]; !ok {

--- a/vendor/github.com/tiglabs/raft/server.go
+++ b/vendor/github.com/tiglabs/raft/server.go
@@ -191,6 +191,24 @@ func (rs *RaftServer) ChangeMember(id uint64, changeType proto.ConfChangeType, p
 	return
 }
 
+func (rs *RaftServer) ResetMember(id uint64, peers []proto.Peer, context []byte) (err error) {
+	rs.mu.RLock()
+	raft, ok := rs.rafts[id]
+	rs.mu.RUnlock()
+	if !ok {
+		err = ErrRaftNotExists
+		return
+	}
+	if peers == nil || len(peers) == 0 {
+		err = ErrPeersEmpty
+		return
+	}
+
+	raft.raftFsm.applyResetPeer(&proto.ResetPeers{NewPeers: peers, Context: context})
+	raft.peerState.replace(peers)
+	return nil
+}
+
 func (rs *RaftServer) Status(id uint64) (status *Status) {
 	rs.mu.RLock()
 	raft, ok := rs.rafts[id]


### PR DESCRIPTION
When live raft peers are not more than half, no raft peer can won the election. And the raft group can not work anymore until the dead peers be pulled up. We introduce the `reset` action to raft proto, to make raft group can still recover to normal status even if there is no leader. This action may cause the loss of data, it is the last thing you can do without a better solution.