### PR TITLE
Refactor: keep data for deleted data partitions

### DIFF
--- a/datanode/disk.go
+++ b/datanode/disk.go
@@ -26,10 +26,11 @@ import (
 	"syscall"
 	"time"
 
+	"os"
+
 	"github.com/chubaofs/chubaofs/proto"
 	"github.com/chubaofs/chubaofs/util/exporter"
 	"github.com/chubaofs/chubaofs/util/log"
-	"os"
 )
 
 var (
@@ -37,7 +38,9 @@ var (
 	RegexpDataPartitionDir, _ = regexp.Compile("^datapartition_(\\d)+_(\\d)+$")
 )
 
-const ExpiredPartitionPrefix = "expired_"
+const (
+	ExpiredPartitionPrefix = "expired_"
+)
 
 // Disk represents the structure of the disk
 type Disk struct {

--- a/datanode/partition_raft.go
+++ b/datanode/partition_raft.go
@@ -362,7 +362,7 @@ func (dp *DataPartition) removeRaftNode(req *proto.RemoveDataPartitionRaftMember
 	dp.config.Peers = append(dp.config.Peers[:peerIndex], dp.config.Peers[peerIndex+1:]...)
 	if dp.config.NodeID == req.RemovePeer.ID && !dp.isLoadingDataPartition && canRemoveSelf {
 		dp.raftPartition.Delete()
-		dp.Disk().space.DeletePartition(dp.partitionID)
+		dp.Disk().space.ExpiredPartition(dp.partitionID)
 		isUpdated = false
 	}
 	log.LogInfof("Fininsh RemoveRaftNode  PartitionID(%v) nodeID(%v)  do RaftLog (%v) ",

--- a/datanode/space_manager.go
+++ b/datanode/space_manager.go
@@ -16,15 +16,18 @@ package datanode
 
 import (
 	"fmt"
+	"path"
+	"strconv"
 	"sync"
 	"time"
+
+	"math"
+	"os"
 
 	"github.com/chubaofs/chubaofs/proto"
 	"github.com/chubaofs/chubaofs/raftstore"
 	"github.com/chubaofs/chubaofs/util"
 	"github.com/chubaofs/chubaofs/util/log"
-	"math"
-	"os"
 )
 
 // SpaceManager manages the disk space.
@@ -298,6 +301,38 @@ func (manager *SpaceManager) DeletePartition(dpID uint64) {
 	dp.Stop()
 	dp.Disk().DetachDataPartition(dp)
 	os.RemoveAll(dp.Path())
+}
+
+// ExpiredPartition marks specified partition as expired.
+// It renames data path to a new name which add 'expired_' as prefix and operation timestamp as suffix.
+// (e.g. '/disk0/datapartition_1_128849018880' to '/disk0/deleted_datapartition_1_128849018880_1600054521')
+func (manager *SpaceManager) ExpiredPartition(partitionID uint64) {
+	dp := manager.Partition(partitionID)
+	if dp == nil {
+		return
+	}
+	manager.partitionMutex.Lock()
+	delete(manager.partitions, partitionID)
+	manager.partitionMutex.Unlock()
+	dp.Stop()
+	dp.Disk().DetachDataPartition(dp)
+	var currentPath = path.Clean(dp.Path())
+	var newPath = path.Join(path.Dir(currentPath),
+		ExpiredPartitionPrefix+path.Base(currentPath)+"_"+strconv.FormatInt(time.Now().Unix(), 10))
+	if err := os.Rename(currentPath, newPath); err != nil {
+		log.LogErrorf("ExpiredPartition: move deleted partition fail: volume(%v) partitionID(%v) path(%v) newPath(%v) err(%v)",
+			dp.volumeID,
+			dp.partitionID,
+			dp.path,
+			newPath,
+			err)
+		return
+	}
+	log.LogInfof("ExpiredPartition: move deleted partition: volume(%v) partitionID(%v) path(%v) newPath(%v)",
+		dp.volumeID,
+		dp.partitionID,
+		dp.path,
+		newPath)
 }
 
 func (s *DataNode) buildHeartBeatResponse(response *proto.DataNodeHeartbeatResponse) {

--- a/datanode/wrap_operator.go
+++ b/datanode/wrap_operator.go
@@ -249,7 +249,7 @@ func (s *DataNode) handlePacketToDeleteDataPartition(p *repl.Packet) {
 		if err != nil {
 			return
 		} else {
-			s.space.DeletePartition(request.PartitionId)
+			s.space.ExpiredPartition(request.PartitionId)
 		}
 	} else {
 		err = fmt.Errorf("illegal opcode ")


### PR DESCRIPTION
**What this PR does / why we need it**:
When the operation of deleting data partition is performed, the data is not deleted immediately, but the data is retained and the data directory of the data partition is marked and renamed.

This logical adjustment is to increase the possibility of data recovery after accidental deletion of data.

**Which issue this PR fixes**:
None.

**Special notes for your reviewer**:
None.

**Release note**:
None.