### PR TITLE
Fix: putObject the key with double slash return 403

### DIFF
--- a/objectnode/auth_signature_v4.go
+++ b/objectnode/auth_signature_v4.go
@@ -506,7 +506,9 @@ func calculateSignatureV4(r *http.Request, cred credential, secretKey string, si
 }
 
 func getCanonicalURI(r *http.Request) string {
-	return r.URL.EscapedPath()
+	// If request path contain double slash, the java sdk of aws escape the second slash into '%2F' after computing signature,
+	// so we received path is '/%2F', we have to unescape it to double slash again before computing signature.
+	return strings.ReplaceAll(r.URL.EscapedPath(), "/%2F", "//")
 }
 
 // https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix: Put object return 403 if key contain double slash.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
