### PR TITLE
Fix: listObjects and listObjectsV2 list result is not expected

### DIFF
--- a/objectnode/fs.go
+++ b/objectnode/fs.go
@@ -52,6 +52,13 @@ func (m PrefixMap) Prefixes() Prefixes {
 	return s
 }
 
+func (m PrefixMap) contain(prefix string) bool {
+	if _, ok := m[prefix]; ok {
+		return true
+	}
+	return false
+}
+
 type FSUpload struct {
 	Key          string
 	UploadId     string

--- a/objectnode/fs_volume.go
+++ b/objectnode/fs_volume.go
@@ -344,25 +344,23 @@ func (v *Volume) ListFilesV1(opt *ListFilesV1Option) (result *ListFilesV1Result,
 
 	var infos []*FSFileInfo
 	var prefixes Prefixes
+	var nextMarker string
 
-	infos, prefixes, err = v.listFilesV1(prefix, marker, delimiter, maxKeys)
+	infos, prefixes, nextMarker, err = v.listFilesV1(prefix, marker, delimiter, maxKeys)
 	if err != nil {
-		log.LogErrorf("ListFilesV1: list fail: volume(%v) prefix(%v) marker(%v) delimiter(%v) maxKeys(%v) err(%v)",
-			v.name, prefix, marker, delimiter, maxKeys, err)
+		log.LogErrorf("ListFilesV1: list fail: volume(%v) prefix(%v) marker(%v) delimiter(%v) maxKeys(%v) nextMarker(%v) err(%v)",
+			v.name, prefix, marker, delimiter, maxKeys, nextMarker, err)
 		return
 	}
 
 	result = &ListFilesV1Result{
 		CommonPrefixes: prefixes,
 	}
-	if len(infos) > int(maxKeys) {
-		result.NextMarker = infos[maxKeys].Path
-		result.Files = infos[:maxKeys]
+
+	result.NextMarker = nextMarker
+	result.Files = infos
+	if len(nextMarker) > 0 {
 		result.Truncated = true
-	} else {
-		result.NextMarker = ""
-		result.Files = infos
-		result.Truncated = false
 	}
 
 	return
@@ -380,8 +378,9 @@ func (v *Volume) ListFilesV2(opt *ListFilesV2Option) (result *ListFilesV2Result,
 
 	var infos []*FSFileInfo
 	var prefixes Prefixes
+	var nextMarker string
 
-	infos, prefixes, err = v.listFilesV2(prefix, startAfter, contToken, delimiter, maxKeys)
+	infos, prefixes, nextMarker, err = v.listFilesV2(prefix, startAfter, contToken, delimiter, maxKeys)
 	if err != nil {
 		log.LogErrorf("ListFilesV2: list fail: volume(%v) prefix(%v) startAfter(%v) contToken(%v) delimiter(%v) maxKeys(%v) err(%v)",
 			v.name, prefix, startAfter, contToken, delimiter, maxKeys, err)
@@ -392,18 +391,12 @@ func (v *Volume) ListFilesV2(opt *ListFilesV2Option) (result *ListFilesV2Result,
 		CommonPrefixes: prefixes,
 	}
 
-	if len(infos) > int(maxKeys) {
-		result.NextToken = infos[maxKeys].Path
-		result.Files = infos[:maxKeys]
+	result.Files = infos
+	result.KeyCount = uint64(len(infos))
+	if nextMarker != "" {
 		result.Truncated = true
-		result.KeyCount = maxKeys
-	} else {
-		result.NextToken = ""
-		result.Files = infos
-		result.Truncated = false
-		result.KeyCount = uint64(len(infos))
+		result.NextToken = nextMarker
 	}
-
 	return
 }
 
@@ -1495,7 +1488,7 @@ func (v *Volume) lookupDirectories(dirs []string, autoCreate bool) (inode uint64
 	return
 }
 
-func (v *Volume) listFilesV1(prefix, marker, delimiter string, maxKeys uint64) (infos []*FSFileInfo, prefixes Prefixes, err error) {
+func (v *Volume) listFilesV1(prefix, marker, delimiter string, maxKeys uint64) (infos []*FSFileInfo, prefixes Prefixes, nextMarker string, err error) {
 	var prefixMap = PrefixMap(make(map[string]struct{}))
 
 	parentId, dirs, err := v.findParentId(prefix)
@@ -1503,19 +1496,23 @@ func (v *Volume) listFilesV1(prefix, marker, delimiter string, maxKeys uint64) (
 	// The method returns an ENOENT error, indicating that there
 	// are no files or directories matching the prefix.
 	if err == syscall.ENOENT {
-		return nil, nil, nil
+		return nil, nil, "", nil
 	}
 
 	// Errors other than ENOENT are unexpected errors, method stops and returns it to the caller.
 	if err != nil {
 		log.LogErrorf("listFilesV1: find parent ID fail, prefix(%v) marker(%v) err(%v)", prefix, marker, err)
-		return nil, nil, err
+		return nil, nil, "", err
 	}
 
 	log.LogDebugf("listFilesV1: find parent ID, prefix(%v) marker(%v) delimiter(%v) parentId(%v) dirs(%v)", prefix, marker, delimiter, parentId, len(dirs))
 
+	// Init the value that queried result count.
+	// Check this value when adding key to contents or common prefix,
+	// return if it reach to max keys
+	var rc uint64
 	// recursion scan
-	infos, prefixMap, err = v.recursiveScan(infos, prefixMap, parentId, maxKeys, dirs, prefix, marker, delimiter)
+	infos, prefixMap, nextMarker, _, err = v.recursiveScan(infos, prefixMap, parentId, maxKeys, rc, dirs, prefix, marker, delimiter)
 	if err != nil {
 		log.LogErrorf("listFilesV1: volume list dir fail: Volume(%v) err(%v)", v.name, err)
 		return
@@ -1529,13 +1526,13 @@ func (v *Volume) listFilesV1(prefix, marker, delimiter string, maxKeys uint64) (
 
 	prefixes = prefixMap.Prefixes()
 
-	log.LogDebugf("listFilesV1: Volume list dir: Volume(%v) prefix(%v) marker(%v) delimiter(%v) maxKeys(%v) infos(%v) prefixes(%v)",
-		v.name, prefix, marker, delimiter, maxKeys, len(infos), len(prefixes))
+	log.LogDebugf("listFilesV1: Volume list dir: Volume(%v) prefix(%v) marker(%v) delimiter(%v) maxKeys(%v) infos(%v) prefixes(%v) nextMarker(%v)",
+		v.name, prefix, marker, delimiter, maxKeys, len(infos), len(prefixes), nextMarker)
 
 	return
 }
 
-func (v *Volume) listFilesV2(prefix, startAfter, contToken, delimiter string, maxKeys uint64) (infos []*FSFileInfo, prefixes Prefixes, err error) {
+func (v *Volume) listFilesV2(prefix, startAfter, contToken, delimiter string, maxKeys uint64) (infos []*FSFileInfo, prefixes Prefixes, nextMarker string, err error) {
 	var prefixMap = PrefixMap(make(map[string]struct{}))
 
 	var marker string
@@ -1550,19 +1547,23 @@ func (v *Volume) listFilesV2(prefix, startAfter, contToken, delimiter string, ma
 	// The method returns an ENOENT error, indicating that there
 	// are no files or directories matching the prefix.
 	if err == syscall.ENOENT {
-		return nil, nil, nil
+		return nil, nil, "", nil
 	}
 
 	// Errors other than ENOENT are unexpected errors, method stops and returns it to the caller.
 	if err != nil {
 		log.LogErrorf("listFilesV2: find parent ID fail, prefix(%v) marker(%v) err(%v)", prefix, marker, err)
-		return nil, nil, err
+		return nil, nil, "", err
 	}
 
 	log.LogDebugf("listFilesV2: find parent ID, prefix(%v) marker(%v) delimiter(%v) parentId(%v) dirs(%v)", prefix, marker, delimiter, parentId, len(dirs))
 
+	// Init the value that queried result count.
+	// Check this value when adding key to contents or common prefix,
+	// return if it reach to max keys
+	var rc uint64
 	// recursion scan
-	infos, prefixMap, err = v.recursiveScan(infos, prefixMap, parentId, maxKeys, dirs, prefix, marker, delimiter)
+	infos, prefixMap, nextMarker, _, err = v.recursiveScan(infos, prefixMap, parentId, maxKeys, rc, dirs, prefix, marker, delimiter)
 	if err != nil {
 		log.LogErrorf("listFilesV2: Volume list dir fail, Volume(%v) err(%v)", v.name, err)
 		return
@@ -1577,8 +1578,8 @@ func (v *Volume) listFilesV2(prefix, startAfter, contToken, delimiter string, ma
 
 	prefixes = prefixMap.Prefixes()
 
-	log.LogDebugf("listFilesV2: Volume list dir: Volume(%v) prefix(%v) marker(%v) delimiter(%v) maxKeys(%v) infos(%v) prefixes(%v)",
-		v.name, prefix, marker, delimiter, maxKeys, len(infos), len(prefixes))
+	log.LogDebugf("listFilesV2: Volume list dir: Volume(%v) prefix(%v) marker(%v) delimiter(%v) maxKeys(%v) infos(%v) prefixes(%v), nextMarker(%v)",
+		v.name, prefix, marker, delimiter, maxKeys, len(infos), len(prefixes), nextMarker)
 
 	return
 }
@@ -1634,11 +1635,13 @@ func (v *Volume) findParentId(prefix string) (inode uint64, prefixDirs []string,
 // Recursive scan of the directory starting from the given parentID. Match files and directories
 // that match the prefix and delimiter criteria. Stop when the number of matches reaches a threshold
 // or all files and directories are scanned.
-func (v *Volume) recursiveScan(fileInfos []*FSFileInfo, prefixMap PrefixMap, parentId, maxKeys uint64,
-	dirs []string, prefix, marker, delimiter string) ([]*FSFileInfo, PrefixMap, error) {
+func (v *Volume) recursiveScan(fileInfos []*FSFileInfo, prefixMap PrefixMap, parentId, maxKeys, rc uint64,
+	dirs []string, prefix, marker, delimiter string) ([]*FSFileInfo, PrefixMap, string, uint64, error) {
 	var err error
+	var nextMarker string
 
 	var currentPath = strings.Join(dirs, pathSep) + pathSep
+
 	if len(dirs) > 0 && prefix != "" && strings.HasSuffix(currentPath, prefix) {
 		// When the current scanning position is not the root directory, a prefix matching
 		// check is performed on the current directory first.
@@ -1646,16 +1649,23 @@ func (v *Volume) recursiveScan(fileInfos []*FSFileInfo, prefixMap PrefixMap, par
 		// The reason for this is that according to the definition of Amazon S3's ListObjects
 		// interface, directory entries that meet the exact prefix match will be returned as
 		// a Content result, not as a CommonPrefix.
-		fileInfo := &FSFileInfo{
-			Inode: parentId,
-			Path:  currentPath,
-		}
-		fileInfos = append(fileInfos, fileInfo)
 
-		// If the number of matches reaches the threshold given by maxKey,
-		// stop scanning and return results.
-		if len(fileInfos) >= int(maxKeys+1) {
-			return fileInfos, prefixMap, nil
+		// Add check to marker, if request contain marker, current path must greater than marker,
+		// otherwise can not put it to prefix map
+		if (len(marker) > 0 && currentPath > marker) || len(marker) == 0 {
+			fileInfo := &FSFileInfo{
+				Inode: parentId,
+				Path:  currentPath,
+			}
+			// If the number of matches reaches the threshold given by maxKey,
+			// stop scanning and return results.
+			// To get the next marker, first compare the result counts with the max key
+			// it means that when result count reach the amx key, continue to find the next key as the next marker
+			if rc >= maxKeys {
+				return fileInfos, prefixMap, currentPath, rc, nil
+			}
+			fileInfos = append(fileInfos, fileInfo)
+			rc++
 		}
 	}
 
@@ -1666,55 +1676,74 @@ func (v *Volume) recursiveScan(fileInfos []*FSFileInfo, prefixMap PrefixMap, par
 	var children []proto.Dentry
 	children, err = v.mw.ReadDir_ll(parentId)
 	if err != nil && err != syscall.ENOENT {
-		return fileInfos, prefixMap, err
+		return fileInfos, prefixMap, "", 0, err
 	}
 	if err == syscall.ENOENT {
-		return fileInfos, prefixMap, nil
+		return fileInfos, prefixMap, "", 0, nil
 	}
 
 	for _, child := range children {
-
 		var path = strings.Join(append(dirs, child.Name), pathSep)
-
 		if os.FileMode(child.Type).IsDir() {
 			path += pathSep
 		}
-		log.LogDebugf("recursiveScan: process child, path(%v) prefix(%v) marker(%v) delimiter(%v)",
-			path, prefix, marker, delimiter)
-
 		if prefix != "" && !strings.HasPrefix(path, prefix) {
 			continue
 		}
-		if marker != "" && path < marker {
-			continue
+
+		if marker != "" {
+			if !os.FileMode(child.Type).IsDir() && path < marker {
+				continue
+			}
+			if os.FileMode(child.Type).IsDir() && path < marker {
+				fileInfos, prefixMap, nextMarker, rc, err = v.recursiveScan(fileInfos, prefixMap, child.Inode, maxKeys, rc, append(dirs, child.Name), prefix, marker, delimiter)
+				if err != nil {
+					return fileInfos, prefixMap, nextMarker, rc, err
+				}
+				if rc >= maxKeys && nextMarker != "" {
+					return fileInfos, prefixMap, nextMarker, rc, err
+				}
+				continue
+			}
 		}
+
 		if delimiter != "" {
 			var nonPrefixPart = strings.Replace(path, prefix, "", 1)
 			if idx := strings.Index(nonPrefixPart, delimiter); idx >= 0 {
 				var commonPrefix = prefix + util.SubString(nonPrefixPart, 0, idx) + delimiter
+				if prefixMap.contain(commonPrefix) {
+					continue
+				}
+				if rc >= maxKeys {
+					return fileInfos, prefixMap, commonPrefix, rc, nil
+				}
 				prefixMap.AddPrefix(commonPrefix)
+				rc++
 				continue
 			}
 		}
-		if os.FileMode(child.Type).IsDir() {
-			fileInfos, prefixMap, err = v.recursiveScan(fileInfos, prefixMap, child.Inode, maxKeys, append(dirs, child.Name), prefix, marker, delimiter)
-			if err != nil {
-				return fileInfos, prefixMap, err
-			}
-		} else {
-			fileInfo := &FSFileInfo{
-				Inode: child.Inode,
-				Path:  path,
-			}
-			fileInfos = append(fileInfos, fileInfo)
 
-			// if file numbers is enough, end list dir
-			if len(fileInfos) >= int(maxKeys+1) {
-				return fileInfos, prefixMap, nil
+		fileInfo := &FSFileInfo{
+			Inode: child.Inode,
+			Path:  path,
+		}
+		if rc >= maxKeys {
+			return fileInfos, prefixMap, path, rc, nil
+		}
+		fileInfos = append(fileInfos, fileInfo)
+		rc++
+
+		if os.FileMode(child.Type).IsDir() {
+			fileInfos, prefixMap, nextMarker, rc, err = v.recursiveScan(fileInfos, prefixMap, child.Inode, maxKeys, rc, append(dirs, child.Name), prefix, marker, delimiter)
+			if err != nil {
+				return fileInfos, prefixMap, nextMarker, rc, err
+			}
+			if rc >= maxKeys && nextMarker != "" {
+				return fileInfos, prefixMap, nextMarker, rc, err
 			}
 		}
 	}
-	return fileInfos, prefixMap, nil
+	return fileInfos, prefixMap, nextMarker, rc, nil
 }
 
 // This method is used to supplement file metadata. Supplement the specified file


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix: 
1. listObjects and listObjectsV2 list result is incorrect.
2. listObjects and listObjectsV2 pagination information is incorrect.
3. Add directory to result (Contents or CommonPrefixes in response) if the directory is eligible.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
