### PR TITLE
Refactor: datanode syncTinyDeleteRecordFromLeader limit to 5 on every

### DIFF
--- a/datanode/disk.go
+++ b/datanode/disk.go
@@ -56,10 +56,15 @@ type Disk struct {
 	Status        int // disk status such as READONLY
 	ReservedSpace uint64
 
-	RejectWrite  bool
-	partitionMap map[uint64]*DataPartition
-	space        *SpaceManager
+	RejectWrite                               bool
+	partitionMap                              map[uint64]*DataPartition
+	syncTinyDeleteRecordFromLeaderOnEveryDisk chan bool
+	space                                     *SpaceManager
 }
+
+const (
+	SyncTinyDeleteRecordFromLeaderOnEveryDisk = 5
+)
 
 type PartitionVisitor func(dp *DataPartition)
 
@@ -71,6 +76,7 @@ func NewDisk(path string, reservedSpace uint64, maxErrCnt int, space *SpaceManag
 	d.RejectWrite = false
 	d.space = space
 	d.partitionMap = make(map[uint64]*DataPartition)
+	d.syncTinyDeleteRecordFromLeaderOnEveryDisk = make(chan bool, SyncTinyDeleteRecordFromLeaderOnEveryDisk)
 	d.computeUsage()
 	d.updateSpaceInfo()
 	d.startScheduleToUpdateSpaceInfo()


### PR DESCRIPTION
Refactor: datanode syncTinyDeleteRecordFromLeader limit to 5 on every disk

Signed-off-by: awzhgw <guowl18702995996@gmail.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Refactor: datanode syncTinyDeleteRecordFromLeader limit to 5 on every

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
