### PR TITLE
fix: mount failure for authorized user

### DIFF
--- a/client/fs/super.go
+++ b/client/fs/super.go
@@ -72,7 +72,7 @@ func NewSuper(opt *proto.MountOptions) (s *Super, err error) {
 		Masters:       masters,
 		Authenticate:  opt.Authenticate,
 		TicketMess:    opt.TicketMess,
-		ValidateOwner: true,
+		ValidateOwner: opt.Authenticate || opt.AccessKey == "",
 	}
 	s.mw, err = meta.NewMetaWrapper(metaConfig)
 	if err != nil {


### PR DESCRIPTION
A non-owner user can be authorized to mount with rw/ro permission.
However, the auth key is generated according to the user name which
leads to mount failure when getting volume info from master.

To reproduce:

1. create a volume named V with owner A.
2. authorize user B the rw permission to V.
3. mount V using user B with access and secret key.

The mount would fail.

This commit will not check owner auth key when using access key to
mount.

Signed-off-by: Shuoran Liu <shuoranliu@gmail.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
