### PR TITLE
[release-0720]enhancement: clean up the raft log; limit size of raft logs and rotate

### DIFF
--- a/raftstore/log_test.go
+++ b/raftstore/log_test.go
@@ -1,0 +1,83 @@
+package raftstore
+
+import (
+	"os"
+	"path"
+	"testing"
+	"time"
+)
+
+// test auto remove raft log 7 days ago
+func TestCleanRaftLog(t *testing.T) {
+	dir := path.Join("/tmp/raft", "logs")
+	_, err := os.Stat(dir)
+	if os.IsNotExist(err) {
+		os.MkdirAll(dir, 0755)
+	}
+
+	logFilePath1 := path.Join(dir, "raft_info.log.old")
+	if err = createFile(logFilePath1, true); err != nil {
+		t.Errorf("create file[%v] err[%v]", logFilePath1, err)
+		return
+	}
+	logFilePath2 := path.Join(dir, "test_clean.log.old")
+	if err = createFile(logFilePath2, true); err != nil {
+		t.Errorf("create file[%v] err[%v]", logFilePath2, err)
+		return
+	}
+	logFilePath3 := path.Join(dir, "raft_err.log.new")
+	if err = createFile(logFilePath3, false); err != nil {
+		t.Errorf("create file[%v] err[%v]", logFilePath3, err)
+		return
+	}
+	logFilePath4 := path.Join(dir, "raft_info.log")
+	if err = createFile(logFilePath4, true); err != nil {
+		t.Errorf("create file[%v] err[%v]", logFilePath4, err)
+		return
+	}
+
+	newRaftLogger("/tmp/raft")
+	time.Sleep(time.Second * 10)
+
+	_, err = os.Stat(logFilePath1)
+	if !os.IsNotExist(err) {
+		t.Errorf("expect file[%v] doesn't exist but err is [%v]", logFilePath1, err)
+		return
+	}
+	_, err = os.Stat(logFilePath2)
+	if err != nil {
+		t.Errorf("expect file[%v] exists but err is [%v]", logFilePath2, err)
+		return
+	}
+	_, err = os.Stat(logFilePath3)
+	if err != nil {
+		t.Errorf("expect file[%v] exists but err is [%v]", logFilePath3, err)
+		return
+	}
+	_, err = os.Stat(logFilePath4)
+	if err != nil {
+		t.Errorf("expect file[%v] exists but err is [%v]", logFilePath4, err)
+		return
+	}
+
+	os.RemoveAll(dir)
+}
+
+// create file and modify modTime to 7 days ago
+func createFile(logFilePath string, modTime bool) (err error) {
+	_, err = os.Create(logFilePath)
+	if err != nil {
+		return
+	}
+	info, err := os.Stat(logFilePath)
+	if err != nil {
+		return
+	}
+	if modTime {
+		err = os.Chtimes(logFilePath, info.ModTime().AddDate(0, 0, -7), info.ModTime().AddDate(0, 0, -7))
+		if err != nil {
+			return
+		}
+	}
+	return
+}

--- a/util/log/log.go
+++ b/util/log/log.go
@@ -281,9 +281,14 @@ func InitLog(dir, module string, level Level, rotate *LogRotate) (*Log, error) {
 			return nil, fmt.Errorf("[InitLog] stats disk space: %s",
 				err.Error())
 		}
-		minRatio := float64(fs.Blocks*uint64(fs.
-			Bsize)) * DefaultHeadRatio / 1024 / 1024
+		var minRatio float64
+		if float64(fs.Bavail*uint64(fs.Bsize)) < float64(fs.Blocks*uint64(fs.Bsize))*DefaultHeadRatio {
+			minRatio = float64(fs.Bavail*uint64(fs.Bsize)) * DefaultHeadRatio / 1024 / 1024
+		} else {
+			minRatio = float64(fs.Blocks*uint64(fs.Bsize)) * DefaultHeadRatio / 1024 / 1024
+		}
 		rotate.SetHeadRoomMb(int64(math.Min(minRatio, DefaultHeadRoom)))
+
 		minRollingSize := int64(fs.Bavail * uint64(fs.Bsize) / uint64(len(levelPrefixes)))
 		if minRollingSize < DefaultMinRollingSize {
 			minRollingSize = DefaultMinRollingSize

--- a/util/log/rotate.go
+++ b/util/log/rotate.go
@@ -17,7 +17,7 @@ package log
 const (
 	// DefaultRollingSize Specifies at what size to roll the output log at
 	// Units: byte
-	DefaultRollingSize    = 20 * 1024 * 1024 * 1024
+	DefaultRollingSize    = 5 * 1024 * 1024 * 1024
 	DefaultMinRollingSize = 200 * 1024 * 1024
 	// DefaultHeadRoom The tolerance for the log space limit (in megabytes)
 	DefaultHeadRoom = 50 * 1024

--- a/vendor/github.com/tiglabs/raft/util/log/log.go
+++ b/vendor/github.com/tiglabs/raft/util/log/log.go
@@ -18,9 +18,15 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
+	"math"
 	"os"
+	"path"
 	"runtime"
+	"sort"
+	"strings"
 	"sync"
+	"syscall"
 	"time"
 )
 
@@ -33,7 +39,15 @@ const (
 	Lshortfile                    // final file name element and line number: d.go:23. overrides Llongfile
 	LstdFlags     = Ldate | Ltime // initial values for the standard logger
 
-	LogFileNameDateFormat = "2006-01-02"
+	LogFileNameDateFormat = "200601021504"
+	LogMaxReservedDays    = 7 * 24 * time.Hour
+	// DefaultRollingSize Specifies at what size to roll the output log at, Units: MB
+	DefaultRollingSize    = 5 * 1024
+	DefaultMinRollingSize = 200
+	// DefaultHeadRoom The tolerance for the log space limit, Units: MB
+	DefaultHeadRoom = 50 * 1024
+	// DefaultHeadRatio The disk reserve space ratio
+	DefaultHeadRatio = 0.2
 )
 
 var (
@@ -53,6 +67,20 @@ type logWriter struct {
 
 func newLogWriter(out io.WriteCloser, prefix string, flag int) *logWriter {
 	return &logWriter{out: out, prefix: prefix, flag: flag}
+}
+
+type RolledFile []os.FileInfo
+
+func (f RolledFile) Less(i, j int) bool {
+	return f[i].ModTime().Before(f[j].ModTime())
+}
+
+func (f RolledFile) Len() int {
+	return len(f)
+}
+
+func (f RolledFile) Swap(i, j int) {
+	f[i], f[j] = f[j], f[i]
 }
 
 func itoa(buf *[]byte, i int, wid int) {
@@ -176,6 +204,16 @@ func (lw *logWriter) createFile(logDir, logFile, module string, rotate bool) (*o
 	return file, err
 }
 
+func (lw *logWriter) checkRollingSize(logDir, logFile, module string, rollingSizeMB int64) {
+	logFilePath := path.Join(logDir, module + logFile)
+	fInfo, err := os.Stat(logFilePath)
+	if err == nil {
+		if fInfo.Size() >= rollingSizeMB*1024*1024 {
+			lw.rotateFile(logDir, logFile, module, true)
+		}
+	}
+}
+
 const (
 	TraceLevel = 0
 	DebugLevel = 1
@@ -202,16 +240,18 @@ type entity struct {
 }
 
 type Log struct {
-	dir       string
-	module    string
-	level     int
-	startTime time.Time
-	flag      int
-	err       *logWriter
-	warn      *logWriter
-	info      *logWriter
-	debug     *logWriter
-	entityCh  chan *entity
+	dir       		string
+	module    		string
+	level     		int
+	startTime 		time.Time
+	flag      		int
+	err       		*logWriter
+	warn      		*logWriter
+	info      		*logWriter
+	debug     		*logWriter
+	entityCh  		chan *entity
+	rollingSizeMB	int64 // the size of the rotated log, unit: MB
+	headRoomMB    	int64 // capacity reserved for writing the next log on the disk, unit: MB
 }
 
 var glog *Log = NewDefaultLog()
@@ -236,7 +276,11 @@ func NewLog(dir, module, level string) (*Log, error) {
 	lg.entityCh = make(chan *entity, 204800)
 
 	if dir != "" {
+		if err := lg.SetRotate(dir); err != nil {
+			return nil, err
+		}
 		go lg.checkLogRotation(dir, module)
+		go lg.checkCleanLog(dir, module)
 	}
 	go lg.loopMsg()
 
@@ -304,6 +348,27 @@ func (l *Log) SetLevel(level string) {
 
 func (l *Log) SetPrefix(s, level string) string {
 	return level + " " + s
+}
+
+func (l *Log) SetRotate(logDir string) error {
+	fs := syscall.Statfs_t{}
+	if err := syscall.Statfs(logDir, &fs); err != nil {
+		return fmt.Errorf("[InitLog] stats disk space: %s", err.Error())
+	}
+	var minRatio float64
+	if float64(fs.Bavail * uint64(fs.Bsize)) < float64(fs.Blocks*uint64(fs.Bsize)) * DefaultHeadRatio {
+		minRatio = float64(fs.Bavail*uint64(fs.Bsize)) * DefaultHeadRatio / 1024 /1024
+	} else {
+		minRatio = float64(fs.Blocks*uint64(fs.Bsize)) * DefaultHeadRatio / 1024 / 1024
+	}
+	l.headRoomMB = int64(math.Min(minRatio, DefaultHeadRoom))
+
+	minRollingSize := int64(fs.Bavail * uint64(fs.Bsize) / 4)/1024/1024	// because 4 log levels
+	if minRollingSize < DefaultMinRollingSize {
+		minRollingSize = DefaultMinRollingSize
+	}
+	l.rollingSizeMB = int64(math.Min(float64(minRollingSize), float64(DefaultRollingSize)))
+	return nil
 }
 
 func (l *Log) IsEnableDebug() bool {
@@ -392,10 +457,21 @@ func (l *Log) printMsg(msg string, file string, line int, now time.Time) {
 }
 
 func (l *Log) checkLogRotation(logDir, module string) {
+	// handle panic
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Printf("[Util.Logger]Check logger rotation panic: [%s]\r\n", r)
+		}
+	}()
+
 	for {
 		yesterday := time.Now().AddDate(0, 0, -1)
 		_, err := os.Stat(logDir + "/" + module + errLogFileName + "." + yesterday.Format(LogFileNameDateFormat))
 		if err == nil || time.Now().Day() == l.startTime.Day() {
+			l.debug.checkRollingSize(logDir, debugLogFileName, module, l.rollingSizeMB)
+			l.info.checkRollingSize(logDir, infoLogFileName, module, l.rollingSizeMB)
+			l.warn.checkRollingSize(logDir, warnLogFileName, module, l.rollingSizeMB)
+			l.err.checkRollingSize(logDir, errLogFileName, module, l.rollingSizeMB)
 			time.Sleep(time.Second * 600)
 			continue
 		}
@@ -406,7 +482,71 @@ func (l *Log) checkLogRotation(logDir, module string) {
 		l.warn.rotateFile(logDir, warnLogFileName, module, true)
 		l.err.rotateFile(logDir, errLogFileName, module, true)
 		l.startTime = time.Now()
+		time.Sleep(time.Second * 600)
 	}
+}
+
+func (l *Log) checkCleanLog(logDir, module string) {
+	// handle panic
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Printf("[Util.Logger]Check clean logger file panic: [%s]\r\n", r)
+		}
+	}()
+
+	for {
+		// check disk space
+		fs := syscall.Statfs_t{}
+		if err := syscall.Statfs(logDir, &fs); err != nil {
+			fmt.Printf("[Util.Logger]Check disk space of dir[%s] err: [%s]\r\n", logDir, err)
+			time.Sleep(time.Second * 600)
+			continue
+		}
+		diskSpaceLeft := int64(fs.Bavail * uint64(fs.Bsize))
+		diskSpaceLeft -= l.headRoomMB * 1024 * 1024
+
+		fInfos, err := ioutil.ReadDir(logDir)
+		if err != nil || len(fInfos) == 0 {
+			time.Sleep(time.Second * 600)
+			continue
+		}
+		var needDelFiles RolledFile
+		for _, info := range fInfos {
+			if deleteFileFilter(module, info, diskSpaceLeft) {
+				needDelFiles = append(needDelFiles, info)
+			}
+		}
+		sort.Sort(needDelFiles)
+		for _, info := range needDelFiles {
+			if err = os.Remove(path.Join(logDir, info.Name())); err != nil {
+				fmt.Printf("[Util.Logger]Remove logger file[%s] err: [%s]\r\n", info.Name(), err)
+				continue
+			}
+			diskSpaceLeft += info.Size()
+			if diskSpaceLeft > 0 && time.Since(info.ModTime()) < LogMaxReservedDays {
+				break
+			}
+		}
+		time.Sleep(time.Second * 600)
+	}
+}
+
+func deleteFileFilter(module string, info os.FileInfo, diskSpaceLeft int64) bool {
+	if diskSpaceLeft <= 0 {
+		return info.Mode().IsRegular() && isExpiredRaftLog(module, info.Name())
+	}
+	return time.Since(info.ModTime()) > LogMaxReservedDays && isExpiredRaftLog(module, info.Name())
+}
+
+func isExpiredRaftLog(module, name string) bool {
+	if strings.HasSuffix(name, ".log") {
+		return false
+	}
+	if strings.HasPrefix(name, module + infoLogFileName) || strings.HasPrefix(name, module + debugLogFileName) ||
+		strings.HasPrefix(name, module + warnLogFileName) || strings.HasPrefix(name, module + errLogFileName) {
+		return true
+	}
+	return false
 }
 
 func (l *Log) Debug(format string, v ...interface{}) {


### PR DESCRIPTION
Signed-off-by: wenjia322 <buaa1214wwj@126.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1. Clean up the raft log when the remaining space is insufficient or 7 days ago.
2. Limit the size of raft log and rotate.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

None.

**Special notes for your reviewer**:

None.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
