### PR TITLE
Enhance: datanode optmize performance  When there are many extents

### DIFF
--- a/datanode/partition.go
+++ b/datanode/partition.go
@@ -512,21 +512,10 @@ func (dp *DataPartition) actualSize(path string, finfo os.FileInfo) (size int64)
 }
 
 func (dp *DataPartition) computeUsage() {
-	var (
-		used  int64
-		files []os.FileInfo
-		err   error
-	)
 	if time.Now().Unix()-dp.intervalToUpdatePartitionSize < IntervalToUpdatePartitionSize {
 		return
 	}
-	if files, err = ioutil.ReadDir(dp.path); err != nil {
-		return
-	}
-	for _, file := range files {
-		used += dp.actualSize(dp.path, file)
-	}
-	dp.used = int(used)
+	dp.used=int(dp.ExtentStore().GetStoreUsedSize())
 	dp.intervalToUpdatePartitionSize = time.Now().Unix()
 }
 

--- a/datanode/wrap_operator.go
+++ b/datanode/wrap_operator.go
@@ -490,22 +490,6 @@ func (s *DataNode) handleExtentRepairReadPacket(p *repl.Packet, connect net.Conn
 }
 
 func (s *DataNode) handleTinyExtentRepairReadPacket(p *repl.Packet, connect net.Conn) {
-	var (
-		err error
-	)
-
-	defer func() {
-		if err != nil {
-			p.PackErrorBody(ActionStreamRead, err.Error())
-			p.WriteToConn(connect)
-		}
-		fininshDoExtentRepair()
-	}()
-
-	err = requestDoExtentRepair()
-	if err != nil {
-		return
-	}
 	s.tinyExtentRepairRead(p, connect)
 }
 

--- a/storage/extent_store.go
+++ b/storage/extent_store.go
@@ -356,7 +356,11 @@ func (s *ExtentStore) Read(extentID uint64, offset, size int64, nbuf []byte, isR
 	return
 }
 
-func (s *ExtentStore) tinyDelete(e *Extent, offset, size int64) (err error) {
+func (s *ExtentStore) tinyDelete(extentID uint64, offset, size int64) (err error) {
+	e,err:=s.extentWithHeaderByExtentID(extentID)
+	if err!=nil {
+		return nil
+	}
 	if offset+size > e.dataSize {
 		return
 	}
@@ -378,22 +382,19 @@ func (s *ExtentStore) tinyDelete(e *Extent, offset, size int64) (err error) {
 // MarkDelete marks the given extent as deleted.
 func (s *ExtentStore) MarkDelete(extentID uint64, offset, size int64) (err error) {
 	var (
-		e  *Extent
 		ei *ExtentInfo
 	)
+
+	if IsTinyExtent(extentID) {
+		return s.tinyDelete(extentID, offset, size)
+	}
 
 	s.eiMutex.RLock()
 	ei = s.extentInfoMap[extentID]
 	s.eiMutex.RUnlock()
-	if e, err = s.extentWithHeader(ei); err != nil {
-		return nil
+	if ei == nil || ei.IsDeleted {
+		return
 	}
-
-	if IsTinyExtent(extentID) {
-		return s.tinyDelete(e, offset, size)
-	}
-	e.Close()
-	s.cache.Del(extentID)
 	extentFilePath := path.Join(s.dataPath, strconv.FormatUint(extentID, 10))
 	if err = os.Remove(extentFilePath); err != nil {
 		return
@@ -401,7 +402,7 @@ func (s *ExtentStore) MarkDelete(extentID uint64, offset, size int64) (err error
 	s.PersistenceHasDeleteExtent(extentID)
 	ei.IsDeleted = true
 	ei.ModifyTime = time.Now().Unix()
-	s.cache.Del(e.extentID)
+	s.cache.Del(extentID)
 	s.DeleteBlockCrc(extentID)
 	s.PutNormalExtentToDeleteCache(extentID)
 


### PR DESCRIPTION
Signed-off-by: awzhgw <guowl18702995996@gmail.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
1. When using elatiseach to pressure test chubaofs, when writing and deleting continuously, a large number of extents will be generated under each dp, and these extents will be deleted continuously, the length of extentcache is only 40, when each extent is deleted , LoadExtentWithHeader will be loaded from the disk. When reading the header, it will read the 4096-byte header from the extentcrc file, thus causing some random reads. This pr is to optimize this phenomenon.

2. When there are many extents ，dataPartition computeUseSize  A lot of random IO was wasted, so The memory method is used to calculate the space used by dataPartition。

3. tinyExtentRepair donnot use limit by autoRepairLimit parameter
