### PR TITLE
Fix: key encoding issue of S3 ListObjects API.

### DIFF
--- a/objectnode/const.go
+++ b/objectnode/const.go
@@ -65,7 +65,7 @@ const (
 	HeaderNameXAmzDownloadPartCount   = "x-amz-mp-parts-count"
 	HeaderNameXAmzMetadataDirective   = "x-amz-metadata-directive"
 	HeaderNameXAmzBucketRegion        = "x-amz-bucket-region"
-	HeaderNameXAmzTaggingCount   	  = "x-amz-tagging-count"
+	HeaderNameXAmzTaggingCount        = "x-amz-tagging-count"
 
 	HeaderNameIfMatch           = "If-Match"
 	HeaderNameIfNoneMatch       = "If-None-Match"
@@ -103,6 +103,7 @@ const (
 	ParamPartNoMarker   = "part-number-marker"
 	ParamPartMaxUploads = "max-uploads"
 	ParamPartDelimiter  = "delimiter"
+	ParamEncodingType   = "encoding-type"
 
 	ParamResponseCacheControl       = "response-cache-control"
 	ParamResponseContentType        = "response-content-type"

--- a/objectnode/etag.go
+++ b/objectnode/etag.go
@@ -80,6 +80,14 @@ func DirectoryETagValue() ETagValue {
 	return staticDirectoryETagValue
 }
 
+func EmptyContentETagValue(ts time.Time) ETagValue {
+	return ETagValue{
+		Value:   EmptyContentMD5String,
+		PartNum: 0,
+		TS:      ts,
+	}
+}
+
 func NewRandomBytesETagValue(partNum int, ts time.Time) ETagValue {
 	r := rand.New(rand.NewSource(ts.Unix()))
 	tmp := make([]byte, 4*1024)

--- a/objectnode/fs_store_user.go
+++ b/objectnode/fs_store_user.go
@@ -16,10 +16,11 @@ package objectnode
 
 import (
 	"fmt"
-	"github.com/chubaofs/chubaofs/util/exporter"
 	"hash/crc32"
 	"sync"
 	"time"
+
+	"github.com/chubaofs/chubaofs/util/exporter"
 
 	"github.com/chubaofs/chubaofs/sdk/master"
 
@@ -45,7 +46,7 @@ type StrictUserInfoStore struct {
 func (s *StrictUserInfoStore) LoadUser(accessKey string) (*proto.UserInfo, error) {
 	// if error occurred when loading user, and error is not NotExist, output an ump log
 	userInfo, err := s.mc.UserAPI().GetAKInfo(accessKey)
-	if err != proto.ErrUserNotExists && err != proto.ErrAccessKeyNotExists {
+	if err != nil && err != proto.ErrUserNotExists && err != proto.ErrAccessKeyNotExists {
 		log.LogErrorf("LoadUser: fetch user info fail: err(%v)", err)
 		exporter.Warning(fmt.Sprintf("StrictUserInfoStore load user fail: accessKey(%v) err(%v)", accessKey, err))
 	}

--- a/objectnode/fs_volume.go
+++ b/objectnode/fs_volume.go
@@ -1832,8 +1832,12 @@ func (v *Volume) supplyListFileInfo(fileInfos []*FSFileInfo) (err error) {
 
 func (v *Volume) updateETag(inode uint64, size int64, mt time.Time) (etagValue ETagValue, err error) {
 	// The ETag is invalid or outdated then generate a new ETag and make update.
-	var splittedRanges = SplitFileRange(size, SplitFileRangeBlockSize)
-	etagValue = NewRandomUUIDETagValue(len(splittedRanges), mt)
+	if size == 0 {
+		etagValue = EmptyContentETagValue(mt)
+	} else {
+		var splittedRanges = SplitFileRange(size, SplitFileRangeBlockSize)
+		etagValue = NewRandomUUIDETagValue(len(splittedRanges), mt)
+	}
 	if err = v.mw.XAttrSet_ll(inode, []byte(XAttrKeyOSSETag), []byte(etagValue.Encode())); err != nil {
 		return
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Parse parameter `encoding-type` from request. It this parameter specified and match with constant string `url`, then encode content keys by using url encoding function.

**Which issue this PR fixes**:
fixes #954 

**Special notes for your reviewer**:
None.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Bugfix
Fix object key encoding issue of S3 ListObjects API.
```