### PR TITLE
Fix: some bugs about object tagging and bucket tagging

### DIFF
--- a/objectnode/const.go
+++ b/objectnode/const.go
@@ -65,6 +65,7 @@ const (
 	HeaderNameXAmzDownloadPartCount   = "x-amz-mp-parts-count"
 	HeaderNameXAmzMetadataDirective   = "x-amz-metadata-directive"
 	HeaderNameXAmzBucketRegion        = "x-amz-bucket-region"
+	HeaderNameXAmzTaggingCount   	  = "x-amz-tagging-count"
 
 	HeaderNameIfMatch           = "If-Match"
 	HeaderNameIfNoneMatch       = "If-None-Match"
@@ -164,4 +165,10 @@ const (
 const (
 	MetadataDirectiveCopy    = "COPY"
 	MetadataDirectiveReplace = "REPLACE"
+)
+
+const (
+	TaggingCounts         = 10
+	TaggingKeyMaxLength   = 128
+	TaggingValueMaxLength = 256
 )

--- a/objectnode/fs_store_xattr.go
+++ b/objectnode/fs_store_xattr.go
@@ -61,7 +61,7 @@ func (s *xattrStore) Put(vol, path, key string, data []byte) (err error) {
 		err = err1
 		return
 	}
-	err = v.SetXAttr(path, key, data)
+	err = v.SetXAttr(path, key, data, false)
 	if err != nil {
 		log.LogErrorf("put xattr failed: vol[%v], key[%v], data[%v]", vol, key, data)
 	}

--- a/objectnode/fs_volume.go
+++ b/objectnode/fs_volume.go
@@ -265,10 +265,13 @@ func (v *Volume) getInodeFromPath(path string) (inode uint64, err error) {
 	return
 }
 
-func (v *Volume) SetXAttr(path string, key string, data []byte) error {
+func (v *Volume) SetXAttr(path string, key string, data []byte, autoCreate bool) error {
 	var err error
 	var inode uint64
 	if inode, err = v.getInodeFromPath(path); err != nil && err != syscall.ENOENT {
+		return err
+	}
+	if err == syscall.ENOENT && !autoCreate {
 		return err
 	}
 	if err == syscall.ENOENT {

--- a/objectnode/result_error.go
+++ b/objectnode/result_error.go
@@ -88,7 +88,7 @@ var (
 	InvalidRange                        = &ErrorCode{ErrorCode: "InvalidRange", ErrorMessage: "The requested range cannot be satisfied.", StatusCode: http.StatusRequestedRangeNotSatisfiable}
 	MissingContentLength                = &ErrorCode{ErrorCode: "MissingContentLength", ErrorMessage: "You must provide the Content-Length HTTP header.", StatusCode: http.StatusLengthRequired}
 	NoSuchBucket                        = &ErrorCode{ErrorCode: "NoSuchBucket", ErrorMessage: "The specified bucket does not exist.", StatusCode: http.StatusNotFound}
-	NoSuchKey                           = &ErrorCode{ErrorCode: "NoLoggingStatusForKey", ErrorMessage: "The specified key does not exist.", StatusCode: http.StatusNotFound}
+	NoSuchKey                           = &ErrorCode{ErrorCode: "NoSuchKey", ErrorMessage: "The specified key does not exist.", StatusCode: http.StatusNotFound}
 	PreconditionFailed                  = &ErrorCode{ErrorCode: "PreconditionFailed", ErrorMessage: "At least one of the preconditions you specified did not hold.", StatusCode: http.StatusPreconditionFailed}
 	MaxContentLength                    = &ErrorCode{ErrorCode: "MaxContentLength", ErrorMessage: "Content-Length is bigger than 20KB.", StatusCode: http.StatusLengthRequired}
 	DuplicatedBucket                    = &ErrorCode{ErrorCode: "CreateBucketFailed", ErrorMessage: "Duplicate bucket name.", StatusCode: http.StatusBadRequest}
@@ -97,9 +97,12 @@ var (
 	NoSuchUpload                        = &ErrorCode{ErrorCode: "NoSuchUpload", ErrorMessage: "The specified upload does not exist.", StatusCode: http.StatusNotFound}
 	OverMaxRecordSize                   = &ErrorCode{ErrorCode: "OverMaxRecordSize", ErrorMessage: "The length of a record in the input or result is greater than maxCharsPerRecord of 1 MB.", StatusCode: http.StatusBadRequest}
 	CopySourceSizeTooLarge              = &ErrorCode{ErrorCode: "InvalidRequest", ErrorMessage: "The specified copy source is larger than the maximum allowable size for a copy source: 5368709120", StatusCode: http.StatusBadRequest}
-	InvalidPartOrder					          = &ErrorCode{ErrorCode: "InvalidPartOrder", ErrorMessage: "The list of parts was not in ascending order. Parts list must be specified in order by part number.", StatusCode: http.StatusBadRequest}
-	InvalidPart							            = &ErrorCode{ErrorCode: "InvalidPart", ErrorMessage: "One or more of the specified parts could not be found. The part might not have been uploaded, or the specified entity tag might not have matched the part's entity tag.", StatusCode: http.StatusBadRequest}
+	InvalidPartOrder                    = &ErrorCode{ErrorCode: "InvalidPartOrder", ErrorMessage: "The list of parts was not in ascending order. Parts list must be specified in order by part number.", StatusCode: http.StatusBadRequest}
+	InvalidPart                         = &ErrorCode{ErrorCode: "InvalidPart", ErrorMessage: "One or more of the specified parts could not be found. The part might not have been uploaded, or the specified entity tag might not have matched the part's entity tag.", StatusCode: http.StatusBadRequest}
 	InvalidCacheArgument                = &ErrorCode{ErrorCode: "InvalidCacheArgument", ErrorMessage: "Invalid Cache-Control or Expires Argument", StatusCode: http.StatusBadRequest}
+	TagsGreaterThen10                   = &ErrorCode{ErrorCode: "BadRequest", ErrorMessage: "Object tags cannot be greater than 10", StatusCode: http.StatusBadRequest}
+	InvalidTagKey                       = &ErrorCode{ErrorCode: "InvalidTag", ErrorMessage: "The TagKey you have provided is invalid", StatusCode: http.StatusBadRequest}
+	InvalidTagValue                     = &ErrorCode{ErrorCode: "InvalidTag", ErrorMessage: "The TagValue you have provided is invalid", StatusCode: http.StatusBadRequest}
 )
 
 func HttpStatusErrorCode(code int) *ErrorCode {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix:
1. No limit to the number of object tagging and bucket tagging.
2. Return an empty tagging when bucket has no tagging.
3. getObject Api has no tagging numbers in header when object has one or more tags.
4. setObjectTagging return success when object not exist. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
