### PR TITLE
fix: lack of break

### DIFF
--- a/sdk/data/stream/stream_writer.go
+++ b/sdk/data/stream/stream_writer.go
@@ -265,6 +265,7 @@ func (s *Streamer) write(data []byte, offset, size int, direct bool) (total int,
 	requests := s.extents.PrepareWriteRequests(offset, size, data)
 	log.LogDebugf("Streamer write: ino(%v) prepared requests(%v)", s.inode, requests)
 
+	// Must flush before doing overwrite
 	for _, req := range requests {
 		if req.ExtentKey == nil {
 			continue
@@ -275,6 +276,7 @@ func (s *Streamer) write(data []byte, offset, size int, direct bool) (total int,
 		}
 		requests = s.extents.PrepareWriteRequests(offset, size, data)
 		log.LogDebugf("Streamer write: ino(%v) prepared requests after flush(%v)", s.inode, requests)
+		break
 	}
 
 	for _, req := range requests {


### PR DESCRIPTION
Break the loop if PrepareWriteRequests is invoked again, or it will
result in unnecessary loops and invocations.

Signed-off-by: Shuoran Liu <shuoranliu@gmail.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
