### PR TITLE
fix: clean old logs 7 days ago; rotate critical logs [version: release-20200412]

### DIFF
--- a/util/log/log_test.go
+++ b/util/log/log_test.go
@@ -19,6 +19,8 @@ package log
 import (
 	"net/http"
 	_ "net/http/pprof"
+	"os"
+	"path"
 	"testing"
 	"time"
 )
@@ -27,9 +29,70 @@ func TestLog(t *testing.T) {
 	go func() {
 		http.ListenAndServe(":10000", nil)
 	}()
+
+	dir := path.Join("/tmp/cfs", "cfs")
+	_, err := os.Stat(dir)
+	if os.IsNotExist(err) {
+		os.MkdirAll(dir, 0755)
+	}
+
+	logFilePath1 := path.Join(dir, "log_info.log.old")
+	if err = createFile(logFilePath1, true); err != nil {
+		t.Errorf("create file[%v] err[%v]", logFilePath1, err)
+		return
+	}
+	logFilePath2 := path.Join(dir, "log_err.log")
+	if err = createFile(logFilePath2, false); err != nil {
+		t.Errorf("create file[%v] err[%v]", logFilePath2, err)
+		return
+	}
+	logFilePath3 := path.Join(dir, "log_info.log")
+	if err = createFile(logFilePath3, true); err != nil {
+		t.Errorf("create file[%v] err[%v]", logFilePath3, err)
+		return
+	}
+
 	InitLog("/tmp/cfs", "cfs", DebugLevel, nil)
 	for i := 0; i < 10; i++ {
-		LogDebugf("current time %v.", time.Now())
+		LogDebugf("[debug] current time %v.", time.Now())
+		LogWarnf("[warn] current time %v.", time.Now())
+		LogErrorf("[error] current time %v.", time.Now())
+		LogInfof("[info] current time %v.", time.Now())
 		time.Sleep(200 * time.Millisecond)
 	}
+
+	_, err = os.Stat(logFilePath1)
+	if !os.IsNotExist(err) {
+		t.Errorf("expect file[%v] doesn't exist but err is [%v]", logFilePath1, err)
+		return
+	}
+	_, err = os.Stat(logFilePath2)
+	if err != nil {
+		t.Errorf("expect file[%v] exists but err is [%v]", logFilePath2, err)
+		return
+	}
+	_, err = os.Stat(logFilePath3)
+	if err != nil {
+		t.Errorf("expect file[%v] exists but err is [%v]", logFilePath3, err)
+		return
+	}
+}
+
+// create file and modify modTime to 7 days ago
+func createFile(logFilePath string, modTime bool) (err error) {
+	_, err = os.Create(logFilePath)
+	if err != nil {
+		return
+	}
+	info, err := os.Stat(logFilePath)
+	if err != nil {
+		return
+	}
+	if modTime {
+		err = os.Chtimes(logFilePath, info.ModTime().AddDate(0, 0, -7), info.ModTime().AddDate(0, 0, -7))
+		if err != nil {
+			return
+		}
+	}
+	return
 }


### PR DESCRIPTION
Signed-off-by: wenjia322 <buaa1214wwj@126.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1. Clean old logs 7 days ago.
2. Rotate critical logs.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

None.

**Special notes for your reviewer**:

None.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
