### PR TITLE
fix: batch inode get mechanism is out of service

### DIFF
--- a/client/fs/file.go
+++ b/client/fs/file.go
@@ -428,7 +428,6 @@ func (f *File) fileSize(ino uint64) (size int, gen uint64) {
 	log.LogDebugf("fileSize: ino(%v) fileSize(%v) gen(%v) valid(%v)", ino, size, gen, valid)
 
 	if !valid {
-		f.super.ic.Delete(ino)
 		if info, err := f.super.InodeGet(ino); err == nil {
 			size = int(info.Size)
 			gen = info.Generation

--- a/client/fs/super.go
+++ b/client/fs/super.go
@@ -79,22 +79,6 @@ func NewSuper(opt *proto.MountOptions) (s *Super, err error) {
 		return nil, errors.Trace(err, "NewMetaWrapper failed!")
 	}
 
-	var extentConfig = &stream.ExtentConfig{
-		Volume:            opt.Volname,
-		Masters:           masters,
-		FollowerRead:      opt.FollowerRead,
-		NearRead:          opt.NearRead,
-		ReadRate:          opt.ReadRate,
-		WriteRate:         opt.WriteRate,
-		OnAppendExtentKey: s.mw.AppendExtentKey,
-		OnGetExtents:      s.mw.GetExtents,
-		OnTruncate:        s.mw.Truncate,
-	}
-	s.ec, err = stream.NewExtentClient(extentConfig)
-	if err != nil {
-		return nil, errors.Trace(err, "NewExtentClient failed!")
-	}
-
 	s.volname = opt.Volname
 	s.owner = opt.Owner
 	s.cluster = s.mw.Cluster()
@@ -118,6 +102,23 @@ func NewSuper(opt *proto.MountOptions) (s *Super, err error) {
 	s.disableDcache = opt.DisableDcache
 	s.fsyncOnClose = opt.FsyncOnClose
 	s.enableXattr = opt.EnableXattr
+
+	var extentConfig = &stream.ExtentConfig{
+		Volume:            opt.Volname,
+		Masters:           masters,
+		FollowerRead:      opt.FollowerRead,
+		NearRead:          opt.NearRead,
+		ReadRate:          opt.ReadRate,
+		WriteRate:         opt.WriteRate,
+		OnAppendExtentKey: s.mw.AppendExtentKey,
+		OnGetExtents:      s.mw.GetExtents,
+		OnTruncate:        s.mw.Truncate,
+		OnEvictIcache:     s.ic.Delete,
+	}
+	s.ec, err = stream.NewExtentClient(extentConfig)
+	if err != nil {
+		return nil, errors.Trace(err, "NewExtentClient failed!")
+	}
 
 	if s.rootIno, err = s.mw.GetRootIno(opt.SubDir); err != nil {
 		return nil, err

--- a/sdk/data/stream/extent_client.go
+++ b/sdk/data/stream/extent_client.go
@@ -31,6 +31,7 @@ import (
 type AppendExtentKeyFunc func(inode uint64, key proto.ExtentKey) error
 type GetExtentsFunc func(inode uint64) (uint64, uint64, []proto.ExtentKey, error)
 type TruncateFunc func(inode, size uint64) error
+type EvictIcacheFunc func(inode uint64)
 
 const (
 	MaxMountRetryLimit = 5
@@ -85,6 +86,7 @@ type ExtentConfig struct {
 	OnAppendExtentKey AppendExtentKeyFunc
 	OnGetExtents      GetExtentsFunc
 	OnTruncate        TruncateFunc
+	OnEvictIcache     EvictIcacheFunc
 }
 
 // ExtentClient defines the struct of the extent client.
@@ -99,6 +101,7 @@ type ExtentClient struct {
 	appendExtentKey AppendExtentKeyFunc
 	getExtents      GetExtentsFunc
 	truncate        TruncateFunc
+	evictIcache     EvictIcacheFunc //May be null, must check before using
 }
 
 // NewExtentClient returns a new extent client.
@@ -122,6 +125,7 @@ retry:
 	client.appendExtentKey = config.OnAppendExtentKey
 	client.getExtents = config.OnGetExtents
 	client.truncate = config.OnTruncate
+	client.evictIcache = config.OnEvictIcache
 	client.dataWrapper.InitFollowerRead(config.FollowerRead)
 	client.dataWrapper.SetNearRead(config.NearRead)
 

--- a/sdk/data/stream/stream_writer.go
+++ b/sdk/data/stream/stream_writer.go
@@ -184,6 +184,9 @@ func (s *Streamer) server() {
 				s.client.streamerLock.Lock()
 				if s.idle >= streamWriterIdleTimeoutPeriod && len(s.request) == 0 {
 					delete(s.client.streamers, s.inode)
+					if s.client.evictIcache != nil {
+						s.client.evictIcache(s.inode)
+					}
 					s.client.streamerLock.Unlock()
 
 					// fail the remaining requests in such case


### PR DESCRIPTION
Right now the batch inode get mechanism does not work since in when
getting attr, the inode cache is evicted every time the underlying extent
streamer does not exist. To eliminate the eviction in getAttr, we have
to trigger an active eviction when the underlying streamer quits
silently.

Signed-off-by: Shuoran Liu <shuoranliu@gmail.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
