### PR TITLE
Enhancement: unified version information

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -6,10 +6,14 @@ BuildOutPath=${BuildPath}/out
 BuildBinPath=${BuildPath}/bin
 VendorPath=${RootPath}/vendor
 
+Version=$(git describe --abbrev=0)
 BranchName=$(git rev-parse --abbrev-ref HEAD)
 CommitID=$(git rev-parse HEAD)
 BuildTime=$(date +%Y-%m-%d\ %H:%M)
-LDFlags="-X main.CommitID=${CommitID} -X main.BranchName=${BranchName} -X 'main.BuildTime=${BuildTime}'"
+LDFlags="-X github.com/chubaofs/chubaofs/proto.Version=${Version} \
+-X github.com/chubaofs/chubaofs/proto.CommitID=${CommitID} \
+-X github.com/chubaofs/chubaofs/proto.BranchName=${BranchName} \
+-X 'github.com/chubaofs/chubaofs/proto.BuildTime=${BuildTime}'"
 MODFLAGS=""
 
 NPROC=$(nproc 2>/dev/null)

--- a/cli/build.sh
+++ b/cli/build.sh
@@ -1,8 +1,14 @@
 #!/usr/bin/env bash
+Version=`git describe --abbrev=0`
 BranchName=`git rev-parse --abbrev-ref HEAD`
 CommitID=`git rev-parse HEAD`
 BuildTime=`date +%Y-%m-%d\ %H:%M`
 
 [[ "-$GOPATH" == "-" ]] && { echo "GOPATH not set"; exit 1; }
 
-go build -ldflags "-X main.CommitID=${CommitID} -X main.BranchName=${BranchName} -X 'main.BuildTime=${BuildTime}'" -o cfs-cli
+go build -ldflags "\
+-X github.com/chubaofs/chubaofs/proto.Version=${Version} \
+-X github.com/chubaofs/chubaofs/proto.CommitID=${CommitID} \
+-X github.com/chubaofs/chubaofs/proto.BranchName=${BranchName} \
+-X 'github.com/chubaofs/chubaofs/proto.BuildTime=${BuildTime}'" \
+-o cfs-cli

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -19,6 +19,8 @@ import (
 	"os"
 	"path"
 
+	"github.com/chubaofs/chubaofs/proto"
+
 	"github.com/chubaofs/chubaofs/sdk/master"
 	"github.com/spf13/cobra"
 )
@@ -32,13 +34,22 @@ type ChubaoFSCmd struct {
 }
 
 func NewRootCmd(client *master.MasterClient) *ChubaoFSCmd {
+	var optShowVersion bool
 	var cmd = &ChubaoFSCmd{
 		CFSCmd: &cobra.Command{
 			Use:   path.Base(os.Args[0]),
 			Short: cmdRootShort,
 			Args:  cobra.MinimumNArgs(0),
+			Run: func(cmd *cobra.Command, args []string) {
+				if optShowVersion {
+					stdout(proto.DumpVersion("CLI"))
+					return
+				}
+			},
 		},
 	}
+
+	cmd.CFSCmd.Flags().BoolVarP(&optShowVersion, "version", "v", false, "Show version information")
 
 	cmd.CFSCmd.AddCommand(
 		cmd.newClusterCmd(client),

--- a/client/build.sh
+++ b/client/build.sh
@@ -1,8 +1,14 @@
 #!/usr/bin/env bash
+Version=`git describe --abbrev=0`
 BranchName=`git rev-parse --abbrev-ref HEAD`
 CommitID=`git rev-parse HEAD`
 BuildTime=`date +%Y-%m-%d\ %H:%M`
 
 [[ "-$GOPATH" == "-" ]] && { echo "GOPATH not set"; exit 1 ; }
 
-go build -ldflags "-X main.CommitID=${CommitID} -X main.BranchName=${BranchName} -X 'main.BuildTime=${BuildTime}'" -o cfs-client
+go build -ldflags "\
+-X github.com/chubaofs/chubaofs/proto.Version=${Version} \
+-X github.com/chubaofs/chubaofs/proto.CommitID=${CommitID} \
+-X github.com/chubaofs/chubaofs/proto.BranchName=${BranchName} \
+-X 'github.com/chubaofs/chubaofs/proto.BuildTime=${BuildTime}'" \
+-o cfs-client

--- a/client/fuse.go
+++ b/client/fuse.go
@@ -69,16 +69,8 @@ const (
 	ControlCommandSetRate      = "/rate/set"
 	ControlCommandGetRate      = "/rate/get"
 	ControlCommandFreeOSMemory = "/debug/freeosmemory"
-	Role="Client"
+	Role                       = "Client"
 )
-
-
-var (
-	CommitID   string
-	BranchName string
-	BuildTime  string
-)
-
 
 var (
 	configFile       = flag.String("c", "", "FUSE client config file")
@@ -97,7 +89,7 @@ func main() {
 	flag.Parse()
 
 	if *configVersion {
-		fmt.Print(proto.DumpVersion(Role,BranchName,CommitID,BuildTime))
+		fmt.Print(proto.DumpVersion(Role))
 		os.Exit(0)
 	}
 
@@ -149,7 +141,7 @@ func main() {
 	}()
 	syslog.SetOutput(outputFile)
 
-	syslog.Println(dumpVersion())
+	syslog.Println(proto.DumpVersion(Role))
 	syslog.Println("*** Final Mount Options ***")
 	for _, o := range GlobalMountOptions {
 		syslog.Println(o)
@@ -197,10 +189,6 @@ func main() {
 		syslog.Printf("fs Serve returns err(%v)\n", err)
 		os.Exit(1)
 	}
-}
-
-func dumpVersion() string {
-	return fmt.Sprintf("ChubaoFS Client\nBranch: %s\nCommit: %s\nBuild: %s %s %s %s\n", BranchName, CommitID, runtime.Version(), runtime.GOOS, runtime.GOARCH, BuildTime)
 }
 
 func startDaemon() error {

--- a/cmd/build.sh
+++ b/cmd/build.sh
@@ -1,8 +1,14 @@
 #!/usr/bin/env bash
+Version=`git describe --abbrev=0`
 BranchName=`git rev-parse --abbrev-ref HEAD`
 CommitID=`git rev-parse HEAD`
 BuildTime=`date +%Y-%m-%d\ %H:%M`
 
 [[ "-$GOPATH" == "-" ]] && { echo "GOPATH not set"; exit 1; }
 
-go build -ldflags "-X main.CommitID=${CommitID} -X main.BranchName=${BranchName} -X 'main.BuildTime=${BuildTime}'" -o cfs-server
+go build -ldflags "\
+-X github.com/chubaofs/chubaofs/proto.Version=${Version} \
+-X github.com/chubaofs/chubaofs/proto.CommitID=${CommitID} \
+-X github.com/chubaofs/chubaofs/proto.BranchName=${BranchName} \
+-X 'github.com/chubaofs/chubaofs/proto.BuildTime=${BuildTime}'" \
+-o cfs-server

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -17,8 +17,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/chubaofs/chubaofs/console"
-	"github.com/chubaofs/chubaofs/proto"
 	syslog "log"
 	"net/http"
 	_ "net/http/pprof"
@@ -29,6 +27,9 @@ import (
 	"runtime"
 	"strings"
 	"syscall"
+
+	"github.com/chubaofs/chubaofs/console"
+	"github.com/chubaofs/chubaofs/proto"
 
 	sysutil "github.com/chubaofs/chubaofs/util/sys"
 
@@ -45,7 +46,6 @@ import (
 	"github.com/chubaofs/chubaofs/util/log"
 	"github.com/chubaofs/chubaofs/util/ump"
 )
-
 
 const (
 	ConfigKeyRole       = "role"
@@ -75,12 +75,6 @@ const (
 
 const (
 	LoggerOutput = "output.log"
-)
-
-var (
-	CommitID   string
-	BranchName string
-	BuildTime  string
 )
 
 var (
@@ -124,7 +118,7 @@ func modifyOpenFiles() (err error) {
 func main() {
 	flag.Parse()
 
-	Version := proto.DumpVersion("Server",BranchName,CommitID,BuildTime)
+	Version := proto.DumpVersion("Server")
 	if *configVersion {
 		fmt.Printf("%v", Version)
 		os.Exit(0)

--- a/proto/version.go
+++ b/proto/version.go
@@ -5,11 +5,22 @@ import (
 	"runtime"
 )
 
-const (
-	BaseVersion="2.1.0"
+var (
+	Version    string
+	CommitID   string
+	BranchName string
+	BuildTime  string
 )
 
-
-func DumpVersion(role,branchName,commitID,buildTime string) string {
-	return fmt.Sprintf("ChubaoFS %s\nBranch: %s\nVersion: %s\nCommit: %s\nBuild: %s %s %s %s\n", role,branchName, BaseVersion,commitID,runtime.Version(), runtime.GOOS, runtime.GOARCH, buildTime)
+func DumpVersion(role string) string {
+	return fmt.Sprintf("ChubaoFS %s\n"+
+		"Version : %s\n"+
+		"Branch  : %s\n"+
+		"Commit  : %s\n"+
+		"Build   : %s %s %s %s\n",
+		role,
+		Version,
+		BranchName,
+		CommitID,
+		runtime.Version(), runtime.GOOS, runtime.GOARCH, BuildTime)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

When using the build script to compile the program, it automatically uses the latest git tag as the program version number information.

Using the `-v` argument will output version information like this:
```
ChubaoFS CLI
Version : v2.1.0-rc.1
Branch  : mervinkid/unified_version_info
Commit  : c458dd6409d22aca4c968c5028d3423dbf95b0da
Build   : go1.13.1 darwin amd64 2020-07-16 19:39
```

**Which issue this PR fixes**:
None.

**Special notes for your reviewer**:
None.

**Release note**:
None.