### PR TITLE
Fix blank version when cfs-cli -v

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -282,8 +282,8 @@ build_cli() {
     pre_build_server
     pushd $SrcPath >/dev/null
     echo -n "build cfs-cli      "
-    #go build $MODFLAGS -ldflags "${LDFlags}" -o ${BuildBinPath}/cfs-cli ${SrcPath}/cli/*.go  && echo "success" || echo "failed"
-    sh cli/build.sh ${BuildBinPath}/cfs-cli && echo "success" || echo "failed"
+    go build $MODFLAGS -ldflags "${LDFlags}" -o ${BuildBinPath}/cfs-cli ${SrcPath}/cli/*.go  && echo "success" || echo "failed"
+    #sh cli/build.sh ${BuildBinPath}/cfs-cli && echo "success" || echo "failed"
     popd >/dev/null
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
./cfs-cli -v                                                                                                                           
ChubaoFS CLI
Version : 
Branch  : 
Commit  : 
Build   : go1.13.11 linux amd64 
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
I uncommented the line of go build,and commented the line of cli/build.sh.
./cfs-cli -v
ChubaoFS CLI
Version : v2.1.0
Branch  : master
Commit  : 85b36b54724e866d62c9cf3be0f28a78a93eb704
Build   : go1.13.11 linux amd64 2020-07-30 18:45

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
