### PR TITLE
Fix: ListBuckets and headBucket result is empty using java sdk

### DIFF
--- a/objectnode/api_handler_bucket.go
+++ b/objectnode/api_handler_bucket.go
@@ -30,7 +30,7 @@ import (
 // Head bucket
 // API reference: https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadBucket.html
 func (o *ObjectNode) headBucketHandler(w http.ResponseWriter, r *http.Request) {
-	// do nothing
+	w.Header()[HeaderNameXAmzBucketRegion] = []string{o.region}
 }
 
 // Create bucket
@@ -136,9 +136,9 @@ func (o *ObjectNode) listBucketsHandler(w http.ResponseWriter, r *http.Request) 
 	}
 
 	type listBucketsOutput struct {
-		XMLName xml.Name `xml:"ListBucketsOutput"`
-		Buckets []bucket `xml:"Buckets>Bucket"`
+		XMLName xml.Name `xml:"ListAllMyBucketsResult"`
 		Owner   Owner    `xml:"Owner"`
+		Buckets []bucket `xml:"Buckets>Bucket"`
 	}
 
 	var output = listBucketsOutput{}

--- a/objectnode/const.go
+++ b/objectnode/const.go
@@ -64,6 +64,7 @@ const (
 	HeaderNameXAmzMetaPrefix          = "x-amz-meta-"
 	HeaderNameXAmzDownloadPartCount   = "x-amz-mp-parts-count"
 	HeaderNameXAmzMetadataDirective   = "x-amz-metadata-directive"
+	HeaderNameXAmzBucketRegion        = "x-amz-bucket-region"
 
 	HeaderNameIfMatch           = "If-Match"
 	HeaderNameIfNoneMatch       = "If-None-Match"


### PR DESCRIPTION
**What this PR does / why we need it**:
1. ListBuckets result is empty when buckets has existed via using java sdk.
2. HeadBucket result is empty, expect bucket region.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
