### PR TITLE
Expose raft peers info in data node api.

### DIFF
--- a/datanode/server_handler.go
+++ b/datanode/server_handler.go
@@ -181,6 +181,7 @@ func (s *DataNode) getPartitionAPI(w http.ResponseWriter, r *http.Request) {
 		Files                []*storage.ExtentInfo `json:"extents"`
 		FileCount            int                   `json:"fileCount"`
 		Replicas             []string              `json:"replicas"`
+		Peers                []proto.Peer          `json:"peers"`
 		TinyDeleteRecordSize int64                 `json:"tinyDeleteRecordSize"`
 		RaftStatus           *raft.Status          `json:"raftStatus"`
 	}{
@@ -195,6 +196,7 @@ func (s *DataNode) getPartitionAPI(w http.ResponseWriter, r *http.Request) {
 		Replicas:             partition.Replicas(),
 		TinyDeleteRecordSize: tinyDeleteRecordSize,
 		RaftStatus:           partition.raftPartition.Status(),
+		Peers:                partition.config.Peers,
 	}
 	s.buildSuccessResp(w, result)
 }

--- a/raftstore/partition.go
+++ b/raftstore/partition.go
@@ -144,6 +144,9 @@ func (p *partition) Expired() (err error) {
 
 // Status returns the current raft status.
 func (p *partition) Status() (status *PartitionStatus) {
+	if p == nil || p.raft == nil {
+		return nil
+	}
 	status = p.raft.Status(p.id)
 	return
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Expose raft peers info in get partition info API of data node.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*:
None.

**Special notes for your reviewer**:
None.

**Release note**:
None.
