### PR TITLE
Some Optimize and bug fix

### DIFF
--- a/master/admin_task_manager.go
+++ b/master/admin_task_manager.go
@@ -33,6 +33,8 @@ const (
 	MaxTaskNum = 30
 
 	TaskWorkerInterval = time.Second * time.Duration(2)
+	idleConnTimeout    = 90 //seconds
+	connectTimeout     = 10 //seconds
 )
 
 // AdminTaskManager sends administration commands to the metaNode or dataNode.
@@ -41,8 +43,8 @@ type AdminTaskManager struct {
 	targetAddr string
 	TaskMap    map[string]*proto.AdminTask
 	sync.RWMutex
-	exitCh   chan struct{}
-	connPool *util.ConnectPool
+	exitCh     chan struct{}
+	connPool   *util.ConnectPool
 }
 
 func newAdminTaskManager(targetAddr, clusterID string) (sender *AdminTaskManager) {
@@ -52,7 +54,7 @@ func newAdminTaskManager(targetAddr, clusterID string) (sender *AdminTaskManager
 		clusterID:  clusterID,
 		TaskMap:    make(map[string]*proto.AdminTask),
 		exitCh:     make(chan struct{}, 1),
-		connPool:   util.NewConnectPool(),
+		connPool:   util.NewConnectPoolWithTimeout(idleConnTimeout, connectTimeout),
 	}
 	go sender.process()
 

--- a/master/api_service.go
+++ b/master/api_service.go
@@ -33,6 +33,22 @@ import (
 	"github.com/chubaofs/chubaofs/util/log"
 )
 
+// NodeView provides the view of the data or meta node.
+type NodeView struct {
+	Addr       string
+	Status     bool
+	ID         uint64
+	IsWritable bool
+}
+
+// NodeView provides the view of the data or meta node.
+type InvalidNodeView struct {
+	Addr     string
+	ID       uint64
+	OldID    uint64
+	NodeType string
+}
+
 // TopologyView provides the view of the topology view of the cluster
 type TopologyView struct {
 	Zones []*ZoneView
@@ -1003,6 +1019,28 @@ func (m *Server) addMetaNode(w http.ResponseWriter, r *http.Request) {
 	sendOkReply(w, r, newSuccessHTTPReply(id))
 }
 
+func (m *Server) checkInvalidIDNodes(w http.ResponseWriter,r *http.Request) {
+	nodes := m.cluster.getInvalidIDNodes()
+	sendOkReply(w, r, newSuccessHTTPReply(nodes))
+}
+
+func (m *Server) updateDataNode(w http.ResponseWriter, r *http.Request) {
+	var (
+		nodeAddr string
+		id       uint64
+		err      error
+	)
+	if nodeAddr, id, err = parseRequestForUpdateMetaNode(r); err != nil {
+		sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: err.Error()})
+		return
+	}
+	if err = m.cluster.updateDataNodeBaseInfo(nodeAddr, id); err != nil {
+		sendErrReply(w, r, newErrHTTPReply(err))
+		return
+	}
+	sendOkReply(w, r, newSuccessHTTPReply(id))
+}
+
 func (m *Server) updateMetaNode(w http.ResponseWriter, r *http.Request) {
 	var (
 		nodeAddr string
@@ -1200,15 +1238,14 @@ func parseRequestForRaftNode(r *http.Request) (id uint64, host string, err error
 	return
 }
 
-
-func parseRequestForUpdateMetaNode(r *http.Request) (nodeAddr string,id uint64, err error) {
+func parseRequestForUpdateMetaNode(r *http.Request) (nodeAddr string, id uint64, err error) {
 	if err = r.ParseForm(); err != nil {
 		return
 	}
 	if nodeAddr, err = extractNodeAddr(r); err != nil {
 		return
 	}
-	if id,err = extractNodeID(r); err != nil {
+	if id, err = extractNodeID(r); err != nil {
 		return
 	}
 	return
@@ -1566,7 +1603,7 @@ func extractNodeAddr(r *http.Request) (nodeAddr string, err error) {
 	return
 }
 
-func extractNodeID(r *http.Request) (ID uint64,err error) {
+func extractNodeID(r *http.Request) (ID uint64, err error) {
 	var value string
 	if value = r.FormValue(idKey); value == "" {
 		err = keyNotFound(idKey)

--- a/master/api_service.go
+++ b/master/api_service.go
@@ -1003,6 +1003,23 @@ func (m *Server) addMetaNode(w http.ResponseWriter, r *http.Request) {
 	sendOkReply(w, r, newSuccessHTTPReply(id))
 }
 
+func (m *Server) updateMetaNode(w http.ResponseWriter, r *http.Request) {
+	var (
+		nodeAddr string
+		id       uint64
+		err      error
+	)
+	if nodeAddr, id, err = parseRequestForUpdateMetaNode(r); err != nil {
+		sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: err.Error()})
+		return
+	}
+	if err = m.cluster.updateMetaNodeBaseInfo(nodeAddr, id); err != nil {
+		sendErrReply(w, r, newErrHTTPReply(err))
+		return
+	}
+	sendOkReply(w, r, newSuccessHTTPReply(id))
+}
+
 func (m *Server) getMetaNode(w http.ResponseWriter, r *http.Request) {
 	var (
 		nodeAddr     string
@@ -1178,6 +1195,20 @@ func parseRequestForRaftNode(r *http.Request) (id uint64, host string, err error
 
 	if arr := strings.Split(host, colonSplit); len(arr) < 2 {
 		err = unmatchedKey(addrKey)
+		return
+	}
+	return
+}
+
+
+func parseRequestForUpdateMetaNode(r *http.Request) (nodeAddr string,id uint64, err error) {
+	if err = r.ParseForm(); err != nil {
+		return
+	}
+	if nodeAddr, err = extractNodeAddr(r); err != nil {
+		return
+	}
+	if id,err = extractNodeID(r); err != nil {
 		return
 	}
 	return
@@ -1533,6 +1564,15 @@ func extractNodeAddr(r *http.Request) (nodeAddr string, err error) {
 		return
 	}
 	return
+}
+
+func extractNodeID(r *http.Request) (ID uint64,err error) {
+	var value string
+	if value = r.FormValue(idKey); value == "" {
+		err = keyNotFound(idKey)
+		return
+	}
+	return strconv.ParseUint(value, 10, 64)
 }
 
 func extractDiskPath(r *http.Request) (diskPath string, err error) {

--- a/master/cluster.go
+++ b/master/cluster.go
@@ -320,6 +320,26 @@ func (c *Cluster) checkVolReduceReplicaNum() {
 	}
 }
 
+func (c *Cluster) updateMetaNodeBaseInfo(nodeAddr string, id uint64) (err error) {
+	c.mnMutex.Lock()
+	defer c.mnMutex.Unlock()
+	value, ok := c.metaNodes.Load(nodeAddr)
+	if !ok {
+		err = fmt.Errorf("node %v is not exist", nodeAddr)
+	}
+	metaNode := value.(*MetaNode)
+	if metaNode.ID == id {
+		return
+	}
+
+	metaNode.ID = id
+	if err = c.syncUpdateMetaNode(metaNode); err != nil {
+		return
+	}
+	//partitions := c.getAllMetaPartitionsByMetaNode(nodeAddr)
+	return
+}
+
 func (c *Cluster) addMetaNode(nodeAddr, zoneName string) (id uint64, err error) {
 	c.mnMutex.Lock()
 	defer c.mnMutex.Unlock()
@@ -858,6 +878,22 @@ func (c *Cluster) getAllMetaPartitionIDByMetaNode(addr string) (partitionIDs []u
 		}
 	}
 
+	return
+}
+
+func (c *Cluster) getAllMetaPartitionsByMetaNode(addr string) (partitions []*MetaPartition) {
+	partitions = make([]*MetaPartition, 0)
+	safeVols := c.allVols()
+	for _, vol := range safeVols {
+		for _, mp := range vol.MetaPartitions {
+			for _, host := range mp.Hosts {
+				if host == addr {
+					partitions = append(partitions, mp)
+					break
+				}
+			}
+		}
+	}
 	return
 }
 

--- a/master/cluster.go
+++ b/master/cluster.go
@@ -320,12 +320,102 @@ func (c *Cluster) checkVolReduceReplicaNum() {
 	}
 }
 
+func (c *Cluster) getInvalidIDNodes() (nodes []*InvalidNodeView) {
+	metaNodes := c.getNotConsistentIDMetaNodes()
+	nodes = append(nodes, metaNodes...)
+	dataNodes := c.getNotConsistentIDDataNodes()
+	nodes = append(nodes, dataNodes...)
+	return
+}
+
+func (c *Cluster) getNotConsistentIDMetaNodes() (metaNodes []*InvalidNodeView) {
+	metaNodes = make([]*InvalidNodeView, 0)
+	c.metaNodes.Range(func(key, value interface{}) bool {
+		metanode, ok := value.(*MetaNode)
+		if !ok {
+			return true
+		}
+		notConsistent, oldID := c.hasNotConsistentIDMetaPartitions(metanode)
+		if notConsistent {
+			metaNodes = append(metaNodes, &InvalidNodeView{Addr: metanode.Addr, ID: metanode.ID, OldID: oldID, NodeType: "meta"})
+		}
+		return true
+	})
+	return
+}
+
+func (c *Cluster) hasNotConsistentIDMetaPartitions(metanode *MetaNode) (notConsistent bool, oldID uint64) {
+	safeVols := c.allVols()
+	for _, vol := range safeVols {
+		for _, mp := range vol.MetaPartitions {
+			for _, peer := range mp.Peers {
+				if peer.Addr == metanode.Addr && peer.ID != metanode.ID {
+					return true, peer.ID
+				}
+			}
+		}
+	}
+	return
+}
+
+func (c *Cluster) getNotConsistentIDDataNodes() (dataNodes []*InvalidNodeView) {
+	dataNodes = make([]*InvalidNodeView, 0)
+	c.dataNodes.Range(func(key, value interface{}) bool {
+		datanode, ok := value.(*DataNode)
+		if !ok {
+			return true
+		}
+		notConsistent, oldID := c.hasNotConsistentIDDataPartitions(datanode)
+		if notConsistent {
+			dataNodes = append(dataNodes, &InvalidNodeView{Addr: datanode.Addr, ID: datanode.ID, OldID: oldID, NodeType: "data"})
+		}
+		return true
+	})
+	return
+}
+
+func (c *Cluster) hasNotConsistentIDDataPartitions(datanode *DataNode) (notConsistent bool, oldID uint64) {
+	safeVols := c.allVols()
+	for _, vol := range safeVols {
+		for _, mp := range vol.dataPartitions.partitions {
+			for _, peer := range mp.Peers {
+				if peer.Addr == datanode.Addr && peer.ID != datanode.ID {
+					return true, peer.ID
+				}
+			}
+		}
+	}
+	return
+}
+
+func (c *Cluster) updateDataNodeBaseInfo(nodeAddr string, id uint64) (err error) {
+	c.dnMutex.Lock()
+	defer c.dnMutex.Unlock()
+	value, ok := c.dataNodes.Load(nodeAddr)
+	if !ok {
+		err = fmt.Errorf("node %v is not exist", nodeAddr)
+		return
+	}
+	dataNode := value.(*DataNode)
+	if dataNode.ID == id {
+		return
+	}
+
+	dataNode.ID = id
+	if err = c.syncUpdateDataNode(dataNode); err != nil {
+		return
+	}
+	//partitions := c.getAllMetaPartitionsByMetaNode(nodeAddr)
+	return
+}
+
 func (c *Cluster) updateMetaNodeBaseInfo(nodeAddr string, id uint64) (err error) {
 	c.mnMutex.Lock()
 	defer c.mnMutex.Unlock()
 	value, ok := c.metaNodes.Load(nodeAddr)
 	if !ok {
 		err = fmt.Errorf("node %v is not exist", nodeAddr)
+		return
 	}
 	metaNode := value.(*MetaNode)
 	if metaNode.ID == id {

--- a/master/cluster.go
+++ b/master/cluster.go
@@ -981,6 +981,9 @@ func (c *Cluster) decommissionDataPartition(offlineAddr string, dp *DataPartitio
 	dp.Status = proto.ReadOnly
 	dp.isRecover = true
 	c.putBadDataPartitionIDs(replica, offlineAddr, dp.PartitionID)
+	dp.RLock()
+	c.syncUpdateDataPartition(dp)
+	dp.RUnlock()
 	log.LogWarnf("clusterID[%v] partitionID:%v  on Node:%v offline success,newHost[%v],PersistenceHosts:[%v]",
 		c.Name, dp.PartitionID, offlineAddr, newAddr, dp.Hosts)
 	return

--- a/master/cluster_task.go
+++ b/master/cluster_task.go
@@ -548,6 +548,7 @@ func (c *Cluster) doLoadDataPartition(dp *DataPartition) {
 
 	dp.getFileCount()
 	dp.validateCRC(c.Name)
+	dp.checkReplicaSize(c.Name,c.cfg.diffSpaceUsage)
 	dp.setToNormal()
 }
 

--- a/master/cluster_task.go
+++ b/master/cluster_task.go
@@ -148,6 +148,9 @@ func (c *Cluster) decommissionMetaPartition(nodeAddr string, mp *MetaPartition) 
 	}
 	mp.IsRecover = true
 	c.putBadMetaPartitions(nodeAddr, mp.PartitionID)
+	mp.RLock()
+	c.syncUpdateMetaPartition(mp)
+	mp.RUnlock()
 	Warn(c.Name, fmt.Sprintf("action[decommissionMetaPartition] clusterID[%v] vol[%v] meta partition[%v] "+
 		"offline addr[%v] success,new addr[%v]", c.Name, mp.volName, mp.PartitionID, nodeAddr, newPeers[0].Addr))
 	return

--- a/master/data_partition.go
+++ b/master/data_partition.go
@@ -469,6 +469,7 @@ func (partition *DataPartition) loadFile(dataNode *DataNode, resp *proto.LoadDat
 		fc.updateFileInCore(partition.PartitionID, dpf, replica, index)
 	}
 	replica.HasLoadResponse = true
+	replica.Used = resp.Used
 }
 
 func (partition *DataPartition) getReplicaIndex(addr string) (index int, err error) {

--- a/master/data_partition_check.go
+++ b/master/data_partition_check.go
@@ -78,7 +78,7 @@ func (partition *DataPartition) checkReplicaStatus(timeOutSec int64) {
 	defer partition.Unlock()
 	for _, replica := range partition.Replicas {
 		if !replica.isLive(timeOutSec) {
-			replica.Status = proto.Unavailable
+			replica.Status = proto.ReadOnly
 		}
 	}
 }

--- a/master/disk_manager.go
+++ b/master/disk_manager.go
@@ -61,6 +61,9 @@ func (c *Cluster) checkDiskRecoveryProgress() {
 			diff = partition.getMinus()
 			if diff < util.GB {
 				partition.isRecover = false
+				partition.RLock()
+				c.syncUpdateDataPartition(partition)
+				partition.RUnlock()
 				Warn(c.Name, fmt.Sprintf("clusterID[%v],partitionID[%v] has recovered success", c.Name, partitionID))
 			} else {
 				newBadDpIds = append(newBadDpIds, partitionID)

--- a/master/http_server.go
+++ b/master/http_server.go
@@ -215,6 +215,9 @@ func (m *Server) registerAPIRoutes(router *mux.Router) {
 	router.NewRoute().Methods(http.MethodGet, http.MethodPost).
 		Path(proto.AdminDeleteDataReplica).
 		HandlerFunc(m.deleteDataReplica)
+	router.NewRoute().Methods(http.MethodGet, http.MethodPost).
+		Path(proto.AdminUpdateMetaNode).
+		HandlerFunc(m.updateMetaNode)
 
 	// data node management APIs
 	router.NewRoute().Methods(http.MethodGet, http.MethodPost).

--- a/master/http_server.go
+++ b/master/http_server.go
@@ -218,6 +218,12 @@ func (m *Server) registerAPIRoutes(router *mux.Router) {
 	router.NewRoute().Methods(http.MethodGet, http.MethodPost).
 		Path(proto.AdminUpdateMetaNode).
 		HandlerFunc(m.updateMetaNode)
+	router.NewRoute().Methods(http.MethodGet, http.MethodPost).
+		Path(proto.AdminUpdateDataNode).
+		HandlerFunc(m.updateDataNode)
+	router.NewRoute().Methods(http.MethodGet, http.MethodPost).
+		Path(proto.AdminGetInvalidNodes).
+		HandlerFunc(m.checkInvalidIDNodes)
 
 	// data node management APIs
 	router.NewRoute().Methods(http.MethodGet, http.MethodPost).

--- a/master/meta_partition_manager.go
+++ b/master/meta_partition_manager.go
@@ -169,6 +169,9 @@ func (c *Cluster) checkMetaPartitionRecoveryProgress() {
 			diff = partition.getMinusOfMaxInodeID()
 			if diff < defaultMinusOfMaxInodeID {
 				partition.IsRecover = false
+				partition.RLock()
+				c.syncUpdateMetaPartition(partition)
+				partition.RUnlock()
 				Warn(c.Name, fmt.Sprintf("clusterID[%v],vol[%v] partitionID[%v] has recovered success", c.Name, partition.volName, partitionID))
 			} else {
 				newBadMpIds = append(newBadMpIds, partitionID)

--- a/master/metadata_fsm_op.go
+++ b/master/metadata_fsm_op.go
@@ -64,6 +64,7 @@ type metaPartitionValue struct {
 	VolName     string
 	Hosts       string
 	Peers       []bsProto.Peer
+	IsRecover   bool
 }
 
 func newMetaPartitionValue(mp *MetaPartition) (mpv *metaPartitionValue) {
@@ -77,6 +78,7 @@ func newMetaPartitionValue(mp *MetaPartition) (mpv *metaPartitionValue) {
 		VolName:     mp.volName,
 		Hosts:       mp.hostsToString(),
 		Peers:       mp.Peers,
+		IsRecover:   mp.IsRecover,
 	}
 	return
 }
@@ -90,6 +92,7 @@ type dataPartitionValue struct {
 	VolID       uint64
 	VolName     string
 	Replicas    []*replicaValue
+	IsRecover   bool
 }
 
 type replicaValue struct {
@@ -107,6 +110,7 @@ func newDataPartitionValue(dp *DataPartition) (dpv *dataPartitionValue) {
 		VolID:       dp.VolID,
 		VolName:     dp.VolName,
 		Replicas:    make([]*replicaValue, 0),
+		IsRecover:   dp.isRecover,
 	}
 	for _, replica := range dp.Replicas {
 		rv := &replicaValue{Addr: replica.Addr, DiskPath: replica.DiskPath}
@@ -669,6 +673,7 @@ func (c *Cluster) loadMetaPartitions() (err error) {
 		mp := newMetaPartition(mpv.PartitionID, mpv.Start, mpv.End, vol.mpReplicaNum, vol.Name, mpv.VolID)
 		mp.setHosts(strings.Split(mpv.Hosts, underlineSeparator))
 		mp.setPeers(mpv.Peers)
+		mp.IsRecover = mpv.IsRecover
 		vol.addMetaPartition(mp)
 		log.LogInfof("action[loadMetaPartitions],vol[%v],mp[%v]", vol.Name, mp.PartitionID)
 	}
@@ -700,6 +705,7 @@ func (c *Cluster) loadDataPartitions() (err error) {
 		dp := newDataPartition(dpv.PartitionID, dpv.ReplicaNum, dpv.VolName, dpv.VolID)
 		dp.Hosts = strings.Split(dpv.Hosts, underlineSeparator)
 		dp.Peers = dpv.Peers
+		dp.isRecover = dpv.IsRecover
 		for _, rv := range dpv.Replicas {
 			if !contains(dp.Hosts, rv.Addr) {
 				continue

--- a/master/mocktest/data_server.go
+++ b/master/mocktest/data_server.go
@@ -26,6 +26,10 @@ import (
 	"github.com/chubaofs/chubaofs/util"
 )
 
+const (
+	defaultUsedSize = 20 * util.GB
+)
+
 type MockDataServer struct {
 	nodeID                          uint64
 	TcpAddr                         string
@@ -206,12 +210,12 @@ func (mds *MockDataServer) handleCreateDataPartition(conn net.Conn, p *proto.Pac
 	if err = json.Unmarshal(requestJson, req); err != nil {
 		return
 	}
-	// Create new  metaPartition.
+	// Create new  partition.
 	partition := &MockDataPartition{
 		PartitionID: req.PartitionId,
 		VolName:     req.VolumeId,
 		total:       req.PartitionSize,
-		used:        10 * util.GB,
+		used:        defaultUsedSize,
 	}
 	mds.partitions = append(mds.partitions, partition)
 	return
@@ -238,7 +242,7 @@ func (mds *MockDataServer) handleHeartbeats(conn net.Conn, pkg *proto.Packet, ta
 			PartitionID:     partition.PartitionID,
 			PartitionStatus: proto.ReadWrite,
 			Total:           120 * util.GB,
-			Used:            20 * util.GB,
+			Used:            defaultUsedSize,
 			DiskPath:        "/cfs",
 			ExtentCount:     10,
 			NeedCompare:     true,
@@ -277,7 +281,7 @@ func (mds *MockDataServer) handleLoadDataPartition(conn net.Conn, pkg *proto.Pac
 	partitionID := uint64(req.PartitionId)
 	response := &proto.LoadDataPartitionResponse{}
 	response.PartitionId = partitionID
-	response.Used = 10 * util.GB
+	response.Used = defaultUsedSize
 	response.PartitionSnapshot = buildSnapshot()
 	response.Status = proto.TaskSucceeds
 	var partition *MockDataPartition

--- a/master/vol.go
+++ b/master/vol.go
@@ -241,7 +241,6 @@ func (vol *Vol) checkDataPartitions(c *Cluster) (cnt int) {
 		if len(tasks) != 0 {
 			c.addDataNodeTasks(tasks)
 		}
-		dp.checkReplicaSize(c.Name, c.cfg.diffSpaceUsage)
 	}
 	return
 }

--- a/metanode/manager_op.go
+++ b/metanode/manager_op.go
@@ -138,14 +138,16 @@ func (m *metadataManager) opCreateInode(conn net.Conn, p *Packet,
 	remoteAddr string) (err error) {
 	req := &CreateInoReq{}
 	if err = json.Unmarshal(p.Data, req); err != nil {
-		p.PacketErrorWithBody(proto.OpErr, []byte(err.Error()))
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
 		m.respondToClient(conn, p)
+		err = errors.NewErrorf("[%v],req[%v],err[%v]", p.GetOpMsgWithReqAndResult(), req, string(p.Data))
 		return
 	}
 	mp, err := m.getPartition(req.PartitionID)
 	if err != nil {
-		p.PacketErrorWithBody(proto.OpNotExistErr, []byte(err.Error()))
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
 		m.respondToClient(conn, p)
+		err = errors.NewErrorf("[%v],req[%v],err[%v]", p.GetOpMsgWithReqAndResult(), req, string(p.Data))
 		return
 	}
 	if !m.serveProxy(conn, mp, p) {
@@ -163,14 +165,16 @@ func (m *metadataManager) opMetaLinkInode(conn net.Conn, p *Packet,
 	remoteAddr string) (err error) {
 	req := &LinkInodeReq{}
 	if err = json.Unmarshal(p.Data, req); err != nil {
-		p.PacketErrorWithBody(proto.OpErr, []byte(err.Error()))
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
 		m.respondToClient(conn, p)
+		err = errors.NewErrorf("[%v],req[%v],err[%v]", p.GetOpMsgWithReqAndResult(), req, string(p.Data))
 		return
 	}
 	mp, err := m.getPartition(req.PartitionID)
 	if err != nil {
-		p.PacketErrorWithBody(proto.OpNotExistErr, []byte(err.Error()))
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
 		m.respondToClient(conn, p)
+		err = errors.NewErrorf("[%v],req[%v],err[%v]", p.GetOpMsgWithReqAndResult(), req, string(p.Data))
 		return
 	}
 	if !m.serveProxy(conn, mp, p) {
@@ -188,8 +192,9 @@ func (m *metadataManager) opFreeInodeOnRaftFollower(conn net.Conn, p *Packet,
 	remoteAddr string) (err error) {
 	mp, err := m.getPartition(p.PartitionID)
 	if err != nil {
-		p.PacketErrorWithBody(proto.OpErr, []byte(err.Error()))
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
 		m.respondToClient(conn, p)
+		err = errors.NewErrorf("[%v],req[%v],err[%v]", p.GetOpMsgWithReqAndResult(), string(p.Data))
 		return
 	}
 	mp.(*metaPartition).internalDelete(p.Data[:p.Size])
@@ -204,14 +209,16 @@ func (m *metadataManager) opCreateDentry(conn net.Conn, p *Packet,
 	remoteAddr string) (err error) {
 	req := &CreateDentryReq{}
 	if err = json.Unmarshal(p.Data, req); err != nil {
-		p.PacketErrorWithBody(proto.OpErr, []byte(err.Error()))
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
 		m.respondToClient(conn, p)
+		err = errors.NewErrorf("[%v],req[%v],err[%v]", p.GetOpMsgWithReqAndResult(), req, string(p.Data))
 		return
 	}
 	mp, err := m.getPartition(req.PartitionID)
 	if err != nil {
-		p.PacketErrorWithBody(proto.OpNotExistErr, []byte(err.Error()))
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
 		m.respondToClient(conn, p)
+		err = errors.NewErrorf("[%v],req[%v],err[%v]", p.GetOpMsgWithReqAndResult(), req, string(p.Data))
 		return
 	}
 	if !m.serveProxy(conn, mp, p) {
@@ -229,14 +236,16 @@ func (m *metadataManager) opDeleteDentry(conn net.Conn, p *Packet,
 	remoteAddr string) (err error) {
 	req := &DeleteDentryReq{}
 	if err = json.Unmarshal(p.Data, req); err != nil {
-		p.PacketErrorWithBody(proto.OpErr, nil)
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
 		m.respondToClient(conn, p)
+		err = errors.NewErrorf("[%v],req[%v],err[%v]", p.GetOpMsgWithReqAndResult(), req, string(p.Data))
 		return
 	}
 	mp, err := m.getPartition(req.PartitionID)
 	if err != nil {
-		p.PacketErrorWithBody(proto.OpNotExistErr, nil)
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
 		m.respondToClient(conn, p)
+		err = errors.NewErrorf("[%v],req[%v],err[%v]", p.GetOpMsgWithReqAndResult(), req, string(p.Data))
 		return
 	}
 	if !m.serveProxy(conn, mp, p) {
@@ -254,14 +263,16 @@ func (m *metadataManager) opBatchDeleteDentry(conn net.Conn, p *Packet,
 	remoteAddr string) (err error) {
 	req := &BatchDeleteDentryReq{}
 	if err = json.Unmarshal(p.Data, req); err != nil {
-		p.PacketErrorWithBody(proto.OpErr, nil)
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
 		m.respondToClient(conn, p)
+		err = errors.NewErrorf("[%v],req[%v],err[%v]", p.GetOpMsgWithReqAndResult(), req, string(p.Data))
 		return
 	}
 	mp, err := m.getPartition(req.PartitionID)
 	if err != nil {
-		p.PacketErrorWithBody(proto.OpNotExistErr, nil)
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
 		m.respondToClient(conn, p)
+		err = errors.NewErrorf("[%v],req[%v],err[%v]", p.GetOpMsgWithReqAndResult(), req, string(p.Data))
 		return
 	}
 	if !m.serveProxy(conn, mp, p) {
@@ -278,14 +289,16 @@ func (m *metadataManager) opUpdateDentry(conn net.Conn, p *Packet,
 	remoteAddr string) (err error) {
 	req := &UpdateDentryReq{}
 	if err = json.Unmarshal(p.Data, req); err != nil {
-		p.PacketErrorWithBody(proto.OpErr, nil)
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
 		m.respondToClient(conn, p)
+		err = errors.NewErrorf("[%v],req[%v],err[%v]", p.GetOpMsgWithReqAndResult(), req, string(p.Data))
 		return
 	}
 	mp, err := m.getPartition(req.PartitionID)
 	if err != nil {
-		p.PacketErrorWithBody(proto.OpNotExistErr, nil)
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
 		m.respondToClient(conn, p)
+		err = errors.NewErrorf("[%v],req[%v],err[%v]", p.GetOpMsgWithReqAndResult(), req, string(p.Data))
 		return
 	}
 	if !m.serveProxy(conn, mp, p) {
@@ -302,14 +315,16 @@ func (m *metadataManager) opMetaUnlinkInode(conn net.Conn, p *Packet,
 	remoteAddr string) (err error) {
 	req := &UnlinkInoReq{}
 	if err = json.Unmarshal(p.Data, req); err != nil {
-		p.PacketErrorWithBody(proto.OpErr, nil)
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
 		m.respondToClient(conn, p)
+		err = errors.NewErrorf("[%v],req[%v],err[%v]", p.GetOpMsgWithReqAndResult(), req, string(p.Data))
 		return
 	}
 	mp, err := m.getPartition(req.PartitionID)
 	if err != nil {
-		p.PacketErrorWithBody(proto.OpNotExistErr, nil)
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
 		m.respondToClient(conn, p)
+		err = errors.NewErrorf("[%v],req[%v],err[%v]", p.GetOpMsgWithReqAndResult(), req, string(p.Data))
 		return
 	}
 	if !m.serveProxy(conn, mp, p) {
@@ -326,14 +341,16 @@ func (m *metadataManager) opMetaBatchUnlinkInode(conn net.Conn, p *Packet,
 	remoteAddr string) (err error) {
 	req := &BatchUnlinkInoReq{}
 	if err = json.Unmarshal(p.Data, req); err != nil {
-		p.PacketErrorWithBody(proto.OpErr, nil)
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
 		m.respondToClient(conn, p)
+		err = errors.NewErrorf("[%v],req[%v],err[%v]", p.GetOpMsgWithReqAndResult(), req, string(p.Data))
 		return
 	}
 	mp, err := m.getPartition(req.PartitionID)
 	if err != nil {
-		p.PacketErrorWithBody(proto.OpNotExistErr, nil)
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
 		m.respondToClient(conn, p)
+		err = errors.NewErrorf("[%v],req[%v],err[%v]", p.GetOpMsgWithReqAndResult(), req, string(p.Data))
 		return
 	}
 	if !m.serveProxy(conn, mp, p) {
@@ -351,14 +368,16 @@ func (m *metadataManager) opReadDir(conn net.Conn, p *Packet,
 	remoteAddr string) (err error) {
 	req := &proto.ReadDirRequest{}
 	if err = json.Unmarshal(p.Data, req); err != nil {
-		p.PacketErrorWithBody(proto.OpErr, nil)
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
 		m.respondToClient(conn, p)
+		err = errors.NewErrorf("[%v],req[%v],err[%v]", p.GetOpMsgWithReqAndResult(), req, string(p.Data))
 		return
 	}
 	mp, err := m.getPartition(req.PartitionID)
 	if err != nil {
-		p.PacketErrorWithBody(proto.OpNotExistErr, nil)
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
 		m.respondToClient(conn, p)
+		err = errors.NewErrorf("[%v],req[%v],err[%v]", p.GetOpMsgWithReqAndResult(), req, string(p.Data))
 		return
 	}
 	if !m.serveProxy(conn, mp, p) {
@@ -366,7 +385,7 @@ func (m *metadataManager) opReadDir(conn net.Conn, p *Packet,
 	}
 	err = mp.ReadDir(req, p)
 	m.respondToClient(conn, p)
-	log.LogDebugf("%s [opReadDir] req: %d - %v, resp: %v, body: %s", remoteAddr,
+	log.LogDebugf("%s [%v]req: %d - %v, resp: %v, body: %s", remoteAddr,
 		p.GetReqID(), req, p.GetResultMsg(), p.Data)
 	return
 }
@@ -375,25 +394,23 @@ func (m *metadataManager) opMetaInodeGet(conn net.Conn, p *Packet,
 	remoteAddr string) (err error) {
 	req := &InodeGetReq{}
 	if err = json.Unmarshal(p.Data, req); err != nil {
-		p.PacketErrorWithBody(proto.OpErr, nil)
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
 		m.respondToClient(conn, p)
-		err = errors.NewErrorf("[opMetaInodeGet]: %s", err.Error())
+		err = errors.NewErrorf("[opMetaInodeGet] %s, req: %s", p.GetOpMsgWithReqAndResult(), req, string(p.Data))
 		return
 	}
 	mp, err := m.getPartition(req.PartitionID)
 	if err != nil {
-		p.PacketErrorWithBody(proto.OpNotExistErr, nil)
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
 		m.respondToClient(conn, p)
-		err = errors.NewErrorf("[opMetaInodeGet] %s, req: %s", err.Error(),
-			string(p.Data))
+		err = errors.NewErrorf("[opMetaInodeGet] %s, req: %s", p.GetOpMsgWithReqAndResult(), req, string(p.Data))
 		return
 	}
 	if !m.serveProxy(conn, mp, p) {
 		return
 	}
 	if err = mp.InodeGet(req, p); err != nil {
-		err = errors.NewErrorf("[opMetaInodeGet] %s, req: %s", err.Error(),
-			string(p.Data))
+		err = errors.NewErrorf("[opMetaInodeGet] %s, req: %s", p.GetOpMsgWithReqAndResult(), req, string(p.Data))
 	}
 	m.respondToClient(conn, p)
 	log.LogDebugf("%s [opMetaInodeGet] req: %d - %v; resp: %v, body: %s",
@@ -407,14 +424,14 @@ func (m *metadataManager) opBatchMetaEvictInode(conn net.Conn, p *Packet,
 	if err = json.Unmarshal(p.Data, req); err != nil {
 		p.PacketErrorWithBody(proto.OpErr, []byte(err.Error()))
 		m.respondToClient(conn, p)
-		err = errors.NewErrorf("[opMetaEvictInode] request unmarshal: %v", err.Error())
+		err = errors.NewErrorf("[%v] request unmarshal: %v", err.Error())
 		return
 	}
 	mp, err := m.getPartition(req.PartitionID)
 	if err != nil {
-		p.PacketErrorWithBody(proto.OpNotExistErr, nil)
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
 		m.respondToClient(conn, p)
-		err = errors.NewErrorf("[opMetaEvictInode] req: %v, resp: %v", req, err.Error())
+		err = errors.NewErrorf("[%v] req: %v, resp: %v", p.GetOpMsgWithReqAndResult(), req, err.Error())
 		return
 	}
 	if !m.serveProxy(conn, mp, p) {
@@ -422,10 +439,10 @@ func (m *metadataManager) opBatchMetaEvictInode(conn net.Conn, p *Packet,
 	}
 
 	if err = mp.EvictInodeBatch(req, p); err != nil {
-		err = errors.NewErrorf("[opMetaEvictInode] req: %v, resp: %v", req, err.Error())
+		err = errors.NewErrorf("[%v] req: %v, resp: %v", p.GetOpMsgWithReqAndResult(), req, err.Error())
 	}
 	m.respondToClient(conn, p)
-	log.LogDebugf("%s [opMetaEvictInode] req: %d - %v, resp: %v, body: %s",
+	log.LogDebugf("%s [%v] req: %d - %v, resp: %v, body: %s",
 		remoteAddr, p.GetReqID(), req, p.GetResultMsg(), p.Data)
 	return
 }
@@ -434,16 +451,16 @@ func (m *metadataManager) opMetaEvictInode(conn net.Conn, p *Packet,
 	remoteAddr string) (err error) {
 	req := &proto.EvictInodeRequest{}
 	if err = json.Unmarshal(p.Data, req); err != nil {
-		p.PacketErrorWithBody(proto.OpErr, []byte(err.Error()))
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
 		m.respondToClient(conn, p)
-		err = errors.NewErrorf("[opMetaEvictInode] request unmarshal: %v", err.Error())
+		err = errors.NewErrorf("[%v] req: %v, resp: %v", p.GetOpMsgWithReqAndResult(), req, err.Error())
 		return
 	}
 	mp, err := m.getPartition(req.PartitionID)
 	if err != nil {
-		p.PacketErrorWithBody(proto.OpNotExistErr, nil)
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
 		m.respondToClient(conn, p)
-		err = errors.NewErrorf("[opMetaEvictInode] req: %v, resp: %v", req, err.Error())
+		err = errors.NewErrorf("[%v] req: %v, resp: %v", p.GetOpMsgWithReqAndResult(), req, err.Error())
 		return
 	}
 	if !m.serveProxy(conn, mp, p) {
@@ -451,10 +468,10 @@ func (m *metadataManager) opMetaEvictInode(conn net.Conn, p *Packet,
 	}
 
 	if err = mp.EvictInode(req, p); err != nil {
-		err = errors.NewErrorf("[opMetaEvictInode] req: %v, resp: %v", req, err.Error())
+		err = errors.NewErrorf("[%v] req: %v, resp: %v", p.GetOpMsgWithReqAndResult(), req, err.Error())
 	}
 	m.respondToClient(conn, p)
-	log.LogDebugf("%s [opMetaEvictInode] req: %d - %v, resp: %v, body: %s",
+	log.LogDebugf("%s [%v] req: %d - %v, resp: %v, body: %s",
 		remoteAddr, p.GetReqID(), req, p.GetResultMsg(), p.Data)
 	return
 }
@@ -463,17 +480,17 @@ func (m *metadataManager) opSetAttr(conn net.Conn, p *Packet,
 	remoteAddr string) (err error) {
 	req := &SetattrRequest{}
 	if err = json.Unmarshal(p.Data, req); err != nil {
-		p.PacketErrorWithBody(proto.OpErr, []byte(err.Error()))
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
 		m.respondToClient(conn, p)
-		err = errors.NewErrorf("[opSetAttr] req: %v, error: %v", req, err.Error())
+		err = errors.NewErrorf("[%v] req: %v, resp: %v", p.GetOpMsgWithReqAndResult(), req, err.Error())
 		return
 	}
 
 	mp, err := m.getPartition(req.PartitionID)
 	if err != nil {
-		p.PacketErrorWithBody(proto.OpErr, []byte(err.Error()))
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
 		m.respondToClient(conn, p)
-		err = errors.NewErrorf("[opSetAttr] req: %v, error: %v", req, err.Error())
+		err = errors.NewErrorf("[%v] req: %v, resp: %v", p.GetOpMsgWithReqAndResult(), req, err.Error())
 		return
 	}
 
@@ -494,14 +511,16 @@ func (m *metadataManager) opMetaLookup(conn net.Conn, p *Packet,
 	remoteAddr string) (err error) {
 	req := &proto.LookupRequest{}
 	if err = json.Unmarshal(p.Data, req); err != nil {
-		p.PacketErrorWithBody(proto.OpErr, nil)
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
 		m.respondToClient(conn, p)
+		err = errors.NewErrorf("[%v] req: %v, resp: %v", p.GetOpMsgWithReqAndResult(), req, err.Error())
 		return
 	}
 	mp, err := m.getPartition(req.PartitionID)
 	if err != nil {
-		p.PacketErrorWithBody(proto.OpNotExistErr, nil)
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
 		m.respondToClient(conn, p)
+		err = errors.NewErrorf("[%v] req: %v, resp: %v", p.GetOpMsgWithReqAndResult(), req, err.Error())
 		return
 	}
 	if !m.serveProxy(conn, mp, p) {
@@ -518,16 +537,16 @@ func (m *metadataManager) opMetaExtentsAdd(conn net.Conn, p *Packet,
 	remoteAddr string) (err error) {
 	req := &proto.AppendExtentKeyRequest{}
 	if err = json.Unmarshal(p.Data, req); err != nil {
-		p.PacketErrorWithBody(proto.OpErr, nil)
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
 		m.respondToClient(conn, p)
+		err = errors.NewErrorf("[%v] req: %v, resp: %v", p.GetOpMsgWithReqAndResult(), req, err.Error())
 		return
 	}
 	mp, err := m.getPartition(req.PartitionID)
 	if err != nil {
-		p.PacketErrorWithBody(proto.OpNotExistErr, nil)
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
 		m.respondToClient(conn, p)
-		err = errors.NewErrorf("%s, response to client: %s", err.Error(),
-			p.GetResultMsg())
+		err = errors.NewErrorf("[%v] req: %v, resp: %v", p.GetOpMsgWithReqAndResult(), req, err.Error())
 		return
 	}
 	if !m.serveProxy(conn, mp, p) {
@@ -548,14 +567,16 @@ func (m *metadataManager) opMetaExtentsList(conn net.Conn, p *Packet,
 	remoteAddr string) (err error) {
 	req := &proto.GetExtentsRequest{}
 	if err = json.Unmarshal(p.Data, req); err != nil {
-		p.PacketErrorWithBody(proto.OpErr, nil)
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
 		m.respondToClient(conn, p)
+		err = errors.NewErrorf("[%v] req: %v, resp: %v", p.GetOpMsgWithReqAndResult(), req, err.Error())
 		return
 	}
 	mp, err := m.getPartition(req.PartitionID)
 	if err != nil {
-		p.PacketErrorWithBody(proto.OpNotExistErr, nil)
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
 		m.respondToClient(conn, p)
+		err = errors.NewErrorf("[%v] req: %v, resp: %v", p.GetOpMsgWithReqAndResult(), req, err.Error())
 		return
 	}
 	if !m.serveProxy(conn, mp, p) {
@@ -578,14 +599,16 @@ func (m *metadataManager) opMetaExtentsTruncate(conn net.Conn, p *Packet,
 	remoteAddr string) (err error) {
 	req := &ExtentsTruncateReq{}
 	if err = json.Unmarshal(p.Data, req); err != nil {
-		p.PacketErrorWithBody(proto.OpErr, nil)
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
 		m.respondToClient(conn, p)
+		err = errors.NewErrorf("[%v] req: %v, resp: %v", p.GetOpMsgWithReqAndResult(), req, err.Error())
 		return
 	}
 	mp, err := m.getPartition(req.PartitionID)
 	if err != nil {
-		p.PacketErrorWithBody(proto.OpNotExistErr, nil)
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
 		m.respondToClient(conn, p)
+		err = errors.NewErrorf("[%v] req: %v, resp: %v", p.GetOpMsgWithReqAndResult(), req, err.Error())
 		return
 	}
 	if !m.serveProxy(conn, mp, p) {
@@ -610,6 +633,7 @@ func (m *metadataManager) opDeleteMetaPartition(conn net.Conn,
 	if err = decode.Decode(adminTask); err != nil {
 		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
 		m.respondToClient(conn, p)
+		err = errors.NewErrorf("[%v] req: %v, resp: %v", p.GetOpMsgWithReqAndResult(), req, err.Error())
 		return
 	}
 	mp, err := m.getPartition(req.PartitionID)
@@ -641,15 +665,17 @@ func (m *metadataManager) opUpdateMetaPartition(conn net.Conn, p *Packet,
 	decode := json.NewDecoder(bytes.NewBuffer(p.Data))
 	decode.UseNumber()
 	if err = decode.Decode(adminTask); err != nil {
-		p.PacketErrorWithBody(proto.OpErr, nil)
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
 		m.respondToClient(conn, p)
+		err = errors.NewErrorf("[%v] req: %v, resp: %v", p.GetOpMsgWithReqAndResult(), req, err.Error())
 		return
 	}
 
 	mp, err := m.getPartition(req.PartitionID)
 	if err != nil {
-		p.PacketErrorWithBody(proto.OpErr, nil)
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
 		m.respondToClient(conn, p)
+		err = errors.NewErrorf("[%v] req: %v, resp: %v", p.GetOpMsgWithReqAndResult(), req, err.Error())
 		return
 	}
 	if !m.serveProxy(conn, mp, p) {
@@ -679,14 +705,16 @@ func (m *metadataManager) opLoadMetaPartition(conn net.Conn, p *Packet,
 	decode := json.NewDecoder(bytes.NewBuffer(p.Data))
 	decode.UseNumber()
 	if err = decode.Decode(adminTask); err != nil {
-		p.PacketErrorWithBody(proto.OpErr, nil)
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
 		m.respondToClient(conn, p)
+		err = errors.NewErrorf("[%v] req: %v, resp: %v", p.GetOpMsgWithReqAndResult(), req, err.Error())
 		return
 	}
 	mp, err := m.getPartition(req.PartitionID)
 	if err != nil {
-		p.PacketErrorWithBody(proto.OpNotExistErr, nil)
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
 		m.respondToClient(conn, p)
+		err = errors.NewErrorf("[%v] req: %v, resp: %v", p.GetOpMsgWithReqAndResult(), req, err.Error())
 		return
 	}
 	if err = mp.ResponseLoadMetaPartition(p); err != nil {
@@ -715,12 +743,14 @@ func (m *metadataManager) opDecommissionMetaPartition(conn net.Conn,
 	if err = decode.Decode(adminTask); err != nil {
 		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
 		m.respondToClient(conn, p)
+		err = errors.NewErrorf("[%v] req: %v, resp: %v", p.GetOpMsgWithReqAndResult(), req, err.Error())
 		return err
 	}
 	mp, err := m.getPartition(req.PartitionID)
 	if err != nil {
 		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
 		m.respondToClient(conn, p)
+		err = errors.NewErrorf("[%v] req: %v, resp: %v", p.GetOpMsgWithReqAndResult(), req, err.Error())
 		return err
 	}
 	if !m.serveProxy(conn, mp, p) {
@@ -887,12 +917,16 @@ func (m *metadataManager) opMetaBatchInodeGet(conn net.Conn, p *Packet,
 	remoteAddr string) (err error) {
 	req := &proto.BatchInodeGetRequest{}
 	if err = json.Unmarshal(p.Data, req); err != nil {
-		p.PacketErrorWithBody(proto.OpErr, nil)
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
+		m.respondToClient(conn, p)
+		err = errors.NewErrorf("[%v] req: %v, resp: %v", p.GetOpMsgWithReqAndResult(), req, err.Error())
 		return
 	}
 	mp, err := m.getPartition(req.PartitionID)
 	if err != nil {
-		p.PacketErrorWithBody(proto.OpNotExistErr, nil)
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
+		m.respondToClient(conn, p)
+		err = errors.NewErrorf("[%v] req: %v, resp: %v", p.GetOpMsgWithReqAndResult(), req, err.Error())
 		return
 	}
 	err = mp.InodeGetBatch(req, p)
@@ -924,14 +958,16 @@ func (m *metadataManager) opMetaDeleteInode(conn net.Conn, p *Packet,
 	remoteAddr string) (err error) {
 	req := &proto.DeleteInodeRequest{}
 	if err = json.Unmarshal(p.Data, req); err != nil {
-		p.PacketErrorWithBody(proto.OpErr, []byte(err.Error()))
-		_ = m.respondToClient(conn, p)
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
+		m.respondToClient(conn, p)
+		err = errors.NewErrorf("[%v] req: %v, resp: %v", p.GetOpMsgWithReqAndResult(), req, err.Error())
 		return
 	}
 	mp, err := m.getPartition(req.PartitionId)
 	if err != nil {
-		p.PacketErrorWithBody(proto.OpNotExistErr, []byte(err.Error()))
-		_ = m.respondToClient(conn, p)
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
+		m.respondToClient(conn, p)
+		err = errors.NewErrorf("[%v] req: %v, resp: %v", p.GetOpMsgWithReqAndResult(), req, err.Error())
 		return
 	}
 	if !m.serveProxy(conn, mp, p) {
@@ -948,15 +984,17 @@ func (m *metadataManager) opMetaBatchDeleteInode(conn net.Conn, p *Packet,
 	remoteAddr string) (err error) {
 	var req *proto.DeleteInodeBatchRequest
 	if err = json.Unmarshal(p.Data, &req); err != nil {
-		p.PacketErrorWithBody(proto.OpErr, []byte(err.Error()))
-		_ = m.respondToClient(conn, p)
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
+		m.respondToClient(conn, p)
+		err = errors.NewErrorf("[%v] req: %v, resp: %v", p.GetOpMsgWithReqAndResult(), req, err.Error())
 		return
 	}
 
 	mp, err := m.getPartition(req.PartitionId)
 	if err != nil {
-		p.PacketErrorWithBody(proto.OpNotExistErr, []byte(err.Error()))
-		_ = m.respondToClient(conn, p)
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
+		m.respondToClient(conn, p)
+		err = errors.NewErrorf("[%v] req: %v, resp: %v", p.GetOpMsgWithReqAndResult(), req, err.Error())
 		return
 	}
 	if !m.serveProxy(conn, mp, p) {
@@ -974,14 +1012,16 @@ func (m *metadataManager) opMetaBatchDeleteInode(conn net.Conn, p *Packet,
 func (m *metadataManager) opMetaSetXAttr(conn net.Conn, p *Packet, remoteAddr string) (err error) {
 	req := &proto.SetXAttrRequest{}
 	if err = json.Unmarshal(p.Data, req); err != nil {
-		p.PacketErrorWithBody(proto.OpErr, []byte(err.Error()))
-		_ = m.respondToClient(conn, p)
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
+		m.respondToClient(conn, p)
+		err = errors.NewErrorf("[%v] req: %v, resp: %v", p.GetOpMsgWithReqAndResult(), req, err.Error())
 		return
 	}
 	mp, err := m.getPartition(req.PartitionId)
 	if err != nil {
-		p.PacketErrorWithBody(proto.OpNotExistErr, []byte(err.Error()))
-		_ = m.respondToClient(conn, p)
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
+		m.respondToClient(conn, p)
+		err = errors.NewErrorf("[%v] req: %v, resp: %v", p.GetOpMsgWithReqAndResult(), req, err.Error())
 		return
 	}
 	if !m.serveProxy(conn, mp, p) {
@@ -997,14 +1037,16 @@ func (m *metadataManager) opMetaSetXAttr(conn net.Conn, p *Packet, remoteAddr st
 func (m *metadataManager) opMetaGetXAttr(conn net.Conn, p *Packet, remoteAddr string) (err error) {
 	req := &proto.GetXAttrRequest{}
 	if err = json.Unmarshal(p.Data, req); err != nil {
-		p.PacketErrorWithBody(proto.OpErr, []byte(err.Error()))
-		_ = m.respondToClient(conn, p)
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
+		m.respondToClient(conn, p)
+		err = errors.NewErrorf("[%v] req: %v, resp: %v", p.GetOpMsgWithReqAndResult(), req, err.Error())
 		return
 	}
 	mp, err := m.getPartition(req.PartitionId)
 	if err != nil {
-		p.PacketErrorWithBody(proto.OpNotExistErr, []byte(err.Error()))
-		_ = m.respondToClient(conn, p)
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
+		m.respondToClient(conn, p)
+		err = errors.NewErrorf("[%v] req: %v, resp: %v", p.GetOpMsgWithReqAndResult(), req, err.Error())
 		return
 	}
 	if !m.serveProxy(conn, mp, p) {
@@ -1020,14 +1062,16 @@ func (m *metadataManager) opMetaGetXAttr(conn net.Conn, p *Packet, remoteAddr st
 func (m *metadataManager) opMetaBatchGetXAttr(conn net.Conn, p *Packet, remoteAddr string) (err error) {
 	req := &proto.BatchGetXAttrRequest{}
 	if err = json.Unmarshal(p.Data, req); err != nil {
-		p.PacketErrorWithBody(proto.OpErr, []byte(err.Error()))
-		_ = m.respondToClient(conn, p)
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
+		m.respondToClient(conn, p)
+		err = errors.NewErrorf("[%v] req: %v, resp: %v", p.GetOpMsgWithReqAndResult(), req, err.Error())
 		return
 	}
 	mp, err := m.getPartition(req.PartitionId)
 	if err != nil {
-		p.PacketErrorWithBody(proto.OpNotExistErr, []byte(err.Error()))
-		_ = m.respondToClient(conn, p)
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
+		m.respondToClient(conn, p)
+		err = errors.NewErrorf("[%v] req: %v, resp: %v", p.GetOpMsgWithReqAndResult(), req, err.Error())
 		return
 	}
 	if !m.serveProxy(conn, mp, p) {
@@ -1043,14 +1087,16 @@ func (m *metadataManager) opMetaBatchGetXAttr(conn net.Conn, p *Packet, remoteAd
 func (m *metadataManager) opMetaRemoveXAttr(conn net.Conn, p *Packet, remoteAddr string) (err error) {
 	req := &proto.RemoveXAttrRequest{}
 	if err = json.Unmarshal(p.Data, req); err != nil {
-		p.PacketErrorWithBody(proto.OpErr, []byte(err.Error()))
-		_ = m.respondToClient(conn, p)
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
+		m.respondToClient(conn, p)
+		err = errors.NewErrorf("[%v] req: %v, resp: %v", p.GetOpMsgWithReqAndResult(), req, err.Error())
 		return
 	}
 	mp, err := m.getPartition(req.PartitionId)
 	if err != nil {
-		p.PacketErrorWithBody(proto.OpNotExistErr, []byte(err.Error()))
-		_ = m.respondToClient(conn, p)
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
+		m.respondToClient(conn, p)
+		err = errors.NewErrorf("[%v] req: %v, resp: %v", p.GetOpMsgWithReqAndResult(), req, err.Error())
 		return
 	}
 	if !m.serveProxy(conn, mp, p) {
@@ -1066,14 +1112,16 @@ func (m *metadataManager) opMetaRemoveXAttr(conn net.Conn, p *Packet, remoteAddr
 func (m *metadataManager) opMetaListXAttr(conn net.Conn, p *Packet, remoteAddr string) (err error) {
 	req := &proto.ListXAttrRequest{}
 	if err = json.Unmarshal(p.Data, req); err != nil {
-		p.PacketErrorWithBody(proto.OpErr, []byte(err.Error()))
-		_ = m.respondToClient(conn, p)
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
+		m.respondToClient(conn, p)
+		err = errors.NewErrorf("[%v] req: %v, resp: %v", p.GetOpMsgWithReqAndResult(), req, err.Error())
 		return
 	}
 	mp, err := m.getPartition(req.PartitionId)
 	if err != nil {
-		p.PacketErrorWithBody(proto.OpNotExistErr, []byte(err.Error()))
-		_ = m.respondToClient(conn, p)
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
+		m.respondToClient(conn, p)
+		err = errors.NewErrorf("[%v] req: %v, resp: %v", p.GetOpMsgWithReqAndResult(), req, err.Error())
 		return
 	}
 	if !m.serveProxy(conn, mp, p) {
@@ -1089,14 +1137,16 @@ func (m *metadataManager) opMetaListXAttr(conn net.Conn, p *Packet, remoteAddr s
 func (m *metadataManager) opMetaBatchExtentsAdd(conn net.Conn, p *Packet, remoteAddr string) (err error) {
 	req := &proto.AppendExtentKeysRequest{}
 	if err = json.Unmarshal(p.Data, req); err != nil {
-		p.PacketErrorWithBody(proto.OpErr, []byte(err.Error()))
-		_ = m.respondToClient(conn, p)
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
+		m.respondToClient(conn, p)
+		err = errors.NewErrorf("[%v] req: %v, resp: %v", p.GetOpMsgWithReqAndResult(), req, err.Error())
 		return
 	}
 	mp, err := m.getPartition(req.PartitionId)
 	if err != nil {
-		p.PacketErrorWithBody(proto.OpNotExistErr, []byte(err.Error()))
-		_ = m.respondToClient(conn, p)
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
+		m.respondToClient(conn, p)
+		err = errors.NewErrorf("[%v] req: %v, resp: %v", p.GetOpMsgWithReqAndResult(), req, err.Error())
 		return
 	}
 	if !m.serveProxy(conn, mp, p) {
@@ -1112,14 +1162,16 @@ func (m *metadataManager) opMetaBatchExtentsAdd(conn net.Conn, p *Packet, remote
 func (m *metadataManager) opCreateMultipart(conn net.Conn, p *Packet, remote string) (err error) {
 	req := &proto.CreateMultipartRequest{}
 	if err = json.Unmarshal(p.Data, req); err != nil {
-		p.PacketErrorWithBody(proto.OpErr, []byte(err.Error()))
-		_ = m.respondToClient(conn, p)
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
+		m.respondToClient(conn, p)
+		err = errors.NewErrorf("[%v] req: %v, resp: %v", p.GetOpMsgWithReqAndResult(), req, err.Error())
 		return
 	}
 	mp, err := m.getPartition(req.PartitionId)
 	if err != nil {
-		p.PacketErrorWithBody(proto.OpErr, []byte(err.Error()))
-		_ = m.respondToClient(conn, p)
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
+		m.respondToClient(conn, p)
+		err = errors.NewErrorf("[%v] req: %v, resp: %v", p.GetOpMsgWithReqAndResult(), req, err.Error())
 		return
 	}
 	if !m.serveProxy(conn, mp, p) {
@@ -1132,15 +1184,18 @@ func (m *metadataManager) opCreateMultipart(conn net.Conn, p *Packet, remote str
 
 func (m *metadataManager) opRemoveMultipart(conn net.Conn, p *Packet, remote string) (err error) {
 	req := &proto.RemoveMultipartRequest{}
+
 	if err = json.Unmarshal(p.Data, req); err != nil {
-		p.PacketErrorWithBody(proto.OpErr, []byte(err.Error()))
-		_ = m.respondToClient(conn, p)
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
+		m.respondToClient(conn, p)
+		err = errors.NewErrorf("[%v] req: %v, resp: %v", p.GetOpMsgWithReqAndResult(), req, err.Error())
 		return
 	}
 	mp, err := m.getPartition(req.PartitionId)
 	if err != nil {
-		p.PacketErrorWithBody(proto.OpErr, []byte(err.Error()))
-		_ = m.respondToClient(conn, p)
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
+		m.respondToClient(conn, p)
+		err = errors.NewErrorf("[%v] req: %v, resp: %v", p.GetOpMsgWithReqAndResult(), req, err.Error())
 		return
 	}
 	if !m.serveProxy(conn, mp, p) {
@@ -1154,14 +1209,16 @@ func (m *metadataManager) opRemoveMultipart(conn net.Conn, p *Packet, remote str
 func (m *metadataManager) opGetMultipart(conn net.Conn, p *Packet, remote string) (err error) {
 	req := &proto.GetMultipartRequest{}
 	if err = json.Unmarshal(p.Data, req); err != nil {
-		p.PacketErrorWithBody(proto.OpErr, []byte(err.Error()))
-		_ = m.respondToClient(conn, p)
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
+		m.respondToClient(conn, p)
+		err = errors.NewErrorf("[opGetMultipart] req: %v, resp: %v", req, err.Error())
 		return
 	}
 	mp, err := m.getPartition(req.PartitionId)
 	if err != nil {
-		p.PacketErrorWithBody(proto.OpErr, []byte(err.Error()))
-		_ = m.respondToClient(conn, p)
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
+		m.respondToClient(conn, p)
+		err = errors.NewErrorf("[opGetMultipart] req: %v, resp: %v", req, err.Error())
 		return
 	}
 	if !m.serveProxy(conn, mp, p) {
@@ -1197,14 +1254,16 @@ func (m *metadataManager) opAppendMultipart(conn net.Conn, p *Packet, remote str
 func (m *metadataManager) opListMultipart(conn net.Conn, p *Packet, remote string) (err error) {
 	req := &proto.ListMultipartRequest{}
 	if err = json.Unmarshal(p.Data, req); err != nil {
-		p.PacketErrorWithBody(proto.OpErr, []byte(err.Error()))
-		_ = m.respondToClient(conn, p)
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
+		m.respondToClient(conn, p)
+		err = errors.NewErrorf("[opListMultipart] req: %v, resp: %v", req, err.Error())
 		return
 	}
 	mp, err := m.getPartition(req.PartitionId)
 	if err != nil {
-		p.PacketErrorWithBody(proto.OpErr, []byte(err.Error()))
-		_ = m.respondToClient(conn, p)
+		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
+		m.respondToClient(conn, p)
+		err = errors.NewErrorf("[opListMultipart] req: %v, resp: %v", req, err.Error())
 		return
 	}
 	if !m.serveProxy(conn, mp, p) {

--- a/metanode/manager_op.go
+++ b/metanode/manager_op.go
@@ -194,7 +194,7 @@ func (m *metadataManager) opFreeInodeOnRaftFollower(conn net.Conn, p *Packet,
 	if err != nil {
 		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
 		m.respondToClient(conn, p)
-		err = errors.NewErrorf("[%v],req[%v],err[%v]", p.GetOpMsgWithReqAndResult(), string(p.Data))
+		err = errors.NewErrorf("[%v],err[%v]", p.GetOpMsgWithReqAndResult(), string(p.Data))
 		return
 	}
 	mp.(*metaPartition).internalDelete(p.Data[:p.Size])
@@ -385,7 +385,7 @@ func (m *metadataManager) opReadDir(conn net.Conn, p *Packet,
 	}
 	err = mp.ReadDir(req, p)
 	m.respondToClient(conn, p)
-	log.LogDebugf("%s [%v]req: %d - %v, resp: %v, body: %s", remoteAddr,
+	log.LogDebugf("%s [%v]req: %v , resp: %v, body: %s", remoteAddr,
 		p.GetReqID(), req, p.GetResultMsg(), p.Data)
 	return
 }
@@ -396,21 +396,21 @@ func (m *metadataManager) opMetaInodeGet(conn net.Conn, p *Packet,
 	if err = json.Unmarshal(p.Data, req); err != nil {
 		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
 		m.respondToClient(conn, p)
-		err = errors.NewErrorf("[opMetaInodeGet] %s, req: %s", p.GetOpMsgWithReqAndResult(), req, string(p.Data))
+		err = errors.NewErrorf("[%v],req[%v],err[%v]", p.GetOpMsgWithReqAndResult(), req, string(p.Data))
 		return
 	}
 	mp, err := m.getPartition(req.PartitionID)
 	if err != nil {
 		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))
 		m.respondToClient(conn, p)
-		err = errors.NewErrorf("[opMetaInodeGet] %s, req: %s", p.GetOpMsgWithReqAndResult(), req, string(p.Data))
+		err = errors.NewErrorf("[%v],req[%v],err[%v]", p.GetOpMsgWithReqAndResult(), req, string(p.Data))
 		return
 	}
 	if !m.serveProxy(conn, mp, p) {
 		return
 	}
 	if err = mp.InodeGet(req, p); err != nil {
-		err = errors.NewErrorf("[opMetaInodeGet] %s, req: %s", p.GetOpMsgWithReqAndResult(), req, string(p.Data))
+		err = errors.NewErrorf("[%v],req[%v],err[%v]", p.GetOpMsgWithReqAndResult(), req, string(p.Data))
 	}
 	m.respondToClient(conn, p)
 	log.LogDebugf("%s [opMetaInodeGet] req: %d - %v; resp: %v, body: %s",
@@ -424,7 +424,7 @@ func (m *metadataManager) opBatchMetaEvictInode(conn net.Conn, p *Packet,
 	if err = json.Unmarshal(p.Data, req); err != nil {
 		p.PacketErrorWithBody(proto.OpErr, []byte(err.Error()))
 		m.respondToClient(conn, p)
-		err = errors.NewErrorf("[%v] request unmarshal: %v", err.Error())
+		err = errors.NewErrorf("[%v] request unmarshal: %v", p.GetOpMsgWithReqAndResult(),err.Error())
 		return
 	}
 	mp, err := m.getPartition(req.PartitionID)
@@ -442,7 +442,7 @@ func (m *metadataManager) opBatchMetaEvictInode(conn net.Conn, p *Packet,
 		err = errors.NewErrorf("[%v] req: %v, resp: %v", p.GetOpMsgWithReqAndResult(), req, err.Error())
 	}
 	m.respondToClient(conn, p)
-	log.LogDebugf("%s [%v] req: %d - %v, resp: %v, body: %s",
+	log.LogDebugf("%s [opBatchMetaEvictInode] req: %d - %v, resp: %v, body: %s",
 		remoteAddr, p.GetReqID(), req, p.GetResultMsg(), p.Data)
 	return
 }
@@ -471,7 +471,7 @@ func (m *metadataManager) opMetaEvictInode(conn net.Conn, p *Packet,
 		err = errors.NewErrorf("[%v] req: %v, resp: %v", p.GetOpMsgWithReqAndResult(), req, err.Error())
 	}
 	m.respondToClient(conn, p)
-	log.LogDebugf("%s [%v] req: %d - %v, resp: %v, body: %s",
+	log.LogDebugf("%s [opMetaEvictInode] req: %d - %v, resp: %v, body: %s",
 		remoteAddr, p.GetReqID(), req, p.GetResultMsg(), p.Data)
 	return
 }

--- a/metanode/partition_delete_extents.go
+++ b/metanode/partition_delete_extents.go
@@ -33,21 +33,42 @@ import (
 
 const (
 	prefixDelExtent     = "EXTENT_DEL"
+	prefixDelExtentV2   = "EXTENT_DEL_V2"
 	maxDeleteExtentSize = 10 * MB
 )
 
 var extentsFileHeader = []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x08}
 
+/// start metapartition delete extents work
+///
 func (mp *metaPartition) startToDeleteExtents() {
 	fileList := synclist.New()
 	go mp.appendDelExtentsToFile(fileList)
 	go mp.deleteExtentsFromList(fileList)
 }
 
+// create extent delete file
+func (mp *metaPartition) createExtentDeleteFile(prefix string, idx int64, fileList *synclist.SyncList) (fp *os.File, fileName string, fileSize int64, err error) {
+	fileName = fmt.Sprintf("%s_%d", prefix, idx)
+	fp, err = os.OpenFile(path.Join(mp.config.RootDir, fileName),
+		os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		log.LogErrorf("[metaPartition] createExtentDeletFile openFile %v %v error %v", mp.config.RootDir, fileName, err)
+		return
+	}
+	if _, err = fp.Write(extentsFileHeader); err != nil {
+		log.LogErrorf("[metaPartition] createExtentDeletFile Write %v %v error %v", mp.config.RootDir, fileName, err)
+	}
+	fileSize = int64(len(extentsFileHeader))
+	fileList.PushBack(fileName)
+	return
+}
+
+//append delete extents from extDelCh to EXTENT_DEL_N files
 func (mp *metaPartition) appendDelExtentsToFile(fileList *synclist.SyncList) {
 	defer func() {
 		if r := recover(); r != nil {
-			log.LogErrorf(fmt.Sprintf("appendDelExtentsToFile(%v) appendDelExtentsToFile panic (%v)", mp.config.PartitionId, r))
+			log.LogErrorf(fmt.Sprintf("[metaPartition] appendDelExtentsToFile pid(%v) panic (%v)", mp.config.PartitionId, r))
 		}
 	}()
 	var (
@@ -58,6 +79,7 @@ func (mp *metaPartition) appendDelExtentsToFile(fileList *synclist.SyncList) {
 		err      error
 	)
 LOOP:
+	// scan existed EXTENT_DEL_* files to fill fileList
 	finfos, err := ioutil.ReadDir(mp.config.RootDir)
 	if err != nil {
 		panic(err)
@@ -68,24 +90,27 @@ LOOP:
 			fileSize = info.Size()
 		}
 	}
+	// check
 	lastItem := fileList.Back()
 	if lastItem == nil {
-		fileName = fmt.Sprintf("%s_%d", prefixDelExtent, idx)
-		fp, err = os.OpenFile(path.Join(mp.config.RootDir, fileName),
-			os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+		//if no exist EXTENT_DEL_*, create one
+		fp, fileName, fileSize, err = mp.createExtentDeleteFile(prefixDelExtentV2, idx, fileList)
 		if err != nil {
 			panic(err)
 		}
-		// TODO Unhandled errors
-		fp.Write(extentsFileHeader)
-		fileList.PushBack(fileName)
 	} else {
+		//exist, open last file
 		fileName = lastItem.Value.(string)
 		fp, err = os.OpenFile(path.Join(mp.config.RootDir, fileName),
 			os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
 		if err != nil {
 			panic(err)
 		}
+	}
+
+	extentV2 := false
+	if strings.HasPrefix(fileName, prefixDelExtentV2) {
+		extentV2 = true
 	}
 
 	// TODO Unhandled errors
@@ -105,7 +130,11 @@ LOOP:
 			var data []byte
 			buf = buf[:0]
 			for _, ek := range eks {
-				data, err = ek.MarshalBinary()
+				if extentV2 {
+					data, err = ek.MarshalBinaryWithCheckSum()
+				} else {
+					data, err = ek.MarshalBinary()
+				}
 				if err != nil {
 					log.LogWarnf("[appendDelExtentsToFile] partitionId=%d,"+
 						" extentKey marshal: %s", mp.config.PartitionId, err.Error())
@@ -122,26 +151,18 @@ LOOP:
 				// close old File
 				fp.Close()
 				idx += 1
-				fileName = fmt.Sprintf("%s_%d", prefixDelExtent, idx)
-				fp, err = os.OpenFile(path.Join(mp.config.RootDir, fileName),
-					os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+				fp, fileName, fileSize, err = mp.createExtentDeleteFile(prefixDelExtentV2, idx, fileList)
 				if err != nil {
 					panic(err)
 				}
-				if _, err = fp.Write(extentsFileHeader); err != nil {
-					panic(err)
-				}
-				fileSize = 8
-				fileList.PushBack(fileName)
 			}
-			// write file
+			// write delete extents into file
 			if _, err = fp.Write(buf); err != nil {
 				panic(err)
 			}
 			fileSize += int64(len(buf))
 		}
 	}
-
 }
 
 // Delete all the extents of a file.
@@ -177,11 +198,15 @@ func (mp *metaPartition) deleteExtentsFromList(fileList *synclist.SyncList) {
 			fileList.Remove(element)
 			goto LOOP
 		}
+		//if not leader, ignore delete
 		if _, ok := mp.IsLeader(); !ok {
 			log.LogDebugf("[deleteExtentsFromList] partitionId=%d, "+
 				"not raft leader,please ignore", mp.config.PartitionId)
 			continue
 		}
+		//leader do delete extent for EXTENT_DEL_* file
+
+		// read delete extents from file
 		buf := make([]byte, MB)
 		fp, err := os.OpenFile(file, os.O_RDWR, 0644)
 		if err != nil {
@@ -190,6 +215,7 @@ func (mp *metaPartition) deleteExtentsFromList(fileList *synclist.SyncList) {
 			goto LOOP
 		}
 
+		//get delete extents cursor at file header 8 bytes
 		if _, err = fp.ReadAt(buf[:8], 0); err != nil {
 			log.LogWarnf("[deleteExtentsFromList] partitionId=%d, "+
 				"read cursor least 8bytes, retry later", mp.config.PartitionId)
@@ -197,11 +223,17 @@ func (mp *metaPartition) deleteExtentsFromList(fileList *synclist.SyncList) {
 			fp.Close()
 			continue
 		}
+		extentV2 := false
+		extentKeyLen := uint64(proto.ExtentLength)
+		if strings.HasPrefix(fileName, prefixDelExtentV2) {
+			extentV2 = true
+			extentKeyLen = uint64(proto.ExtentV2Length)
+		}
 		cursor := binary.BigEndian.Uint64(buf[:8])
 		if size := uint64(fileInfo.Size()) - cursor; size < MB {
 			if size <= 0 {
-				size = uint64(proto.ExtentLength)
-			} else if size > 0 && size < uint64(proto.ExtentLength) {
+				size = extentKeyLen
+			} else if size > 0 && size < extentKeyLen {
 				errStr := fmt.Sprintf(
 					"[deleteExtentsFromList] partitionId=%d, %s file corrupted!",
 					mp.config.PartitionId, fileName)
@@ -212,37 +244,36 @@ func (mp *metaPartition) deleteExtentsFromList(fileList *synclist.SyncList) {
 			}
 			buf = buf[:size]
 		}
+		//read extents from cursor
 		n, err := fp.ReadAt(buf, int64(cursor))
 		// TODO Unhandled errors
 		fp.Close()
-		if err != nil {
-			if err == io.EOF {
-				err = nil
-				if fileList.Len() > 1 {
-					status := mp.raftPartition.Status()
-					if status.State == "StateLeader" && !status.
-						RestoringSnapshot {
-						if _, err = mp.submit(opFSMInternalDelExtentFile,
-							[]byte(fileName)); err != nil {
-							log.LogErrorf(
-								"[deleteExtentsFromList] partitionId=%d,"+
-									"delete old file: %s,status: %s", mp.config.PartitionId,
-								fileName, err.Error())
-						}
-						log.LogDebugf("[deleteExtentsFromList] partitionId=%d "+
-							",delete old file: %s, status: %v", mp.config.PartitionId, fileName,
-							err == nil)
-						goto LOOP
-					}
-					log.LogDebugf("[deleteExtentsFromList] partitionId=%d,delete"+
-						" old file status: %s", mp.config.PartitionId, status.State)
-				} else {
-					log.LogDebugf("[deleteExtentsFromList] partitionId=%d, %s"+
-						" extents delete ok", mp.config.PartitionId, fileName)
-				}
-				continue
-			}
+		if err != nil && err != io.EOF {
 			panic(err)
+		} else if err == io.EOF {
+			err = nil
+			if fileList.Len() <= 1 {
+				log.LogDebugf("[deleteExtentsFromList] partitionId=%d, %s"+
+					" extents delete ok", mp.config.PartitionId, fileName)
+			} else {
+				status := mp.raftPartition.Status()
+				if status.State == "StateLeader" && !status.RestoringSnapshot {
+					// delete old delete extents file for metapartition
+					if _, err = mp.submit(opFSMInternalDelExtentFile, []byte(fileName)); err != nil {
+						log.LogErrorf(
+							"[deleteExtentsFromList] partitionId=%d,"+
+								"delete old file: %s,status: %s", mp.config.PartitionId,
+							fileName, err.Error())
+					}
+					log.LogDebugf("[deleteExtentsFromList] partitionId=%d "+
+						",delete old file: %s, status: %v", mp.config.PartitionId, fileName,
+						err == nil)
+					goto LOOP
+				}
+				log.LogDebugf("[deleteExtentsFromList] partitionId=%d,delete"+
+					" old file status: %s", mp.config.PartitionId, status.State)
+			}
+			continue
 		}
 		buff := bytes.NewBuffer(buf)
 		cursor += uint64(n)
@@ -251,13 +282,22 @@ func (mp *metaPartition) deleteExtentsFromList(fileList *synclist.SyncList) {
 			if buff.Len() == 0 {
 				break
 			}
-			if buff.Len() < proto.ExtentLength {
+			if uint64(buff.Len()) < extentKeyLen {
 				cursor -= uint64(buff.Len())
 				break
 			}
 			ek := new(proto.ExtentKey)
-			if err = ek.UnmarshalBinary(buff); err != nil {
-				panic(err)
+			if extentV2 {
+				if err = ek.UnmarshalBinaryWithCheckSum(buff); err != nil {
+					if err == proto.InvalidKeyHeader {
+						log.LogErrorf("[deleteExtentsFromList] invalid extent key header %v, %v, %v", fileName, mp.config.PartitionId, err)
+					}
+					panic(err)
+				}
+			} else {
+				if err = ek.UnmarshalBinary(buff); err != nil {
+					panic(err)
+				}
 			}
 			extents, ok := allExtents[ek.PartitionId]
 			if !ok {
@@ -281,7 +321,7 @@ func (mp *metaPartition) deleteExtentsFromList(fileList *synclist.SyncList) {
 
 func (mp *metaPartition) checkBatchDeleteExtents(allExtents map[uint64][]*proto.ExtentKey) {
 	for partitionID, deleteExtents := range allExtents {
-		needDeleteExtents:=make([]proto.ExtentKey,len(deleteExtents))
+		needDeleteExtents := make([]proto.ExtentKey, len(deleteExtents))
 		for index, ek := range deleteExtents {
 			newEx := proto.ExtentKey{
 				FileOffset:   ek.FileOffset,
@@ -292,7 +332,7 @@ func (mp *metaPartition) checkBatchDeleteExtents(allExtents map[uint64][]*proto.
 				CRC:          ek.CRC,
 			}
 			needDeleteExtents[index] = newEx
-			log.LogWritef("mp(%v) deleteExtents(%v)",mp.config.PartitionId,newEx.String())
+			log.LogWritef("mp(%v) deleteExtents(%v)", mp.config.PartitionId, newEx.String())
 		}
 		err := mp.doBatchDeleteExtentsByPartition(partitionID, deleteExtents)
 		if err != nil {

--- a/metanode/partition_delete_extents.go
+++ b/metanode/partition_delete_extents.go
@@ -289,9 +289,11 @@ func (mp *metaPartition) deleteExtentsFromList(fileList *synclist.SyncList) {
 			ek := new(proto.ExtentKey)
 			if extentV2 {
 				if err = ek.UnmarshalBinaryWithCheckSum(buff); err != nil {
-					if err == proto.InvalidKeyHeader {
+					if err == proto.InvalidKeyHeader || err == proto.InvalidKeyCheckSum {
 						log.LogErrorf("[deleteExtentsFromList] invalid extent key header %v, %v, %v", fileName, mp.config.PartitionId, err)
+						continue
 					}
+					log.LogErrorf("[deleteExtentsFromList] mp: %v Unmarshal extentkey from %v unresolved error: %v", mp.config.PartitionId, fileName, err)
 					panic(err)
 				}
 			} else {

--- a/metanode/partition_delete_extents.go
+++ b/metanode/partition_delete_extents.go
@@ -292,6 +292,7 @@ func (mp *metaPartition) checkBatchDeleteExtents(allExtents map[uint64][]*proto.
 				CRC:          ek.CRC,
 			}
 			needDeleteExtents[index] = newEx
+			log.LogWritef("mp(%v) deleteExtents(%v)",mp.config.PartitionId,newEx.String())
 		}
 		err := mp.doBatchDeleteExtentsByPartition(partitionID, deleteExtents)
 		if err != nil {

--- a/metanode/partition_delete_extents.go
+++ b/metanode/partition_delete_extents.go
@@ -311,7 +311,7 @@ func (mp *metaPartition) deleteExtentsFromList(fileList *synclist.SyncList) {
 				eks = append(eks, ek)
 				mp.extDelCh <- eks
 				log.LogWarnf("[deleteExtentsFromList] mp: %v, extent: %v, %s",
-					ek, err.Error())
+					mp.config.PartitionId,ek, err.Error())
 			}
 			deleteCnt++
 		}

--- a/metanode/partition_free_list.go
+++ b/metanode/partition_free_list.go
@@ -212,7 +212,7 @@ func (mp *metaPartition) deleteMarkedInodes(inoSlice []uint64) {
 				exts = make([]*proto.ExtentKey, 0)
 			}
 			exts = append(exts, ext)
-			log.LogWritef("mp(%v) ino(%v) deleteExtent(%v)",mp.config.PartitionId,inode.Inode,ext.String())
+			log.LogWritef("mp(%v) ino(%v) deleteExtent(%v)", mp.config.PartitionId, inode.Inode, ext.String())
 			deleteExtentsByPartition[ext.PartitionId] = exts
 			return true
 		})

--- a/metanode/partition_free_list.go
+++ b/metanode/partition_free_list.go
@@ -212,6 +212,7 @@ func (mp *metaPartition) deleteMarkedInodes(inoSlice []uint64) {
 				exts = make([]*proto.ExtentKey, 0)
 			}
 			exts = append(exts, ext)
+			log.LogWritef("mp(%v) ino(%v) deleteExtent(%v)",mp.config.PartitionId,inode.Inode,ext.String())
 			deleteExtentsByPartition[ext.PartitionId] = exts
 			return true
 		})

--- a/metanode/partition_fsmop.go
+++ b/metanode/partition_fsmop.go
@@ -167,6 +167,7 @@ func (mp *metaPartition) delOldExtentFile(buf []byte) (err error) {
 	return
 }
 
+//
 func (mp *metaPartition) setExtentDeleteFileCursor(buf []byte) (err error) {
 	str := string(buf)
 	var (

--- a/metanode/partition_item.go
+++ b/metanode/partition_item.go
@@ -163,6 +163,9 @@ func newMetaItemIterator(mp *metaPartition) (si *MetaItemIterator, err error) {
 		if !fileInfo.IsDir() && strings.HasPrefix(fileInfo.Name(), prefixDelExtent) {
 			filenames = append(filenames, fileInfo.Name())
 		}
+		if !fileInfo.IsDir() && strings.HasPrefix(fileInfo.Name(), prefixDelExtentV2) {
+			filenames = append(filenames, fileInfo.Name())
+		}
 	}
 	si.filenames = filenames
 

--- a/proto/admin_proto.go
+++ b/proto/admin_proto.go
@@ -73,6 +73,8 @@ const (
 	DecommissionMetaNode           = "/metaNode/decommission"
 	GetMetaNode                    = "/metaNode/get"
 	AdminUpdateMetaNode            = "/metaNode/update"
+	AdminUpdateDataNode            = "/dataNode/update"
+	AdminGetInvalidNodes           = "/invalid/nodes"
 	AdminLoadMetaPartition         = "/metaPartition/load"
 	AdminDiagnoseMetaPartition     = "/metaPartition/diagnose"
 	AdminDecommissionMetaPartition = "/metaPartition/decommission"

--- a/proto/admin_proto.go
+++ b/proto/admin_proto.go
@@ -72,6 +72,7 @@ const (
 	AddMetaNode                    = "/metaNode/add"
 	DecommissionMetaNode           = "/metaNode/decommission"
 	GetMetaNode                    = "/metaNode/get"
+	AdminUpdateMetaNode            = "/metaNode/update"
 	AdminLoadMetaPartition         = "/metaPartition/load"
 	AdminDiagnoseMetaPartition     = "/metaPartition/diagnose"
 	AdminDecommissionMetaPartition = "/metaPartition/decommission"

--- a/proto/extent_key.go
+++ b/proto/extent_key.go
@@ -19,13 +19,21 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"hash/crc32"
 
 	"github.com/chubaofs/chubaofs/util/btree"
+	"github.com/chubaofs/chubaofs/util/log"
 )
 
 var (
-	ExtentLength = 40
-	InvalidKey   = errors.New("invalid key error")
+	ExtentKeyHeader       = []byte("EKV2")
+	ExtentKeyHeaderSize   = len(ExtentKeyHeader)
+	ExtentLength          = 40
+	ExtentKeyChecksumSize = 4
+	ExtentV2Length        = ExtentKeyHeaderSize + ExtentLength + ExtentKeyChecksumSize
+	InvalidKey            = errors.New("invalid key error")
+	InvalidKeyHeader      = errors.New("invalid extent v2 key header error")
+	InvalidKeyCheckSum    = errors.New("invalid extent v2 key checksum error")
 )
 
 // ExtentKey defines the extent key struct.
@@ -102,6 +110,88 @@ func (k *ExtentKey) UnmarshalBinary(buf *bytes.Buffer) (err error) {
 	if err = binary.Read(buf, binary.BigEndian, &k.CRC); err != nil {
 		return
 	}
+	return
+}
+
+func (k *ExtentKey) CheckSum() uint32 {
+	sign := crc32.NewIEEE()
+	buf, err := k.MarshalBinary()
+	if err != nil {
+		log.LogErrorf("[ExtentKey] extentKey %v CRC32 error: %v", k, err)
+		return 0
+	}
+	sign.Write(buf)
+
+	return sign.Sum32()
+}
+
+// marshal extentkey to []bytes with v2 of magic head
+func (k *ExtentKey) MarshalBinaryWithCheckSum() ([]byte, error) {
+	buf := bytes.NewBuffer(make([]byte, 0, ExtentV2Length))
+	if err := binary.Write(buf, binary.BigEndian, ExtentKeyHeader); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(buf, binary.BigEndian, k.FileOffset); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(buf, binary.BigEndian, k.PartitionId); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(buf, binary.BigEndian, k.ExtentId); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(buf, binary.BigEndian, k.ExtentOffset); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(buf, binary.BigEndian, k.Size); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(buf, binary.BigEndian, k.CRC); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(buf, binary.BigEndian, k.CheckSum()); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// unmarshal extentkey from bytes.Buffer with checksum
+func (k *ExtentKey) UnmarshalBinaryWithCheckSum(buf *bytes.Buffer) (err error) {
+	var checksum uint32
+	magic := make([]byte, ExtentKeyHeaderSize)
+	if err = binary.Read(buf, binary.BigEndian, magic); err != nil {
+		return
+	}
+	if r := bytes.Compare(magic, ExtentKeyHeader); r != 0 {
+		err = InvalidKeyHeader
+		return
+	}
+	if err = binary.Read(buf, binary.BigEndian, &k.FileOffset); err != nil {
+		return
+	}
+	if err = binary.Read(buf, binary.BigEndian, &k.PartitionId); err != nil {
+		return
+	}
+	if err = binary.Read(buf, binary.BigEndian, &k.ExtentId); err != nil {
+		return
+	}
+	if err = binary.Read(buf, binary.BigEndian, &k.ExtentOffset); err != nil {
+		return
+	}
+	if err = binary.Read(buf, binary.BigEndian, &k.Size); err != nil {
+		return
+	}
+	if err = binary.Read(buf, binary.BigEndian, &k.CRC); err != nil {
+		return
+	}
+	if err = binary.Read(buf, binary.BigEndian, &checksum); err != nil {
+		return
+	}
+	if k.CheckSum() != checksum {
+		err = InvalidKeyCheckSum
+		return
+	}
+
 	return
 }
 

--- a/proto/packet.go
+++ b/proto/packet.go
@@ -228,6 +228,10 @@ func (p *Packet) GetStoreType() (m string) {
 	return
 }
 
+func (p *Packet) GetOpMsgWithReqAndResult() (m string) {
+	return fmt.Sprintf("Req(%v)_(%v)_Result(%v)", p.ReqID, p.GetOpMsg(), p.GetResultMsg())
+}
+
 // GetOpMsg returns the operation type.
 func (p *Packet) GetOpMsg() (m string) {
 	switch p.Opcode {

--- a/vendor/github.com/tiglabs/raft/raft.go
+++ b/vendor/github.com/tiglabs/raft/raft.go
@@ -331,7 +331,9 @@ func (s *raft) run() {
 				}
 				s.maybeChange(respErr)
 			} else if logger.IsEnableWarn() && m.Type != proto.RespMsgHeartBeat {
-				logger.Warn("[raft][%v term: %d] ignored a %s message without the replica from [%v term: %d].", s.raftFsm.id, s.raftFsm.term, m.Type, m.From, m.Term)
+				logger.Warn(" [raft] [%v term: %d] raftFm[%p] raftReplicas[%v] ignored a %s message " +
+					"without the replica from [%v term: %d].",
+					s.raftFsm.id, s.raftFsm.term,s.raftFsm,s.raftFsm.getReplicas(), m.Type, m.From, m.Term)
 			}
 
 		case snapReq := <-s.snapRecvc:

--- a/vendor/github.com/tiglabs/raft/raft_fsm.go
+++ b/vendor/github.com/tiglabs/raft/raft_fsm.go
@@ -57,6 +57,13 @@ type raftFsm struct {
 	stopCh      chan struct{}
 }
 
+func (fsm *raftFsm)getReplicas()(m string) {
+	for id,_:=range fsm.replicas{
+		m+=fmt.Sprintf(" [%v] ,",id)
+	}
+	return  m
+}
+
 func newRaftFsm(config *Config, raftConfig *RaftConfig) (*raftFsm, error) {
 	raftlog, err := newRaftLog(raftConfig.Storage)
 	if err != nil {

--- a/vendor/github.com/tiglabs/raft/raft_fsm_candidate.go
+++ b/vendor/github.com/tiglabs/raft/raft_fsm_candidate.go
@@ -114,7 +114,8 @@ func (r *raftFsm) campaign(force bool) {
 		}
 		li, lt := r.raftLog.lastIndexAndTerm()
 		if logger.IsEnableDebug() {
-			logger.Debug("[raft->campaign][%v logterm: %d, index: %d] sent vote request to %v at term %d.", r.id, lt, li, id, r.term)
+			logger.Debug("[raft->campaign][%v logterm: %d, index: %d] sent " +
+				"vote request to %v at term %d.   raftFSM[%p]", r.id, lt, li, id, r.term,r)
 		}
 
 		m := proto.GetMessage()


### PR DESCRIPTION
**What this PR does / why we need it**:
1. Add log on raftFSM ignored mesg 
2. Modify warn message when the difference used usage between all…
3. Check whether the used space between the replicas is consistent when performing the load partition operation
4. Persist `isRecover` status to rocksDB
5. Connection pool with connect timeout
6. Provide update datanode API and check invalid nodes API
7. Update invalid extentKey unmarsharl error
8. Add extentKey header into `EXTENT_DEL` file with checksum verification process.
9. Modify metanode log 
10. MetaMode uses `handleMarkDeleteExtent` command to delete extent if it is a truncate extent.

**Which issue this PR fixes**:
None.

**Special notes for your reviewer**:
None.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```