### PR TITLE
Fix:exclude hosts when alloc node set for data node

### DIFF
--- a/master/topology.go
+++ b/master/topology.go
@@ -222,10 +222,15 @@ func (ns *nodeSet) deleteMetaNode(metaNode *MetaNode) {
 	ns.metaNodes.Delete(metaNode.Addr)
 }
 
-func (ns *nodeSet) canWriteForDataNode(replicaNum int) bool {
+// can Write For DataNode With Exclude Hosts
+func (ns *nodeSet) canWriteForDataNode(excludeHosts []string, replicaNum int) bool {
 	var count int
 	ns.dataNodes.Range(func(key, value interface{}) bool {
 		node := value.(*DataNode)
+		if contains(excludeHosts, node.Addr) == true {
+			log.LogDebugf("contains return")
+			return true
+		}
 		if node.isWriteAble() {
 			count++
 		}
@@ -564,7 +569,7 @@ func (zone *Zone) deleteMetaNode(metaNode *MetaNode) (err error) {
 	return
 }
 
-func (zone *Zone) allocNodeSetForDataNode(excludeNodeSets []uint64, replicaNum uint8) (ns *nodeSet, err error) {
+func (zone *Zone) allocNodeSetForDataNode(excludeNodeSets []uint64, excludeHosts []string, replicaNum uint8) (ns *nodeSet, err error) {
 	nset := zone.getAllNodeSet()
 	if nset == nil {
 		return nil, errors.NewError(proto.ErrNoNodeSetToCreateDataPartition)
@@ -580,7 +585,7 @@ func (zone *Zone) allocNodeSetForDataNode(excludeNodeSets []uint64, replicaNum u
 		if containsID(excludeNodeSets, ns.ID) {
 			continue
 		}
-		if ns.canWriteForDataNode(int(replicaNum)) {
+		if ns.canWriteForDataNode(excludeHosts, int(replicaNum)) {
 			return
 		}
 	}
@@ -666,7 +671,7 @@ func (zone *Zone) getAvailDataNodeHosts(excludeNodeSets []uint64, excludeHosts [
 	if replicaNum == 0 {
 		return
 	}
-	ns, err := zone.allocNodeSetForDataNode(excludeNodeSets, uint8(replicaNum))
+	ns, err := zone.allocNodeSetForDataNode(excludeNodeSets, excludeHosts, uint8(replicaNum))
 	if err != nil {
 		return nil, nil, errors.Trace(err, "zone[%v] alloc node set,replicaNum[%v]", zone.name, replicaNum)
 	}

--- a/master/topology_test.go
+++ b/master/topology_test.go
@@ -63,6 +63,15 @@ func TestSingleZone(t *testing.T) {
 		return
 	}
 	fmt.Println(newHosts)
+
+	// single zone with exclude hosts
+	excludeHosts := []string{mds1Addr,mds2Addr,mds3Addr}
+	newHosts, _, err = zones[0].getAvailDataNodeHosts(nil, excludeHosts, replicaNum)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	fmt.Println(newHosts)
 	topo.deleteDataNode(createDataNodeForTopo(mds1Addr, zoneName, nodeSet))
 }
 


### PR DESCRIPTION
Signed-off-by: yangqingyuan8 <yangqingyuan8@jd.com>
to solve the warning info below:
dataNodeOfflineErr clusterID[spark] partitionID:5985 on Node:XXXX Then Fix It on newHost: Err:action[getAvailHosts] no enough writable hosts,replicaNum:1 MatchNodeCount:0 ,
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
