### PR TITLE
fix: limit name of deleted raft logs

### DIFF
--- a/raftstore/log_test.go
+++ b/raftstore/log_test.go
@@ -15,19 +15,24 @@ func TestCleanRaftLog(t *testing.T) {
 		os.MkdirAll(dir, 0755)
 	}
 
-	logFilePath1 := path.Join(dir, "test_clean.log.old")
+	logFilePath1 := path.Join(dir, "raft_info.log.old")
 	if err = createFile(logFilePath1, true); err != nil {
 		t.Errorf("create file[%v] err[%v]", logFilePath1, err)
 		return
 	}
-	logFilePath2 := path.Join(dir, "test_clean.log")
+	logFilePath2 := path.Join(dir, "test_clean.log.old")
 	if err = createFile(logFilePath2, true); err != nil {
 		t.Errorf("create file[%v] err[%v]", logFilePath2, err)
 		return
 	}
-	logFilePath3 := path.Join(dir, "test_clean.log.new")
+	logFilePath3 := path.Join(dir, "raft_err.log.new")
 	if err = createFile(logFilePath3, false); err != nil {
 		t.Errorf("create file[%v] err[%v]", logFilePath3, err)
+		return
+	}
+	logFilePath4 := path.Join(dir, "raft_info.log")
+	if err = createFile(logFilePath4, true); err != nil {
+		t.Errorf("create file[%v] err[%v]", logFilePath4, err)
 		return
 	}
 
@@ -47,6 +52,11 @@ func TestCleanRaftLog(t *testing.T) {
 	_, err = os.Stat(logFilePath3)
 	if err != nil {
 		t.Errorf("expect file[%v] exists but err is [%v]", logFilePath3, err)
+		return
+	}
+	_, err = os.Stat(logFilePath4)
+	if err != nil {
+		t.Errorf("expect file[%v] exists but err is [%v]", logFilePath4, err)
 		return
 	}
 


### PR DESCRIPTION
Signed-off-by: wenjia322 <buaa1214wwj@126.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Limit name of deleted raft logs.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

None.

**Special notes for your reviewer**:

None.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

None.
