### PR TITLE
fsck: introduce fsck

### DIFF
--- a/fsck/cmd/check.go
+++ b/fsck/cmd/check.go
@@ -1,0 +1,383 @@
+// Copyright 2020 The Chubao Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/chubaofs/chubaofs/proto"
+)
+
+const (
+	InodeCheckOpt int = 1 << iota
+	DentryCheckOpt
+)
+
+func newCheckCmd() *cobra.Command {
+	var c = &cobra.Command{
+		Use:   "check",
+		Short: "check and verify specified volume",
+		Args:  cobra.MinimumNArgs(0),
+	}
+
+	c.AddCommand(
+		newCheckInodeCmd(),
+		newCheckDentryCmd(),
+		newCheckBothCmd(),
+	)
+
+	return c
+}
+
+func newCheckInodeCmd() *cobra.Command {
+	var c = &cobra.Command{
+		Use:   "inode",
+		Short: "check and verify inode",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := Check(InodeCheckOpt); err != nil {
+				fmt.Println(err)
+			}
+		},
+	}
+
+	return c
+}
+
+func newCheckDentryCmd() *cobra.Command {
+	var c = &cobra.Command{
+		Use:   "dentry",
+		Short: "check and verify dentry",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := Check(DentryCheckOpt); err != nil {
+				fmt.Println(err)
+			}
+		},
+	}
+
+	return c
+}
+
+func newCheckBothCmd() *cobra.Command {
+	var c = &cobra.Command{
+		Use:   "both",
+		Short: "check and verify both inode and dentry",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := Check(InodeCheckOpt | DentryCheckOpt); err != nil {
+				fmt.Println(err)
+			}
+		},
+	}
+
+	return c
+}
+
+func Check(chkopt int) (err error) {
+	var remote bool
+
+	if InodesFile == "" || DensFile == "" {
+		remote = true
+	}
+
+	if VolName == "" || (remote && (MasterAddr == "")) {
+		err = fmt.Errorf("Lack of mandatory args: master(%v) vol(%v)", MasterAddr, VolName)
+		return
+	}
+
+	/*
+	 * Record all the inodes and dentries retrieved from metanode
+	 */
+	var (
+		ifile *os.File
+		dfile *os.File
+	)
+
+	dirPath := fmt.Sprintf("_export_%s", VolName)
+	if err = os.MkdirAll(dirPath, 0666); err != nil {
+		return
+	}
+
+	if remote {
+		if ifile, err = os.Create(fmt.Sprintf("%s/%s", dirPath, inodeDumpFileName)); err != nil {
+			return
+		}
+		defer ifile.Close()
+		if dfile, err = os.Create(fmt.Sprintf("%s/%s", dirPath, dentryDumpFileName)); err != nil {
+			return
+		}
+		defer dfile.Close()
+		if err = importRawDataFromRemote(ifile, dfile, chkopt); err != nil {
+			return
+		}
+		// go back to the beginning of the files
+		ifile.Seek(0, 0)
+		dfile.Seek(0, 0)
+	} else {
+		if ifile, err = os.Open(InodesFile); err != nil {
+			return
+		}
+		defer ifile.Close()
+		if dfile, err = os.Open(DensFile); err != nil {
+			return
+		}
+		defer dfile.Close()
+	}
+
+	/*
+	 * Perform analysis
+	 */
+	imap, dlist, err := analyze(ifile, dfile)
+	if err != nil {
+		return
+	}
+
+	if chkopt&InodeCheckOpt != 0 {
+		if err = dumpObsoleteInode(imap, fmt.Sprintf("%s/%s", dirPath, obsoleteInodeDumpFileName)); err != nil {
+			return
+		}
+	}
+	if chkopt&DentryCheckOpt != 0 {
+		if err = dumpObsoleteDentry(dlist, fmt.Sprintf("%s/%s", dirPath, obsoleteDentryDumpFileName)); err != nil {
+			return
+		}
+	}
+	return
+}
+
+func importRawDataFromRemote(ifile, dfile *os.File, opt int) error {
+	/*
+	 * Get all the meta partitions info
+	 */
+	mps, err := getMetaPartitions(MasterAddr, VolName)
+	if err != nil {
+		return err
+	}
+
+	/*
+	 * Note that if we are about to clean obsolete inodes,
+	 * we should get all inodes before geting all dentries.
+	 */
+	if opt&InodeCheckOpt != 0 {
+		for _, mp := range mps {
+			cmdline := fmt.Sprintf("http://%s:9092/getAllInodes?pid=%d", strings.Split(mp.LeaderAddr, ":")[0], mp.PartitionID)
+			if err := exportToFile(ifile, cmdline); err != nil {
+				return err
+			}
+		}
+
+		for _, mp := range mps {
+			cmdline := fmt.Sprintf("http://%s:9092/getAllDentry?pid=%d", strings.Split(mp.LeaderAddr, ":")[0], mp.PartitionID)
+			if err = exportToFile(dfile, cmdline); err != nil {
+				return err
+			}
+		}
+	} else if opt&DentryCheckOpt != 0 {
+		for _, mp := range mps {
+			cmdline := fmt.Sprintf("http://%s:9092/getAllDentry?pid=%d", strings.Split(mp.LeaderAddr, ":")[0], mp.PartitionID)
+			if err = exportToFile(dfile, cmdline); err != nil {
+				return err
+			}
+		}
+
+		for _, mp := range mps {
+			cmdline := fmt.Sprintf("http://%s:9092/getAllInodes?pid=%d", strings.Split(mp.LeaderAddr, ":")[0], mp.PartitionID)
+			if err := exportToFile(ifile, cmdline); err != nil {
+				return err
+			}
+		}
+	} else {
+		return fmt.Errorf("Invalid opt: %v", opt)
+	}
+	return nil
+}
+
+func analyze(ifile, dfile *os.File) (imap map[uint64]*Inode, dlist []*Dentry, err error) {
+	imap = make(map[uint64]*Inode)
+	dlist = make([]*Dentry, 0)
+
+	/*
+	 * Walk through all the inodes to establish inode index
+	 */
+	dec := json.NewDecoder(ifile)
+	for dec.More() {
+		inode := &Inode{Dens: make([]*Dentry, 0)}
+		if err = dec.Decode(inode); err != nil {
+			fmt.Printf("Unmarshal inode failed: %v", err)
+			return
+		}
+		imap[inode.Inode] = inode
+	}
+
+	/*
+	 * Walk through all the dentries to establish inode relations.
+	 */
+	dec = json.NewDecoder(dfile)
+	for dec.More() {
+		body := &struct {
+			Code int32     `json:"code"`
+			Msg  string    `json:"msg"`
+			Data []*Dentry `json:"data"`
+		}{}
+
+		if err = dec.Decode(body); err != nil {
+			err = fmt.Errorf("Decode failed: %v", err)
+			return
+		}
+
+		for _, den := range body.Data {
+			inode, ok := imap[den.ParentId]
+			if !ok {
+				dlist = append(dlist, den)
+			} else {
+				inode.Dens = append(inode.Dens, den)
+			}
+		}
+	}
+
+	root, ok := imap[1]
+	if !ok {
+		err = fmt.Errorf("No root inode")
+		return
+	}
+
+	/*
+	 * Iterate all the path, and mark reachable inode and dentry.
+	 */
+	followPath(imap, root)
+	return
+}
+
+func followPath(imap map[uint64]*Inode, inode *Inode) {
+	inode.Valid = true
+	// there is no down path for file inode
+	if inode.Type == 0 || len(inode.Dens) == 0 {
+		return
+	}
+
+	for _, den := range inode.Dens {
+		childInode, ok := imap[den.Inode]
+		if !ok {
+			continue
+		}
+		den.Valid = true
+		followPath(imap, childInode)
+	}
+}
+
+func dumpObsoleteInode(imap map[uint64]*Inode, name string) error {
+	var (
+		obsoleteTotalFileSize uint64
+		totalFileSize         uint64
+		safeCleanSize         uint64
+	)
+
+	fp, err := os.Create(name)
+	if err != nil {
+		return err
+	}
+	defer fp.Close()
+
+	for _, inode := range imap {
+		if !inode.Valid {
+			if _, err = fp.WriteString(inode.String() + "\n"); err != nil {
+				return err
+			}
+			obsoleteTotalFileSize += inode.Size
+			if inode.NLink == 0 {
+				safeCleanSize += inode.Size
+			}
+		}
+		totalFileSize += inode.Size
+	}
+
+	fmt.Printf("Total File Size: %v\nObselete Total File Size: %v\nNLink Zero Total File Size: %v\n", totalFileSize, obsoleteTotalFileSize, safeCleanSize)
+	return nil
+}
+
+func dumpObsoleteDentry(dlist []*Dentry, name string) error {
+	/*
+	 * Note: if we get all the inodes raw data first, then obsolete
+	 * dentries are not trustable.
+	 */
+	fp, err := os.Create(name)
+	if err != nil {
+		return err
+	}
+	defer fp.Close()
+
+	for _, den := range dlist {
+		if _, err = fp.WriteString(den.String() + "\n"); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func getMetaPartitions(addr, name string) ([]*proto.MetaPartitionView, error) {
+	resp, err := http.Get(fmt.Sprintf("http://%s%s?name=%s", addr, proto.ClientMetaPartitions, name))
+	if err != nil {
+		return nil, fmt.Errorf("Get meta partitions failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("Invalid status code: %v", resp.StatusCode)
+	}
+
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("Get meta partitions read all body failed: %v", err)
+	}
+
+	body := &struct {
+		Code int32           `json:"code"`
+		Msg  string          `json:"msg"`
+		Data json.RawMessage `json:"data"`
+	}{}
+	if err = json.Unmarshal(data, body); err != nil {
+		return nil, fmt.Errorf("Unmarshal meta partitions body failed: %v", err)
+	}
+
+	var mps []*proto.MetaPartitionView
+	if err = json.Unmarshal(body.Data, &mps); err != nil {
+		return nil, fmt.Errorf("Unmarshal meta partitions view failed: %v", err)
+	}
+	return mps, nil
+}
+
+func exportToFile(fp *os.File, cmdline string) error {
+	resp, err := http.Get(cmdline)
+	if err != nil {
+		return fmt.Errorf("Get request failed: %v %v", cmdline, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("Invalid status code: %v", resp.StatusCode)
+	}
+
+	if _, err = io.Copy(fp, resp.Body); err != nil {
+		return fmt.Errorf("io Copy failed: %v", err)
+	}
+	_, err = fp.WriteString("\n")
+	return err
+}

--- a/fsck/cmd/clean.go
+++ b/fsck/cmd/clean.go
@@ -1,0 +1,258 @@
+// Copyright 2020 The Chubao Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/chubaofs/chubaofs/proto"
+	"github.com/chubaofs/chubaofs/sdk/meta"
+	"github.com/chubaofs/chubaofs/util/log"
+	"github.com/chubaofs/chubaofs/util/ump"
+)
+
+var gMetaWrapper *meta.MetaWrapper
+
+func newCleanCmd() *cobra.Command {
+	var c = &cobra.Command{
+		Use:   "clean",
+		Short: "clean dirty inode or dentry according to some rules",
+		Args:  cobra.MinimumNArgs(0),
+	}
+
+	c.AddCommand(
+		newCleanInodeCmd(),
+		newCleanDentryCmd(),
+		newEvictInodeCmd(),
+	)
+
+	return c
+}
+
+func newCleanInodeCmd() *cobra.Command {
+	var c = &cobra.Command{
+		Use:   "inode",
+		Short: "clean dirty inode",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := Clean("inode"); err != nil {
+				fmt.Println(err)
+			}
+		},
+	}
+
+	return c
+}
+
+func newCleanDentryCmd() *cobra.Command {
+	var c = &cobra.Command{
+		Use:   "dentry",
+		Short: "clean dirty dentry",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := Clean("dentry"); err != nil {
+				fmt.Println(err)
+			}
+		},
+	}
+
+	return c
+}
+
+func newEvictInodeCmd() *cobra.Command {
+	var c = &cobra.Command{
+		Use:   "evict",
+		Short: "clean dirty dentry",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := Clean("evict"); err != nil {
+				fmt.Println(err)
+			}
+		},
+	}
+
+	return c
+}
+
+func Clean(opt string) error {
+	defer log.LogFlush()
+
+	if MasterAddr == "" || VolName == "" {
+		return fmt.Errorf("Lack of parameters: master(%v) vol(%v)", MasterAddr, VolName)
+	}
+
+	ump.InitUmp("fsck", "")
+
+	_, err := log.InitLog("fscklog", "fsck", log.InfoLevel, nil)
+	if err != nil {
+		return fmt.Errorf("Init log failed: %v", err)
+	}
+
+	masters := strings.Split(MasterAddr, meta.HostsSeparator)
+	var metaConfig = &meta.MetaConfig{
+		Volume:  VolName,
+		Masters: masters,
+	}
+
+	gMetaWrapper, err = meta.NewMetaWrapper(metaConfig)
+	if err != nil {
+		return fmt.Errorf("NewMetaWrapper failed: %v", err)
+	}
+
+	switch opt {
+	case "inode":
+		err = cleanInodes()
+		if err != nil {
+			return fmt.Errorf("Clean inodes failed: %v", err)
+		}
+	case "dentry":
+		err = cleanDentries()
+		if err != nil {
+			return fmt.Errorf("Clean dentries failed: %v", err)
+		}
+	case "evict":
+		err = evictInodes()
+		if err != nil {
+			return fmt.Errorf("Evict inodes failed: %v", err)
+		}
+	default:
+	}
+
+	return nil
+}
+
+func evictInodes() error {
+	mps, err := getMetaPartitions(MasterAddr, VolName)
+	if err != nil {
+		return err
+	}
+
+	wg := sync.WaitGroup{}
+
+	for _, mp := range mps {
+		cmdline := fmt.Sprintf("http://%s:9092/getAllInodes?pid=%d", strings.Split(mp.LeaderAddr, ":")[0], mp.PartitionID)
+		wg.Add(1)
+		go evictOnTime(&wg, cmdline)
+	}
+
+	wg.Wait()
+	return nil
+}
+
+func evictOnTime(wg *sync.WaitGroup, cmdline string) {
+	defer wg.Done()
+
+	client := &http.Client{Timeout: 0}
+	resp, err := client.Get(cmdline)
+	if err != nil {
+		log.LogErrorf("Get request failed: %v %v", cmdline, err)
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		log.LogErrorf("Invalid status code: %v", resp.StatusCode)
+		return
+	}
+
+	log.LogWritef("Dealing with meta partition: %v", cmdline)
+
+	dec := json.NewDecoder(resp.Body)
+	for dec.More() {
+		inode := &Inode{}
+		err = dec.Decode(inode)
+		if err != nil {
+			log.LogErrorf("Decode inode failed: %v", err)
+			return
+		}
+		doEvictInode(inode)
+	}
+	log.LogWritef("Done! Dealing with meta partition: %v", cmdline)
+}
+func cleanInodes() error {
+	filePath := fmt.Sprintf("_export_%s/%s", VolName, obsoleteInodeDumpFileName)
+
+	fp, err := os.Open(filePath)
+	if err != nil {
+		return err
+	}
+
+	dec := json.NewDecoder(fp)
+	for dec.More() {
+		inode := &Inode{}
+		if err = dec.Decode(inode); err != nil {
+			return err
+		}
+		doEvictInode(inode)
+	}
+
+	return nil
+}
+
+func doEvictInode(inode *Inode) error {
+	if inode.NLink != 0 || time.Since(time.Unix(inode.ModifyTime, 0)) < 24*time.Hour || !proto.IsRegular(inode.Type) {
+		return nil
+	}
+	err := gMetaWrapper.Evict(inode.Inode)
+	if err != nil {
+		if err != syscall.ENOENT {
+			return err
+		}
+	}
+	log.LogWritef("%v", inode)
+	return nil
+}
+
+func doUnlinkInode(inode *Inode) error {
+	/*
+	 * Do clean inode with the following exceptions:
+	 * 1. nlink == 0, might be a temorary inode
+	 * 2. size == 0 && ctime is close to current time, might be in the process of file creation
+	 */
+	//	if inode.NLink == 0 ||
+	//		(inode.Size == 0 &&
+	//			time.Unix(inode.CreateTime, 0).Add(24*time.Hour).After(time.Now())) {
+	//		return nil
+	//	}
+	//
+	//	err := gMetaWrapper.Unlink_ll(inode.Inode)
+	//	if err != nil {
+	//		if err != syscall.ENOENT {
+	//			return err
+	//		}
+	//		err = nil
+	//	}
+	//
+	//	err = gMetaWrapper.Evict(inode.Inode)
+	//	if err != nil {
+	//		if err != syscall.ENOENT {
+	//			return err
+	//		}
+	//	}
+
+	return nil
+}
+
+func cleanDentries() error {
+	//filePath := fmt.Sprintf("_export_%s/%s", VolName, obsoleteDentryDumpFileName)
+	// TODO: send request to meta node directly with pino, name and ino.
+	return nil
+}

--- a/fsck/cmd/common.go
+++ b/fsck/cmd/common.go
@@ -1,0 +1,72 @@
+// Copyright 2020 The Chubao Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cmd
+
+import (
+	"encoding/json"
+)
+
+var (
+	MasterAddr string
+	VolName    string
+	InodesFile string
+	DensFile   string
+)
+
+var (
+	inodeDumpFileName          string = "inode.dump"
+	dentryDumpFileName         string = "dentry.dump"
+	inodeUpdateDumpFileName    string = "inode.dump.update"
+	obsoleteInodeDumpFileName  string = "inode.dump.obsolete"
+	obsoleteDentryDumpFileName string = "dentry.dump.obsolete"
+)
+
+type Inode struct {
+	Inode      uint64
+	Type       uint32
+	Size       uint64
+	CreateTime int64
+	AccessTime int64
+	ModifyTime int64
+	NLink      uint32
+
+	Dens  []*Dentry
+	Valid bool
+}
+
+func (i *Inode) String() string {
+	data, err := json.Marshal(i)
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}
+
+type Dentry struct {
+	ParentId uint64
+	Name     string
+	Inode    uint64
+	Type     uint32
+
+	Valid bool
+}
+
+func (d *Dentry) String() string {
+	data, err := json.Marshal(d)
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}

--- a/fsck/cmd/root.go
+++ b/fsck/cmd/root.go
@@ -1,0 +1,41 @@
+// Copyright 2020 The Chubao Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cmd
+
+import (
+	"os"
+	"path"
+
+	"github.com/spf13/cobra"
+)
+
+func NewRootCmd() *cobra.Command {
+	var c = &cobra.Command{
+		Use:   path.Base(os.Args[0]),
+		Short: "ChubaoFS fsck tool",
+		Args:  cobra.MinimumNArgs(0),
+	}
+
+	c.AddCommand(
+		newCheckCmd(),
+		newCleanCmd(),
+	)
+
+	c.Flags().StringVarP(&MasterAddr, "master", "m", "", "master addresses")
+	c.Flags().StringVarP(&VolName, "vol", "v", "", "volume name")
+	c.Flags().StringVarP(&InodesFile, "inode-list", "i", "", "inode list file")
+	c.Flags().StringVarP(&DensFile, "dentry-list", "d", "", "dentry list file")
+	return c
+}

--- a/fsck/main.go
+++ b/fsck/main.go
@@ -1,0 +1,30 @@
+// Copyright 2020 The Chubao Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/chubaofs/chubaofs/fsck/cmd"
+)
+
+func main() {
+	c := cmd.NewRootCmd()
+	if err := c.Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/fsck/usage.md
+++ b/fsck/usage.md
@@ -1,0 +1,8 @@
+### Command examples
+
+```bash
+./fsck check inode -master "<masterAddr>" -vol "<volName>"
+./fsck check dentry -master "<masterAddr>" -vol "<volName>"
+./fsck check both -master "<masterAddr>" -vol "<volName>"
+./fsck check both -vol "<volName>" --inode-list "inodes.txt" --dentry-list "dens.txt"
+```


### PR DESCRIPTION
This tool can scan the specified volume, perform filesystem
consistency checks and dump obsolete inodes and dentries. It can also
deal with dumped inodes and dentry, like evict inodes whose nlink equals
zero.

Signed-off-by: Shuoran Liu <shuoranliu@gmail.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
