### PR TITLE
Fix: when datanode or metanode start,the master has no anyPartition,t…

### DIFF
--- a/datanode/disk.go
+++ b/datanode/disk.go
@@ -409,7 +409,7 @@ func (d *Disk) getSelectWeight() float64 {
 // if one partition does not exist in master, we decided that it is one expired partition
 func isExpiredPartition(id uint64, partitions []uint64) bool {
 	if len(partitions) == 0 {
-		return false
+		return true
 	}
 
 	for _, existId := range partitions {

--- a/metanode/manager.go
+++ b/metanode/manager.go
@@ -460,14 +460,14 @@ func NewMetadataManager(conf MetadataManagerConfig, metaNode *MetaNode) Metadata
 // if one partition does not exist in master, we decided that it is one expired partition
 func isExpiredPartition(fileName string, partitions []uint64) (expiredPartition bool) {
 	if len(partitions) == 0 {
-		return false
+		return true
 	}
 
 	partitionId := fileName[len(partitionPrefix):]
 	id, err := strconv.ParseUint(partitionId, 10, 64)
 	if err != nil {
 		log.LogWarnf("isExpiredPartition: %s, check error [%v], skip this check", partitionId, err)
-		return false
+		return true
 	}
 
 	for _, existId := range partitions {


### PR DESCRIPTION
Fix: when datanode or metanode start,the master has no anyPartition,then datanode or metanode must rename it to expiredPartition and skip it

Signed-off-by: awzhgw <guowl18702995996@gmail.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Fix: when datanode or metanode start,the master has no anyPartition,then datanode or metanode must rename it to expiredPartition and skip it

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #


