### PR TITLE
enhance: build static executables

### DIFF
--- a/cmd/build.sh
+++ b/cmd/build.sh
@@ -10,5 +10,6 @@ go build -ldflags "\
 -X github.com/chubaofs/chubaofs/proto.Version=${Version} \
 -X github.com/chubaofs/chubaofs/proto.CommitID=${CommitID} \
 -X github.com/chubaofs/chubaofs/proto.BranchName=${BranchName} \
--X 'github.com/chubaofs/chubaofs/proto.BuildTime=${BuildTime}'" \
+-X 'github.com/chubaofs/chubaofs/proto.BuildTime=${BuildTime}' \
+-extldflags '-static'" \
 -o cfs-server


### PR DESCRIPTION
Sometimes it's important that the server executables do not depend on
certain shared libraries.

Signed-off-by: Shuoran Liu <shuoranliu@gmail.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
