### PR TITLE
refactor: whether to cache volume oss meta is determined by the configuration parameter 'strict'

### DIFF
--- a/docker/s3tests/base.py
+++ b/docker/s3tests/base.py
@@ -153,6 +153,21 @@ class S3TestCase(TestCase):
             self.assertTrue('LocationConstraint' in result)
             self.assertEqual(result['LocationConstraint'], location)
 
+    def assert_get_bucket_cors_result(self, result, cors_config=None):
+        self.assert_result_status_code(result=result, status_code=200)
+        if cors_config is not None:
+            self.assertEqual(result['CORSRules'], cors_config['CORSRules'])
+        else:
+            self.assertFalse('CORSRules' in result)
+
+    def assert_cors_request_result(self, result, response_code=200, response_origin=None, response_method=None):
+        self.assertEqual(result.status_code, response_code)
+        self.assertEqual(result.headers.get('Access-Control-Allow-Origin'), response_origin)
+        if response_method is not None:
+            self.assertTrue(response_method in result.headers.get('Access-Control-Allow-Methods'))
+        else:
+            self.assertEqual(result.headers.get('Access-Control-Allow-Methods'), None)
+
     def assert_head_object_result(self, result, etag=None, content_type=None, content_length=None, metadata=None):
         self.assert_result_status_code(result=result, status_code=200)
         if etag is not None:

--- a/docker/s3tests/test_cors.py
+++ b/docker/s3tests/test_cors.py
@@ -1,0 +1,137 @@
+# Copyright 2020 The ChubaoFS Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+# -*- coding: utf-8 -*-
+
+import env
+import requests
+from base import S3TestCase, get_env_s3_client, random_string, random_bytes, compute_md5
+
+PUT_ORIGIN = "www.*.com"
+OTHER_ORIGIN = "*.com"
+
+ALLOWED_HEADERS = ["*"]
+ALLOWED_METHODS = ['PUT', 'POST', 'GET']
+ALLOWED_ORIGINS = [PUT_ORIGIN]
+EXPOSE_HEADERS = ['*']
+MAX_AGE_SECONDS = 123
+
+CORS_CONFIG = {
+    'CORSRules': [
+        {
+            'AllowedHeaders': ALLOWED_HEADERS,
+            'AllowedMethods': ALLOWED_METHODS,
+            'AllowedOrigins': ALLOWED_ORIGINS,
+            'ExposeHeaders': EXPOSE_HEADERS,
+            'MaxAgeSeconds': MAX_AGE_SECONDS
+        },
+    ]
+}
+
+BUCKET_URL = '{endpoint}/{bucket_name}'.format(endpoint=env.ENDPOINT, bucket_name=env.BUCKET)
+
+class CorsTest(S3TestCase):
+    s3 = None
+
+    def __init__(self, case):
+        super(CorsTest, self).__init__(case)
+        self.s3 = get_env_s3_client()
+
+    def test_cors_set(self):
+        # Get bucket CORS configuration
+        self.assert_get_bucket_cors_result(
+            result=self.s3.get_bucket_cors(Bucket=env.BUCKET))
+        # Put bucket CORS configuration
+        self.assert_result_status_code(
+            result=self.s3.put_bucket_cors(Bucket=env.BUCKET, CORSConfiguration=CORS_CONFIG))
+        # Get bucket CORS configuration
+        self.assert_get_bucket_cors_result(
+            result=self.s3.get_bucket_cors(Bucket=env.BUCKET), cors_config=CORS_CONFIG)
+        # Delete bucket CORS configuration
+        self.assert_result_status_code(
+            result=self.s3.delete_bucket_cors(Bucket=env.BUCKET), status_code=204)
+        # Get bucket CORS configuration
+        self.assert_get_bucket_cors_result(
+            result=self.s3.get_bucket_cors(Bucket=env.BUCKET))
+
+    def test_cors_request(self):
+        # Put bucket cors
+        self.assert_result_status_code(
+            result=self.s3.put_bucket_cors(Bucket=env.BUCKET, CORSConfiguration=CORS_CONFIG))
+        # Send allowed cors request
+        self.assert_cors_request_result(
+            result=requests.get(url=BUCKET_URL, headers={'Origin': PUT_ORIGIN, 'Access-Control-Request-Method': 'GET'}),
+            response_code=403,
+            response_origin=PUT_ORIGIN,
+            response_method='GET')
+        # Send not-allowed cors request
+        self.assert_cors_request_result(
+            result=requests.get(url=BUCKET_URL, headers={'Origin': OTHER_ORIGIN, 'Access-Control-Request-Method': 'GET'}),
+            response_code=403,
+            response_origin=None,
+            response_method=None)
+        # Send no cors request
+        self.assert_cors_request_result(
+            result=requests.get(url=BUCKET_URL),
+            response_code=403,
+            response_origin=None,
+            response_method=None)
+
+        # Delete bucket cors
+        self.assert_result_status_code(
+            result=self.s3.delete_bucket_cors(Bucket=env.BUCKET), status_code=204)
+        # Send cors request
+        self.assert_cors_request_result(
+            result=requests.get(url=BUCKET_URL, headers={'Origin': PUT_ORIGIN, 'Access-Control-Request-Method': 'GET'}),
+            response_code=403,
+            response_origin=None,
+            response_method=None)
+
+    def test_cors_options(self):
+        # Put object
+        key = 'test-options-object'
+        size = 1024 * 256
+        body = random_bytes(size)
+        expect_md5 = compute_md5(body)
+        self.assert_put_object_result(
+            result=self.s3.put_object(Bucket=env.BUCKET, Key=key, Body=body),
+            etag=expect_md5)
+
+        # Put bucket cors
+        self.assert_result_status_code(
+            result=self.s3.put_bucket_cors(Bucket=env.BUCKET, CORSConfiguration=CORS_CONFIG))
+
+        options_url = '{bucket_url}/{key}'.format(bucket_url=BUCKET_URL, key=key)
+
+        # Send options requests
+        self.assert_cors_request_result(
+            result=requests.options(url=options_url,
+                                    headers={'Origin': PUT_ORIGIN, 'Access-Control-Request-Method': 'GET'}),
+            response_code=200,
+            response_origin=PUT_ORIGIN,
+            response_method='GET')
+
+        # Delete bucket cors
+        self.assert_result_status_code(
+            result=self.s3.delete_bucket_cors(Bucket=env.BUCKET), status_code=204)
+        # Send options requests
+        self.assert_cors_request_result(
+            result=requests.options(url=options_url,
+                                    headers={'Origin': PUT_ORIGIN, 'Access-Control-Request-Method': 'GET'}),
+            response_code=200,
+            response_origin=None,
+            response_method=None)
+        # Delete object
+        self.assert_delete_object_result(
+            result=self.s3.delete_object(Bucket=env.BUCKET, Key=key))

--- a/docker/s3tests/test_cors.py
+++ b/docker/s3tests/test_cors.py
@@ -41,6 +41,7 @@ CORS_CONFIG = {
 
 BUCKET_URL = '{endpoint}/{bucket_name}'.format(endpoint=env.ENDPOINT, bucket_name=env.BUCKET)
 
+
 class CorsTest(S3TestCase):
     s3 = None
 

--- a/objectnode/acl.go
+++ b/objectnode/acl.go
@@ -296,7 +296,7 @@ func storeBucketACL(bytes []byte, vol *Volume) (*AccessControlPolicy, error) {
 		return nil, err4
 	}
 
-	vol.storeACL(acl)
+	vol.metaLoader.storeACL(acl)
 
 	return acl, nil
 }

--- a/objectnode/acl_handler.go
+++ b/objectnode/acl_handler.go
@@ -64,7 +64,11 @@ func (o *ObjectNode) getBucketACLHandler(w http.ResponseWriter, r *http.Request)
 		ec = NoSuchBucket
 		return
 	}
-	acl := vol.loadACL()
+	var acl *AccessControlPolicy
+	if acl, err = vol.metaLoader.loadACL(); err != nil {
+		ec = InternalErrorCode(err)
+		return
+	}
 	var aclData []byte
 	if acl != nil {
 		aclData, err = xml.Marshal(acl)

--- a/objectnode/api_middleware.go
+++ b/objectnode/api_middleware.go
@@ -268,7 +268,7 @@ func (o *ObjectNode) corsMiddleware(next http.Handler) http.Handler {
 			if origin == "" || method == "" {
 				return
 			}
-			cors := volume.loadCors()
+			cors, _ := volume.metaLoader.loadCors()
 			if cors != nil {
 				headers := strings.Split(headerStr, ",")
 				for _, corsRule := range cors.CORSRule {

--- a/objectnode/cors_handler.go
+++ b/objectnode/cors_handler.go
@@ -30,7 +30,11 @@ func (o *ObjectNode) getBucketCorsHandler(w http.ResponseWriter, r *http.Request
 
 	var output = CORSConfiguration{}
 
-	cors := vol.loadCors()
+	var cors *CORSConfiguration
+	if cors, err = vol.metaLoader.loadCors(); err != nil {
+		_ = InternalErrorCode(err).ServeResponse(w, r)
+		return
+	}
 	if cors != nil {
 		output.CORSRule = cors.CORSRule
 	}
@@ -85,7 +89,7 @@ func (o *ObjectNode) putBucketCorsHandler(w http.ResponseWriter, r *http.Request
 		_ = InternalErrorCode(err).ServeResponse(w, r)
 		return
 	}
-	vol.storeCors(corsConfig)
+	vol.metaLoader.storeCors(corsConfig)
 
 	return
 }
@@ -110,7 +114,7 @@ func (o *ObjectNode) deleteBucketCorsHandler(w http.ResponseWriter, r *http.Requ
 		_ = InternalErrorCode(err).ServeResponse(w, r)
 		return
 	}
-	vol.storeCors(nil)
+	vol.metaLoader.storeCors(nil)
 
 	w.WriteHeader(http.StatusNoContent)
 	return

--- a/objectnode/fs_manager.go
+++ b/objectnode/fs_manager.go
@@ -40,6 +40,7 @@ type VolumeLoader struct {
 	blacklist  sync.Map // mapping: volume name -> timestamp (time.Time)
 	closeOnce  sync.Once
 	closeCh    chan struct{}
+	metaStrict bool
 }
 
 func (loader *VolumeLoader) blacklistCleanup() {
@@ -134,6 +135,7 @@ func (loader *VolumeLoader) loadVolume(volName string) (*Volume, error) {
 			Masters:          loader.masters,
 			Store:            loader.store,
 			OnAsyncTaskError: onAsyncTaskError,
+			MetaStrict:       loader.metaStrict,
 		}
 		if volume, err = NewVolume(config); err != nil {
 			if err != proto.ErrVolNotExists {
@@ -152,7 +154,6 @@ func (loader *VolumeLoader) loadVolume(volName string) (*Volume, error) {
 		loader.volMu.Unlock()
 		release()
 
-		volume.loadOSSMeta()
 	}
 
 	return volume, nil
@@ -172,24 +173,26 @@ func (loader *VolumeLoader) Close() {
 	})
 }
 
-func NewVolumeLoader(masters []string, store Store) *VolumeLoader {
+func NewVolumeLoader(masters []string, store Store, strict bool) *VolumeLoader {
 	loader := &VolumeLoader{
-		masters: masters,
-		store:   store,
-		volumes: make(map[string]*Volume),
-		closeCh: make(chan struct{}),
+		masters:    masters,
+		store:      store,
+		volumes:    make(map[string]*Volume),
+		closeCh:    make(chan struct{}),
+		metaStrict: strict,
 	}
 	go loader.blacklistCleanup()
 	return loader
 }
 
 type VolumeManager struct {
-	masters   []string
-	mc        *master.MasterClient
-	loaders   [volumeLoaderNum]*VolumeLoader
-	store     Store
-	closeOnce sync.Once
-	closeCh   chan struct{}
+	masters    []string
+	mc         *master.MasterClient
+	loaders    [volumeLoaderNum]*VolumeLoader
+	store      Store
+	metaStrict bool
+	closeOnce  sync.Once
+	closeCh    chan struct{}
 }
 
 func (m *VolumeManager) selectLoader(name string) *VolumeLoader {
@@ -219,14 +222,15 @@ func (m *VolumeManager) init() {
 		vm: m,
 	}
 	for i := 0; i < len(m.loaders); i++ {
-		m.loaders[i] = NewVolumeLoader(m.masters, m.store)
+		m.loaders[i] = NewVolumeLoader(m.masters, m.store, m.metaStrict)
 	}
 }
 
-func NewVolumeManager(masters []string) *VolumeManager {
+func NewVolumeManager(masters []string, strict bool) *VolumeManager {
 	manager := &VolumeManager{
-		masters: masters,
-		closeCh: make(chan struct{}),
+		masters:    masters,
+		closeCh:    make(chan struct{}),
+		metaStrict: strict,
 	}
 	manager.init()
 	return manager

--- a/objectnode/fs_volume_meta.go
+++ b/objectnode/fs_volume_meta.go
@@ -1,0 +1,104 @@
+// Copyright 2019 The ChubaoFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package objectnode
+
+import "sync"
+
+type ossMetaLoader interface {
+	loadPolicy() (p *Policy, err error)
+	loadACL() (p *AccessControlPolicy, err error)
+	loadCors() (cors *CORSConfiguration, err error)
+	storePolicy(p *Policy)
+	storeACL(p *AccessControlPolicy)
+	storeCors(cors *CORSConfiguration)
+}
+
+type strictMetaLoader struct {
+	v *Volume
+}
+
+type cacheMetaLoader struct {
+	om *OSSMeta
+}
+
+// OSSMeta is bucket policy and ACL metadata.
+type OSSMeta struct {
+	policy     *Policy
+	acl        *AccessControlPolicy
+	corsConfig *CORSConfiguration
+	policyLock sync.RWMutex
+	aclLock    sync.RWMutex
+	corsLock   sync.RWMutex
+}
+
+func (c *cacheMetaLoader) loadPolicy() (p *Policy, err error) {
+	c.om.policyLock.RLock()
+	p = c.om.policy
+	c.om.policyLock.RUnlock()
+	return
+}
+
+func (c *cacheMetaLoader) storePolicy(p *Policy) {
+	c.om.policyLock.Lock()
+	c.om.policy = p
+	c.om.policyLock.Unlock()
+	return
+}
+
+func (c *cacheMetaLoader) loadACL() (p *AccessControlPolicy, err error) {
+	c.om.aclLock.RLock()
+	p = c.om.acl
+	c.om.aclLock.RUnlock()
+	return
+}
+
+func (c *cacheMetaLoader) storeACL(p *AccessControlPolicy) {
+	c.om.aclLock.Lock()
+	c.om.acl = p
+	c.om.aclLock.Unlock()
+	return
+}
+
+func (c *cacheMetaLoader) loadCors() (cors *CORSConfiguration, err error) {
+	c.om.corsLock.RLock()
+	cors = c.om.corsConfig
+	c.om.corsLock.RUnlock()
+	return
+}
+
+func (c *cacheMetaLoader) storeCors(cors *CORSConfiguration) {
+	c.om.corsLock.Lock()
+	c.om.corsConfig = cors
+	c.om.corsLock.Unlock()
+	return
+}
+
+func (s *strictMetaLoader) loadPolicy() (p *Policy, err error) {
+	return s.v.loadBucketPolicy()
+}
+
+func (s *strictMetaLoader) storePolicy(p *Policy) {}
+
+func (s *strictMetaLoader) loadACL() (acp *AccessControlPolicy, err error) {
+	return s.v.loadBucketACL()
+}
+
+func (s *strictMetaLoader) storeACL(p *AccessControlPolicy) {}
+
+func (s *strictMetaLoader) loadCors() (cors *CORSConfiguration, err error) {
+	return s.v.loadBucketCors()
+}
+
+func (s *strictMetaLoader) storeCors(cors *CORSConfiguration) {}

--- a/objectnode/policy.go
+++ b/objectnode/policy.go
@@ -114,7 +114,7 @@ func storeBucketPolicy(bytes []byte, vol *Volume) (*Policy, error) {
 		return nil, err4
 	}
 
-	vol.storePolicy(policy)
+	vol.metaLoader.storePolicy(policy)
 
 	return policy, nil
 }
@@ -262,8 +262,12 @@ func (o *ObjectNode) policyCheck(f http.HandlerFunc) http.HandlerFunc {
 			if vol, err = o.getVol(bucket); err != nil {
 				return
 			}
-			acl = vol.loadACL()
-			policy = vol.loadPolicy()
+			if acl, err = vol.metaLoader.loadACL(); err != nil {
+				return
+			}
+			if policy, err = vol.metaLoader.loadPolicy(); err != nil {
+				return
+			}
 			return
 		}
 		if err = loadBucketMeta(param.Bucket()); err != nil {

--- a/objectnode/policy_handler.go
+++ b/objectnode/policy_handler.go
@@ -44,13 +44,14 @@ func (o *ObjectNode) getBucketPolicyHandler(w http.ResponseWriter, r *http.Reque
 		ec = NoSuchBucket
 		return
 	}
-	ossMeta := vol.OSSMeta()
-	if ossMeta == nil {
-		ossMeta = &OSSMeta{}
+	var policy *Policy
+	if policy, err = vol.metaLoader.loadPolicy(); err != nil {
+		ec = InternalErrorCode(err)
+		return
 	}
 
 	var policyData []byte
-	policyData, err = json.Marshal(ossMeta.policy)
+	policyData, err = json.Marshal(policy)
 	if err != nil {
 		ec = InternalErrorCode(err)
 		return

--- a/objectnode/server.go
+++ b/objectnode/server.go
@@ -177,7 +177,7 @@ func (o *ObjectNode) loadConfig(cfg *config.Config) (err error) {
 	log.LogInfof("loadConfig: strict: %v", strict)
 
 	o.mc = master.NewMasterClient(masters, false)
-	o.vm = NewVolumeManager(masters)
+	o.vm = NewVolumeManager(masters, strict)
 	o.userStore = NewUserInfoStore(masters, strict)
 
 	return


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1. Whether to cache volume oss meta is determined by the configuration parameter 'strict'.
2. Add cors test cases.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

None.

**Special notes for your reviewer**:

None.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

None.
