### PR TITLE
Fix: datapartition on delete normalextent action,forget remove it from

### DIFF
--- a/storage/extent_store.go
+++ b/storage/extent_store.go
@@ -408,6 +408,10 @@ func (s *ExtentStore) MarkDelete(extentID uint64, offset, size int64) (err error
 	s.DeleteBlockCrc(extentID)
 	s.PutNormalExtentToDeleteCache(extentID)
 
+	s.eiMutex.Lock()
+	delete(s.extentInfoMap,extentID)
+	s.eiMutex.Unlock()
+
 	return
 }
 
@@ -475,7 +479,7 @@ const (
 )
 
 func (s *ExtentStore) GetStoreUsedSize() (used int64) {
-	extentInfoSlice := make([]*ExtentInfo, 0, len(s.extentInfoMap))
+	extentInfoSlice := make([]*ExtentInfo, 0, s.GetExtentCount())
 	s.eiMutex.RLock()
 	for _, extentID := range s.extentInfoMap {
 		extentInfoSlice = append(extentInfoSlice, extentID)


### PR DESCRIPTION
Fix: datapartition on delete normalextent action,forget remove it from storage.extentInfoMap, so some dp can change to readonly status,now fix
this bug

Signed-off-by: awzhgw <guowl18702995996@gmail.com>


