### PR TITLE
Fix: main build script issue

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -11,7 +11,7 @@ if [[ "-x$RM" == "-x" ]] ; then
     RM=rm
 fi
 
-Version=$(git describe --abbrev=0 2>/dev/null)
+Version=$(git describe --abbrev=0 --tags 2>/dev/null)
 BranchName=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
 CommitID=$(git rev-parse HEAD 2>/dev/null)
 BuildTime=$(date +%Y-%m-%d\ %H:%M)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Fix the issue of obtaining the latest tag of the current branch during build when using main build script under the `build` directory.

**Which issue this PR fixes**:
None.

**Special notes for your reviewer**:
None.

**Release note**:
None.