### PR TITLE
Update: recover prefix valid for rockstree range iter

### DIFF
--- a/metanode/btree_rocks.go
+++ b/metanode/btree_rocks.go
@@ -121,7 +121,7 @@ func (r *RocksTree) RangeWithSnap(snapshot *gorocksdb.Snapshot, start, end []byt
 
 func (r *RocksTree) RangeWithIter(it *gorocksdb.Iterator, start []byte, end []byte, cb func(v []byte) (bool, error)) error {
 	it.Seek(start)
-	for ; ; it.Next() {
+	for ; it.ValidForPrefix(start); it.Next() {
 		key := it.Key().Data()
 		value := it.Value().Data()
 		if bytes.Compare(end, key) < 0 {
@@ -380,7 +380,7 @@ func (b *DentryRocks) Create(dentry *Dentry) error {
 		log.LogErrorf("[DentryRocks] Failed to has Key: %v, err: %v", key, err)
 		return err
 	} else if has {
-		log.LogErrorf("[DentryRocks] has Key: %v, err: %v", key, err)
+		log.LogErrorf("[DentryRocks] has Key: %v", key)
 		return existsError
 	}
 

--- a/metanode/partition_fsmop_dentry.go
+++ b/metanode/partition_fsmop_dentry.go
@@ -62,8 +62,8 @@ func (mp *MetaPartition) fsmCreateDentry(dentry *Dentry, forceUpdate bool) (stat
 	if err == existsError {
 		//do not allow directories and files to overwrite each
 		// other when renaming
-		d, err := mp.dentryTree.Get(dentry.Inode, dentry.Name)
-		if err != nil {
+		d, err := mp.dentryTree.Get(dentry.ParentId, dentry.Name)
+		if err != nil || d == nil {
 			status = proto.OpErr
 			return
 		}


### PR DESCRIPTION
Signed-off-by: zhuzhengyi1 <zhuzhengyi@jd.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
