### PR TITLE
Judge null pointer when get datanode info from master

### DIFF
--- a/datanode/server.go
+++ b/datanode/server.go
@@ -41,9 +41,10 @@ import (
 )
 
 var (
-	ErrIncorrectStoreType       = errors.New("Incorrect store type")
-	ErrNoSpaceToCreatePartition = errors.New("No disk space to create a data partition")
-	ErrNewSpaceManagerFailed    = errors.New("Creater new space manager failed")
+	ErrIncorrectStoreType          = errors.New("Incorrect store type")
+	ErrNoSpaceToCreatePartition    = errors.New("No disk space to create a data partition")
+	ErrNewSpaceManagerFailed       = errors.New("Creater new space manager failed")
+	ErrGetMasterDatanodeInfoFailed = errors.New("Failed to get datanode info from master")
 
 	LocalIP, serverPort string
 	gConnPool           = util.NewConnectPool()
@@ -142,7 +143,7 @@ func doStart(server common.Server, cfg *config.Config) (err error) {
 
 	// check local partition compare with master ,if lack,then not start
 	if err = s.checkLocalPartitionMatchWithMaster(); err != nil {
-		fmt.Println(err)
+		log.LogError(err)
 		exporter.Warning(err.Error())
 		return
 	}
@@ -320,6 +321,10 @@ func (s *DataNode) checkLocalPartitionMatchWithMaster() (err error) {
 			continue
 		}
 		break
+	}
+	if dataNode == nil {
+		err = ErrGetMasterDatanodeInfoFailed
+		return
 	}
 	dinfo := convert(dataNode)
 	if len(dinfo.PersistenceDataPartitions) == 0 {


### PR DESCRIPTION
**What this PR does / why we need it**:
Judge null pointer when get datanode info from master.

**Which issue this PR fixes** *(optional, in `fixes #<971>(, fixes #<971>, ...)` format, will close that issue when PR gets merged)*: 
fixes #971

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```