### PR TITLE
Fix: if metanode or datanode id has multi,then use min node id to overwrite 

### DIFF
--- a/master/metadata_fsm_op.go
+++ b/master/metadata_fsm_op.go
@@ -682,6 +682,12 @@ func (c *Cluster) loadMetaPartitions() (err error) {
 			Warn(c.Name, fmt.Sprintf("action[loadMetaPartitions] has duplicate vol[%v],vol.ID[%v],mpv.VolID[%v]", mpv.VolName, vol.ID, mpv.VolID))
 			continue
 		}
+		for i:=0;i<len(mpv.Peers);i++{
+			mn,ok:=c.metaNodes.Load(mpv.Peers[i].Addr)
+			if ok && mn.(*MetaNode).ID!=mpv.Peers[i].ID {
+				mpv.Peers[i].ID=mn.(*MetaNode).ID
+			}
+		}
 		mp := newMetaPartition(mpv.PartitionID, mpv.Start, mpv.End, vol.mpReplicaNum, vol.Name, mpv.VolID)
 		mp.setHosts(strings.Split(mpv.Hosts, underlineSeparator))
 		mp.setPeers(mpv.Peers)
@@ -713,6 +719,12 @@ func (c *Cluster) loadDataPartitions() (err error) {
 		if vol.ID != dpv.VolID {
 			Warn(c.Name, fmt.Sprintf("action[loadDataPartitions] has duplicate vol[%v],vol.ID[%v],mpv.VolID[%v]", dpv.VolName, vol.ID, dpv.VolID))
 			continue
+		}
+		for i:=0;i<len(dpv.Peers);i++{
+			dn,ok:=c.dataNodes.Load(dpv.Peers[i].Addr)
+			if ok && dn.(*DataNode).ID!=dpv.Peers[i].ID {
+				dpv.Peers[i].ID=dn.(*DataNode).ID
+			}
 		}
 		dp := newDataPartition(dpv.PartitionID, dpv.ReplicaNum, dpv.VolName, dpv.VolID)
 		dp.Hosts = strings.Split(dpv.Hosts, underlineSeparator)

--- a/master/metadata_fsm_op.go
+++ b/master/metadata_fsm_op.go
@@ -598,8 +598,14 @@ func (c *Cluster) loadDataNodes() (err error) {
 		dataNode := newDataNode(dnv.Addr, dnv.ZoneName, c.Name)
 		dataNode.ID = dnv.ID
 		dataNode.NodeSetID = dnv.NodeSetID
+		olddn,ok:=c.dataNodes.Load(dataNode.Addr)
+		if ok {
+			if olddn.(*DataNode).ID<=dataNode.ID {
+				continue
+			}
+		}
 		c.dataNodes.Store(dataNode.Addr, dataNode)
-		log.LogInfof("action[loadDataNodes],dataNode[%v],zone[%v],ns[%v]", dataNode.Addr, dnv.ZoneName, dnv.NodeSetID)
+		log.LogInfof("action[loadDataNodes],dataNode[%v],dataNodeID[%v],zone[%v],ns[%v]", dataNode.Addr, dataNode.ID,dnv.ZoneName, dnv.NodeSetID)
 	}
 	return
 }
@@ -622,8 +628,14 @@ func (c *Cluster) loadMetaNodes() (err error) {
 		metaNode := newMetaNode(mnv.Addr, mnv.ZoneName, c.Name)
 		metaNode.ID = mnv.ID
 		metaNode.NodeSetID = mnv.NodeSetID
+		oldmn,ok:=c.metaNodes.Load(metaNode.Addr)
+		if ok {
+			if oldmn.(*MetaNode).ID<=metaNode.ID {
+				continue
+			}
+		}
 		c.metaNodes.Store(metaNode.Addr, metaNode)
-		log.LogInfof("action[loadMetaNodes],metaNode[%v],zone[%v],ns[%v]", metaNode.Addr, mnv.ZoneName, mnv.NodeSetID)
+		log.LogInfof("action[loadMetaNodes],metaNode[%v], metaNodeID[%v],zone[%v],ns[%v]", metaNode.Addr,metaNode.ID, mnv.ZoneName, mnv.NodeSetID)
 	}
 	return
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
1.Fix: if metanode or datanode id has multi,then use min node id to overwrite 
2.Fix: if load mp,dp ,the peerid is not in cluster topo,then use right peer id

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
