### PR TITLE
Fix: tinyExtent cannot autoRepair when localExtentSize is 0,and remot…

### DIFF
--- a/datanode/data_partition_repair.go
+++ b/datanode/data_partition_repair.go
@@ -16,6 +16,8 @@ package datanode
 
 import (
 	"encoding/json"
+	"github.com/chubaofs/chubaofs/util"
+	"math"
 	"net"
 	"sync"
 	"time"
@@ -479,6 +481,9 @@ func (dp *DataPartition) streamRepairExtent(remoteExtentInfo *storage.ExtentInfo
 	sizeDiff := remoteExtentInfo.Size - localExtentInfo.Size
 	request := repl.NewExtentRepairReadPacket(dp.partitionID, remoteExtentInfo.FileID, int(localExtentInfo.Size), int(sizeDiff))
 	if storage.IsTinyExtent(remoteExtentInfo.FileID) {
+		if sizeDiff >= math.MaxUint32 {
+			sizeDiff = math.MaxUint32 - util.MB
+		}
 		request = repl.NewTinyExtentRepairReadPacket(dp.partitionID, remoteExtentInfo.FileID, int(localExtentInfo.Size), int(sizeDiff))
 	}
 	var conn *net.TCPConn

--- a/storage/extent_store.go
+++ b/storage/extent_store.go
@@ -643,9 +643,6 @@ func (s *ExtentStore) StoreSizeExtentID(maxExtentID uint64) (totalSize uint64) {
 	s.eiMutex.RUnlock()
 	for _, extentInfo := range extentInfos {
 		totalSize += extentInfo.Size
-		if extentInfo.Size > util.BlockSize*util.BlockCount {
-			log.LogErrorf("file(%v) size too much (%v)", s.dataPath, extentInfo)
-		}
 	}
 
 	return totalSize


### PR DESCRIPTION
Fix: tinyExtent cannot autoRepair when localExtentSize is 0,and remote ExtentSize > 2^32-1

Signed-off-by: awzhgw <guowl18702995996@gmail.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Fix: tinyExtent cannot autoRepair when localExtentSize is 0,and remote ExtentSize > 2^32-1