### PR TITLE
Fix: dp snapshot function use current applyid   prevent raft painc

### DIFF
--- a/datanode/partition_raftfsm.go
+++ b/datanode/partition_raftfsm.go
@@ -80,7 +80,7 @@ func (dp *DataPartition) ApplyMemberChange(confChange *raftproto.ConfChange, ind
 // Note that the data in each data partition has already been saved on the disk. Therefore there is no need to take the
 // snapshot in this case.
 func (dp *DataPartition) Snapshot() (raftproto.Snapshot, error) {
-	snapIterator := NewItemIterator(dp.lastTruncateID)
+	snapIterator := NewItemIterator(dp.raftPartition.AppliedIndex())
 	log.LogInfof("SendSnapShot PartitionID(%v) Snapshot lastTruncateID(%v) currentApplyID(%v) firstCommitID(%v)",
 		dp.partitionID, dp.lastTruncateID, dp.appliedID, dp.raftPartition.CommittedIndex())
 	return snapIterator, nil


### PR DESCRIPTION
Signed-off-by: awzhgw <guowl18702995996@gmail.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Fix: dp snapshot function use current applyid   prevent raft painc