### PR TITLE
fix: replace 'os.Open' with 'ioutil.ReadDir'

### DIFF
--- a/util/log/rotate.go
+++ b/util/log/rotate.go
@@ -16,8 +16,9 @@ package log
 
 const (
 	// DefaultRollingSize Specifies at what size to roll the output log at
-	// Units: MB
-	DefaultRollingSize = 20 * 1024 * 1024 * 1024
+	// Units: byte
+	DefaultRollingSize    = 20 * 1024 * 1024 * 1024
+	DefaultMinRollingSize = 200 * 1024 * 1024
 	// DefaultHeadRoom The tolerance for the log space limit (in megabytes)
 	DefaultHeadRoom = 50 * 1024
 	// DefaultHeadRatio The disk reserve space ratio


### PR DESCRIPTION
Signed-off-by: wenjia322 <buaa1214wwj@126.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Replace 'os.Open' with 'ioutil.ReadDir' when check to clean logs.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

None.

**Special notes for your reviewer**:

None.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
