### PR TITLE
Fix: deadlock issue when convert Inode to InodeInfo

### DIFF
--- a/metanode/partition_op_inode.go
+++ b/metanode/partition_op_inode.go
@@ -24,6 +24,7 @@ import (
 
 func replyInfo(info *proto.InodeInfo, ino *Inode) bool {
 	ino.RLock()
+	defer ino.RUnlock()
 	if ino.Flag&DeleteMarkFlag > 0 {
 		return false
 	}
@@ -41,7 +42,6 @@ func replyInfo(info *proto.InodeInfo, ino *Inode) bool {
 	info.CreateTime = time.Unix(ino.CreateTime, 0)
 	info.AccessTime = time.Unix(ino.AccessTime, 0)
 	info.ModifyTime = time.Unix(ino.ModifyTime, 0)
-	ino.RUnlock()
 	return true
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Fix: deadlock issue when convert `metanode.Inode` to `proto.InodeInfo`.
https://github.com/chubaofs/chubaofs/blob/d259d3fcf366dda9a4e3fd75017631947336dde2/metanode/partition_op_inode.go#L25-L46
If the specified inode object have been marked as deleted, then the `replyInfo` method returns without unlock the readwrite mutex.


**Which issue this PR fixes**:
None.

**Special notes for your reviewer**:
None.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Bugfix:
- Fix deadlock issue when get an deleted inode info.
```