### PR TITLE
feature: introduce subdir permissions

### DIFF
--- a/cli/cmd/user.go
+++ b/cli/cmd/user.go
@@ -310,6 +310,7 @@ const (
 )
 
 func newUserPermCmd(client *master.MasterClient) *cobra.Command {
+	var subdir string
 	var cmd = &cobra.Command{
 		Use:   cmdUserPermUse,
 		Short: cmdUserPermShort,
@@ -324,11 +325,17 @@ func newUserPermCmd(client *master.MasterClient) *cobra.Command {
 					errout("Error: %v", err)
 				}
 			}()
+
+			perm = proto.BuiltinPermissionPrefix
+			if subdir != "" && subdir != "/" {
+				perm = proto.Permission(string(perm) + subdir + ":")
+			}
+
 			switch strings.ToLower(args[2]) {
 			case "ro", "readonly":
-				perm = proto.BuiltinPermissionReadOnly
+				perm = perm + "ReadOnly"
 			case "rw", "readwrite":
-				perm = proto.BuiltinPermissionWritable
+				perm = perm + "Writable"
 			case "none":
 				perm = proto.NonePermission
 			default:
@@ -338,6 +345,7 @@ func newUserPermCmd(client *master.MasterClient) *cobra.Command {
 			stdout("Setup volume permission\n")
 			stdout("  User ID   : %v\n", userID)
 			stdout("  Volume    : %v\n", volume)
+			stdout("  Subdir    : %v\n", subdir)
 			stdout("  Permission: %v\n", perm.ReadableString())
 
 			// ask user for confirm
@@ -375,6 +383,7 @@ func newUserPermCmd(client *master.MasterClient) *cobra.Command {
 			return validUsers(client, toComplete), cobra.ShellCompDirectiveNoFileComp
 		},
 	}
+	cmd.Flags().StringVar(&subdir, "subdir", "", "Subdir")
 	return cmd
 }
 
@@ -428,4 +437,3 @@ func printUserInfo(userInfo *proto.UserInfo) {
 		stdout("%-20v    %-12v\n", vol, strings.Join(perms, ","))
 	}
 }
-

--- a/client/fuse.go
+++ b/client/fuse.go
@@ -386,12 +386,12 @@ func checkPermission(opt *proto.MountOptions) (err error) {
 		if policy.IsOwn(opt.Volname) {
 			return
 		}
-		if policy.IsAuthorized(opt.Volname, proto.POSIXWriteAction) &&
-			policy.IsAuthorized(opt.Volname, proto.POSIXReadAction) {
+		if policy.IsAuthorized(opt.Volname, opt.SubDir, proto.POSIXWriteAction) &&
+			policy.IsAuthorized(opt.Volname, opt.SubDir, proto.POSIXReadAction) {
 			return
 		}
-		if policy.IsAuthorized(opt.Volname, proto.POSIXReadAction) &&
-			!policy.IsAuthorized(opt.Volname, proto.POSIXWriteAction) {
+		if policy.IsAuthorized(opt.Volname, opt.SubDir, proto.POSIXReadAction) &&
+			!policy.IsAuthorized(opt.Volname, opt.SubDir, proto.POSIXWriteAction) {
 			opt.Rdonly = true
 			return
 		}

--- a/objectnode/api_handler_object.go
+++ b/objectnode/api_handler_object.go
@@ -701,7 +701,7 @@ func (o *ObjectNode) copyObjectHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !userInfo.Policy.IsAuthorized(sourceBucket, proto.OSSCopyObjectAction) {
+	if !userInfo.Policy.IsAuthorized(sourceBucket, "", proto.OSSCopyObjectAction) {
 		log.LogErrorf("copyObjectHandler: no permission to copy from source bucket, requestID(%v), source bucket(%v), source file(%v), target bucket(%v), target file(%v)",
 			GetRequestID(r), sourceBucket, sourceObject, param.bucket, param.object)
 		errorCode = AccessDenied

--- a/objectnode/policy.go
+++ b/objectnode/policy.go
@@ -251,7 +251,7 @@ func (o *ObjectNode) policyCheck(f http.HandlerFunc) http.HandlerFunc {
 			}
 			var userPolicy = userInfo.Policy
 			isOwner = userPolicy.IsOwn(param.Bucket())
-			if !isOwner && !userPolicy.IsAuthorized(param.Bucket(), param.Action()) {
+			if !isOwner && !userPolicy.IsAuthorized(param.Bucket(), "", param.Action()) {
 				log.LogDebugf("policyCheck: user no permission: requestID(%v) userID(%v) accessKey(%v) volume(%v) action(%v)",
 					GetRequestID(r), userInfo.UserID, param.AccessKey(), param.Bucket(), param.Action())
 				allowed = false

--- a/proto/perm_action.go
+++ b/proto/perm_action.go
@@ -16,6 +16,7 @@ package proto
 
 import (
 	"regexp"
+	"strings"
 )
 
 var (
@@ -294,6 +295,27 @@ func (p Permission) IsBuiltin() bool {
 	return builtinPermRegexp.MatchString(string(p))
 }
 
+func (p Permission) MatchSubdir(subdir string) bool {
+	if !strings.HasPrefix(string(p), string(BuiltinPermissionPrefix)) {
+		return false
+	}
+
+	s := strings.TrimPrefix(string(p), string(BuiltinPermissionPrefix))
+	var toCompare string
+
+	if subdirRegexp.MatchString(s) {
+		toCompare = strings.Split(s, ":")[0]
+	} else {
+		toCompare = ""
+	}
+
+	if (subdir == "" || subdir == "/") && (toCompare == "" || toCompare == "/") {
+		return true
+	}
+
+	return subdir == toCompare
+}
+
 func (p Permission) IsCustom() bool {
 	return customPermRegexp.MatchString(string(p))
 }
@@ -321,9 +343,12 @@ const (
 )
 
 var (
-	permRegexp        = regexp.MustCompile("^perm:((builtin:(Writable|ReadOnly))|(custom:(\\w)+))$")
-	builtinPermRegexp = regexp.MustCompile("^perm:builtin:(Writable|ReadOnly)$")
-	customPermRegexp  = regexp.MustCompile("^perm:custom:(\\w)+$")
+	permRegexp                = regexp.MustCompile("^perm:((builtin:((.*/*)([^/]*):*)(Writable|ReadOnly))|(custom:(\\w)+))$")
+	builtinPermRegexp         = regexp.MustCompile("^perm:builtin:((.*/*)([^/]*):*)(Writable|ReadOnly)$")
+	builtinWritablePermRegexp = regexp.MustCompile("^perm:builtin:((.*/*)([^/]*):*)Writable$")
+	builtinReadOnlyPermRegexp = regexp.MustCompile("^perm:builtin:((.*/*)([^/]*):*)ReadOnly$")
+	customPermRegexp          = regexp.MustCompile("^perm:custom:(\\w)+$")
+	subdirRegexp              = regexp.MustCompile("((.*/*)([^/]*)):(Writable|ReadOnly)$")
 )
 
 func ParsePermission(value string) Permission {
@@ -397,7 +422,14 @@ var (
 )
 
 func BuiltinPermissionActions(perm Permission) Actions {
-	if actions, exists := builtinPermissionActionsMap[perm]; exists {
+	var p Permission
+
+	if builtinWritablePermRegexp.MatchString(string(perm)) {
+		p = BuiltinPermissionWritable
+	} else if builtinReadOnlyPermRegexp.MatchString(string(perm)) {
+		p = BuiltinPermissionReadOnly
+	}
+	if actions, exists := builtinPermissionActionsMap[p]; exists {
 		return actions
 	}
 	return nil

--- a/proto/user_proto.go
+++ b/proto/user_proto.go
@@ -147,7 +147,7 @@ func (policy *UserPolicy) IsOwn(volume string) bool {
 	return false
 }
 
-func (policy *UserPolicy) IsAuthorized(volume string, action Action) bool {
+func (policy *UserPolicy) IsAuthorized(volume, subdir string, action Action) bool {
 	policy.mu.RLock()
 	defer policy.mu.RUnlock()
 	if len(policy.OwnVols) > 0 {
@@ -162,7 +162,7 @@ func (policy *UserPolicy) IsAuthorized(volume string, action Action) bool {
 		return false
 	}
 	for _, value := range values {
-		if perm := ParsePermission(value); !perm.IsNone() && perm.IsBuiltin() && BuiltinPermissionActions(perm).Contains(action) {
+		if perm := ParsePermission(value); !perm.IsNone() && perm.IsBuiltin() && perm.MatchSubdir(subdir) && BuiltinPermissionActions(perm).Contains(action) {
 			return true
 		}
 		if act := ParseAction(value); act == action {
@@ -311,6 +311,7 @@ type UserCreateParam struct {
 type UserPermUpdateParam struct {
 	UserID string   `json:"user_id"`
 	Volume string   `json:"volume"`
+	Subdir string   `json:"subdir"`
 	Policy []string `json:"policy"`
 }
 


### PR DESCRIPTION
Originally the permission control for users are in volume level. This
commit introduces subdir level permission control.

Signed-off-by: Shuoran Liu <shuoranliu@gmail.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
