### PR TITLE
Refactor: metanode use syncPool unmarshal inode and dentry

### DIFF
--- a/metanode/dentry.go
+++ b/metanode/dentry.go
@@ -81,21 +81,28 @@ func (d *Dentry) Unmarshal(raw []byte) (err error) {
 	if err = binary.Read(buff, binary.BigEndian, &keyLen); err != nil {
 		return
 	}
-	keyBytes := make([]byte, keyLen)
+	orgData := GetCommonUnmarshalData(int(keyLen))
+	keyBytes := orgData[0:keyLen]
 	if _, err = buff.Read(keyBytes); err != nil {
 		return
 	}
 	if err = d.UnmarshalKey(keyBytes); err != nil {
 		return
 	}
+	PutCommonUnmarshalData(orgData)
+
 	if err = binary.Read(buff, binary.BigEndian, &valLen); err != nil {
 		return
 	}
-	valBytes := make([]byte, valLen)
+
+	orgData = GetCommonUnmarshalData(int(valLen))
+	valBytes := orgData[0:valLen]
 	if _, err = buff.Read(valBytes); err != nil {
 		return
 	}
 	err = d.UnmarshalValue(valBytes)
+	PutCommonUnmarshalData(orgData)
+
 	return
 }
 

--- a/metanode/dentry_mashal_buff.go
+++ b/metanode/dentry_mashal_buff.go
@@ -1,0 +1,53 @@
+package metanode
+
+import (
+	"bytes"
+	"encoding/binary"
+)
+
+// MarshalKey is the bytes version of the MarshalKey method which returns the byte slice result.
+func (d *Dentry) MarshalKeyWithBuff(data []byte) (keyLen uint32) {
+	buff := bytes.NewBuffer(data)
+	if err := binary.Write(buff, binary.BigEndian, &d.ParentId); err != nil {
+		panic(err)
+	}
+	buff.Write([]byte(d.Name))
+	keyLen = uint32(buff.Len())
+	return
+}
+
+// MarshalValue marshals the exporterKey to bytes.
+func (d *Dentry) MarshalValueWithBuff(data []byte) (vLen uint32) {
+	buff := bytes.NewBuffer(data)
+	if err := binary.Write(buff, binary.BigEndian, &d.Inode); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(buff, binary.BigEndian, &d.Type); err != nil {
+		panic(err)
+	}
+	vLen = uint32(buff.Len())
+	return
+}
+
+// Marshal marshals a dentry into a byte array.
+func (d *Dentry) MarshalWithBuff(orgData []byte) (result []byte, err error) {
+	result = orgData
+	//write keyInfo to result[4:]
+	keyLen := d.MarshalKeyWithBuff(result[4:])
+	//write KeyInfoLen to result[0:4]
+	binary.BigEndian.PutUint32(result[0:4], keyLen)
+
+	//keyEndOffset:=keyLen+4
+	keyEnd := keyLen + 4
+
+	///valStart skip 4 byte start Write
+	valStart := keyEnd + 4
+
+	//write valueInfo to result
+	valLen := d.MarshalValueWithBuff(result[valStart:])
+
+	//write valLen to keyEnd:valStart
+	binary.BigEndian.PutUint32(result[keyEnd:valStart], valLen)
+	result = result[0 : valStart+valLen]
+	return
+}

--- a/metanode/free_list.go
+++ b/metanode/free_list.go
@@ -65,8 +65,7 @@ func (fl *freeList) Remove(ino uint64) {
 	}
 }
 
-
-func (fl *freeList)Len() int {
+func (fl *freeList) Len() int {
 	fl.Lock()
 	defer fl.Unlock()
 	return len(fl.index)

--- a/metanode/inode.go
+++ b/metanode/inode.go
@@ -183,21 +183,26 @@ func (i *Inode) Unmarshal(raw []byte) (err error) {
 	if err = binary.Read(buff, binary.BigEndian, &keyLen); err != nil {
 		return
 	}
-	keyBytes := make([]byte, keyLen)
+	orgData := GetCommonUnmarshalData(int(keyLen))
+	keyBytes := orgData[0:keyLen]
 	if _, err = buff.Read(keyBytes); err != nil {
 		return
 	}
 	if err = i.UnmarshalKey(keyBytes); err != nil {
 		return
 	}
+	PutCommonUnmarshalData(orgData)
+
 	if err = binary.Read(buff, binary.BigEndian, &valLen); err != nil {
 		return
 	}
-	valBytes := make([]byte, valLen)
+	orgData = GetCommonUnmarshalData(int(valLen))
+	valBytes := orgData[0:valLen]
 	if _, err = buff.Read(valBytes); err != nil {
 		return
 	}
 	err = i.UnmarshalValue(valBytes)
+	PutCommonUnmarshalData(orgData)
 	return
 }
 

--- a/metanode/inode_mashal_buff.go
+++ b/metanode/inode_mashal_buff.go
@@ -1,0 +1,109 @@
+package metanode
+
+import (
+	"bytes"
+	"encoding/binary"
+)
+
+const (
+	InodeNumSize = 8
+)
+
+// Marshal marshals the inode into a byte array.
+func (i *Inode) MarshalWithBuffer(orgData []byte) (result []byte, err error) {
+	result = orgData
+	keyLen, err := i.MarshalKeyWithBuff(result)
+	if err != nil {
+		return
+	}
+	valueStart := keyLen + 4
+	valueLen := i.MarshalValueWithBuffer(result[valueStart:])
+	binary.BigEndian.PutUint32(result[keyLen:valueStart], valueLen)
+	valueEnd := valueLen + uint32(valueStart)
+	result = result[0:valueEnd]
+	return
+}
+
+func (i *Inode) MarshalKeyWithBuff(data []byte) (keyLen uint32, err error) {
+	// inode is uint64,first write Key
+	buff := bytes.NewBuffer(data)
+	if err = binary.Write(buff, binary.BigEndian, uint32(InodeNumSize)); err != nil {
+		return
+	}
+	if err = binary.Write(buff, binary.BigEndian, i.Inode); err != nil {
+		return
+	}
+	keyLen = uint32(buff.Len())
+	return
+}
+
+// MarshalValue marshals the value to bytes.
+func (i *Inode) MarshalValueWithBuffer(data []byte) (vLen uint32) {
+	var err error
+	buff := bytes.NewBuffer(data)
+	i.RLock()
+	if err = binary.Write(buff, binary.BigEndian, &i.Type); err != nil {
+		panic(err)
+	}
+	if err = binary.Write(buff, binary.BigEndian, &i.Uid); err != nil {
+		panic(err)
+	}
+	if err = binary.Write(buff, binary.BigEndian, &i.Gid); err != nil {
+		panic(err)
+	}
+	if err = binary.Write(buff, binary.BigEndian, &i.Size); err != nil {
+		panic(err)
+	}
+	if err = binary.Write(buff, binary.BigEndian, &i.Generation); err != nil {
+		panic(err)
+	}
+	if err = binary.Write(buff, binary.BigEndian, &i.CreateTime); err != nil {
+		panic(err)
+	}
+	if err = binary.Write(buff, binary.BigEndian, &i.AccessTime); err != nil {
+		panic(err)
+	}
+	if err = binary.Write(buff, binary.BigEndian, &i.ModifyTime); err != nil {
+		panic(err)
+	}
+	// write SymLink
+	symSize := uint32(len(i.LinkTarget))
+	if err = binary.Write(buff, binary.BigEndian, &symSize); err != nil {
+		panic(err)
+	}
+	if _, err = buff.Write(i.LinkTarget); err != nil {
+		panic(err)
+	}
+
+	if err = binary.Write(buff, binary.BigEndian, &i.NLink); err != nil {
+		panic(err)
+	}
+	if err = binary.Write(buff, binary.BigEndian, &i.Flag); err != nil {
+		panic(err)
+	}
+	if err = binary.Write(buff, binary.BigEndian, &i.Reserved); err != nil {
+		panic(err)
+	}
+	// marshal ExtentsKey
+	err = i.Extents.MarshalBinaryWithBuffer(buff)
+	if err != nil {
+		panic(err)
+	}
+
+	i.RUnlock()
+	vLen = uint32(buff.Len())
+	return
+}
+
+func (se *SortedExtents) MarshalBinaryWithBuffer(buff *bytes.Buffer) (err error) {
+	se.RLock()
+	defer se.RUnlock()
+
+	for _, ek := range se.eks {
+		err := ek.MarshalBinaryWithBuffer(buff)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/metanode/partition_fsmop.go
+++ b/metanode/partition_fsmop.go
@@ -228,23 +228,21 @@ func (mp *metaPartition) CanRemoveRaftMember(peer proto.Peer) error {
 	return fmt.Errorf("downReplicas(%v) too much,so donnot offline (%v)", downReplicas, peer)
 }
 
-
-
-func (mp *metaPartition)IsEquareCreateMetaPartitionRequst(request *proto.CreateMetaPartitionRequest) (err error){
-	if len(mp.config.Peers)!=len(request.Members){
-		return fmt.Errorf("Exsit unavali Partition(%v) partitionHosts(%v) requestHosts(%v)", mp.config.PartitionId, mp.config.Peers,request.Members)
+func (mp *metaPartition) IsEquareCreateMetaPartitionRequst(request *proto.CreateMetaPartitionRequest) (err error) {
+	if len(mp.config.Peers) != len(request.Members) {
+		return fmt.Errorf("Exsit unavali Partition(%v) partitionHosts(%v) requestHosts(%v)", mp.config.PartitionId, mp.config.Peers, request.Members)
 	}
-	if mp.config.Start!=request.Start || mp.config.End!=request.End {
-		return fmt.Errorf("Exsit unavali Partition(%v) range(%v-%v) requestRange(%v-%v)", mp.config.PartitionId, mp.config.Start,mp.config.End,request.Start,request.End)
+	if mp.config.Start != request.Start || mp.config.End != request.End {
+		return fmt.Errorf("Exsit unavali Partition(%v) range(%v-%v) requestRange(%v-%v)", mp.config.PartitionId, mp.config.Start, mp.config.End, request.Start, request.End)
 	}
-	for index,peer:=range mp.config.Peers {
-		requestPeer:=request.Members[index]
-		if requestPeer.ID!=peer.ID || requestPeer.Addr!=peer.Addr{
-			return fmt.Errorf("Exsit unavali Partition(%v) partitionHosts(%v) requestHosts(%v)", mp.config.PartitionId, mp.config.Peers,request.Members)
+	for index, peer := range mp.config.Peers {
+		requestPeer := request.Members[index]
+		if requestPeer.ID != peer.ID || requestPeer.Addr != peer.Addr {
+			return fmt.Errorf("Exsit unavali Partition(%v) partitionHosts(%v) requestHosts(%v)", mp.config.PartitionId, mp.config.Peers, request.Members)
 		}
 	}
-	if mp.config.VolName!=request.VolName {
-		return fmt.Errorf("Exsit unavali Partition(%v) VolName(%v) requestVolName(%v)", mp.config.PartitionId, mp.config.VolName,request.VolName)
+	if mp.config.VolName != request.VolName {
+		return fmt.Errorf("Exsit unavali Partition(%v) VolName(%v) requestVolName(%v)", mp.config.PartitionId, mp.config.VolName, request.VolName)
 	}
 
 	return

--- a/metanode/partition_op_multipart.go
+++ b/metanode/partition_op_multipart.go
@@ -63,7 +63,7 @@ func (mp *metaPartition) AppendMultipart(req *proto.AddMultipartPartRequest, p *
 		p.PacketOkReply()
 		return
 	}
-	item := mp.multipartTree.Get(&Multipart{key:req.Path, id: req.MultipartId})
+	item := mp.multipartTree.Get(&Multipart{key: req.Path, id: req.MultipartId})
 	if item == nil {
 		p.PacketErrorWithBody(proto.OpNotExistErr, nil)
 		return

--- a/metanode/partition_store.go
+++ b/metanode/partition_store.go
@@ -406,7 +406,8 @@ func (mp *metaPartition) storeInode(rootDir string,
 	sign := crc32.NewIEEE()
 	sm.inodeTree.Ascend(func(i BtreeItem) bool {
 		ino := i.(*Inode)
-		if data, err = ino.Marshal(); err != nil {
+		orgData := GetCommonUnmarshalData(3)
+		if data, err = ino.MarshalWithBuffer(orgData); err != nil {
 			return false
 		}
 		// set length
@@ -424,6 +425,8 @@ func (mp *metaPartition) storeInode(rootDir string,
 		if _, err = sign.Write(data); err != nil {
 			return false
 		}
+		PutCommonUnmarshalData(orgData)
+
 		return true
 	})
 	crc = sign.Sum32()
@@ -450,7 +453,8 @@ func (mp *metaPartition) storeDentry(rootDir string,
 	sign := crc32.NewIEEE()
 	sm.dentryTree.Ascend(func(i BtreeItem) bool {
 		dentry := i.(*Dentry)
-		data, err = dentry.Marshal()
+		orgData := GetCommonUnmarshalData(3)
+		data, err = dentry.MarshalWithBuff(orgData)
 		if err != nil {
 			return false
 		}
@@ -468,6 +472,7 @@ func (mp *metaPartition) storeDentry(rootDir string,
 		if _, err = sign.Write(data); err != nil {
 			return false
 		}
+		PutCommonUnmarshalData(orgData)
 		return true
 	})
 	crc = sign.Sum32()

--- a/metanode/raft_server.go
+++ b/metanode/raft_server.go
@@ -40,7 +40,7 @@ func (m *MetaNode) startRaftServer() (err error) {
 		IPAddr:            m.localAddr,
 		HeartbeatPort:     heartbeatPort,
 		ReplicaPort:       replicaPort,
-		NumOfLogsToRetain: raftstore.DefaultNumOfLogsToRetain*2,
+		NumOfLogsToRetain: raftstore.DefaultNumOfLogsToRetain * 2,
 	}
 	m.raftStore, err = raftstore.NewRaftStore(raftConf)
 	if err != nil {

--- a/metanode/unmarshal_pool.go
+++ b/metanode/unmarshal_pool.go
@@ -1,0 +1,48 @@
+package metanode
+
+import "sync"
+
+const (
+	MaxCommonUnmarshalSize = 1024
+	storeUnmarshalLength   = 4
+)
+
+var (
+	commonUnmarshalPool = &sync.Pool{
+		New: func() interface{} {
+			return make([]byte, MaxCommonUnmarshalSize)
+		},
+	}
+	storeUnmarshalLengthPool = &sync.Pool{
+		New: func() interface{} {
+			return make([]byte, storeUnmarshalLength)
+		},
+	}
+)
+
+func GetCommonUnmarshalData(inoUnmarshalSize int) (data []byte) {
+	if inoUnmarshalSize <= MaxCommonUnmarshalSize {
+		data = commonUnmarshalPool.Get().([]byte)
+	} else {
+		data = make([]byte, inoUnmarshalSize)
+	}
+	return
+}
+
+func PutCommonUnmarshalData(data []byte) {
+	if len(data) == MaxCommonUnmarshalSize {
+		commonUnmarshalPool.Put(data)
+	}
+	return
+}
+
+func GetStoreUnmarshalLengthData() (data []byte) {
+	return storeUnmarshalLengthPool.Get().([]byte)
+}
+
+func PutStoreUnmarshalLengthData(data []byte) {
+	if len(data) == storeUnmarshalLength {
+		storeUnmarshalLengthPool.Put(data)
+	}
+	return
+}

--- a/proto/extent_key.go
+++ b/proto/extent_key.go
@@ -82,6 +82,29 @@ func (k *ExtentKey) MarshalBinary() ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
+// MarshalBinary marshals the binary format of the extent key.
+func (k *ExtentKey) MarshalBinaryWithBuffer( buf *bytes.Buffer) (err  error) {
+	if err := binary.Write(buf, binary.BigEndian, k.FileOffset); err != nil {
+		return err
+	}
+	if err := binary.Write(buf, binary.BigEndian, k.PartitionId); err != nil {
+		return  err
+	}
+	if err := binary.Write(buf, binary.BigEndian, k.ExtentId); err != nil {
+		return err
+	}
+	if err := binary.Write(buf, binary.BigEndian, k.ExtentOffset); err != nil {
+		return  err
+	}
+	if err := binary.Write(buf, binary.BigEndian, k.Size); err != nil {
+		return  err
+	}
+	if err := binary.Write(buf, binary.BigEndian, k.CRC); err != nil {
+		return err
+	}
+	return  nil
+}
+
 // UnmarshalBinary unmarshals the binary format of the extent key.
 func (k *ExtentKey) UnmarshalBinary(buf *bytes.Buffer) (err error) {
 	if err = binary.Read(buf, binary.BigEndian, &k.FileOffset); err != nil {


### PR DESCRIPTION
Signed-off-by: awzhgw <guowl18702995996@gmail.com>

<!-- Thanks for sending a pull request! -->
Refactor: metanode use syncPool unmarshal inode and dentry


**What this PR does / why we need it**:

Refactor: metanode use syncPool unmarshal inode and dentry

it can optimize metanode gc
