### PR TITLE
Fix: no such bucket when create bucket using S3 API

### DIFF
--- a/objectnode/auth_signature_v4.go
+++ b/objectnode/auth_signature_v4.go
@@ -112,20 +112,20 @@ func (o *ObjectNode) validateHeaderBySignatureAlgorithmV4(r *http.Request) (bool
 	}
 
 	var accessKey = req.Credential.AccessKey
-	var volume *Volume
-	if bucket := mux.Vars(r)["bucket"]; len(bucket) > 0 {
-		if volume, err = o.getVol(bucket); err != nil {
-			return false, err
-		}
-	}
 	var secretKey string
+	var bucket = mux.Vars(r)["bucket"]
 	if userInfo, err := o.getUserInfoByAccessKey(accessKey); err == nil {
 		secretKey = userInfo.SecretKey
-	} else if (err == proto.ErrUserNotExists || err == proto.ErrAccessKeyNotExists) && volume != nil {
+	} else if (err == proto.ErrUserNotExists || err == proto.ErrAccessKeyNotExists) &&
+		len(bucket) > 0 && GetActionFromContext(r) != proto.OSSCreateBucketAction {
 		// In order to be directly compatible with the signature verification of version 1.5
 		// (each volume has its own access key and secret key), if the user does not exist and
 		// the request specifies a volume, try to use the accesskey and secret key bound in the
 		// volume information for verification.
+		var volume *Volume
+		if volume, err = o.getVol(bucket); err != nil {
+			return false, err
+		}
 		if ak, sk := volume.OSSSecure(); ak == accessKey {
 			secretKey = sk
 		} else {
@@ -172,20 +172,20 @@ func (o *ObjectNode) validateUrlBySignatureAlgorithmV4(r *http.Request) (pass bo
 	}
 
 	var accessKey = req.Credential.AccessKey
-	var volume *Volume
-	if bucket := mux.Vars(r)["bucket"]; len(bucket) > 0 {
-		if volume, err = o.getVol(bucket); err != nil {
-			return false, err
-		}
-	}
 	var secretKey string
+	var bucket = mux.Vars(r)["bucket"]
 	if userInfo, err := o.getUserInfoByAccessKey(accessKey); err == nil {
 		secretKey = userInfo.SecretKey
-	} else if (err == proto.ErrUserNotExists || err == proto.ErrAccessKeyNotExists) && volume != nil {
+	} else if (err == proto.ErrUserNotExists || err == proto.ErrAccessKeyNotExists) &&
+		len(bucket) > 0 && GetActionFromContext(r) != proto.OSSCreateBucketAction {
 		// In order to be directly compatible with the signature verification of version 1.5
 		// (each volume has its own access key and secret key), if the user does not exist and
 		// the request specifies a volume, try to use the accesskey and secret key bound in the
 		// volume information for verification.
+		var volume *Volume
+		if volume, err = o.getVol(bucket); err != nil {
+			return false, err
+		}
 		if ak, sk := volume.OSSSecure(); ak == accessKey {
 			secretKey = sk
 		} else {


### PR DESCRIPTION
**What this PR does / why we need it**:
- Fix no such bucket issue when using S3 CreateBucket API.

**Which issue this PR fixes**: 
fixes #869 

**Special notes for your reviewer**:
Focus on the v2 and v4 signature verification process.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Bugfix:
- Fix no such bucket issue when using S3 CreateBucket API.
```
