### PR TITLE
add checksum for metanode snapshoting and add 2 config about it

### DIFF
--- a/metanode/checksum.go
+++ b/metanode/checksum.go
@@ -1,0 +1,47 @@
+package metanode
+
+import (
+	"encoding/base64"
+	"fmt"
+	"github.com/chubaofs/chubaofs/util/errors"
+	"github.com/chubaofs/chubaofs/util/hashfactory"
+	"io/ioutil"
+	"strings"
+)
+
+func checksumToStr(sum []byte) string {
+	return base64.StdEncoding.EncodeToString(sum)
+}
+
+func strToChecksum(str string) ([]byte, error) {
+	return base64.StdEncoding.DecodeString(str)
+}
+
+func writeChecksumToFile(file string, sum []byte, typ string) error {
+	raw := fmt.Sprintf("%s|%s", typ, checksumToStr(sum))
+	return ioutil.WriteFile(file, []byte(raw), 0644)
+}
+
+func readChecksumFromFile(file string) (sum []byte, typ string, err error) {
+	var raw []byte
+	raw, err = ioutil.ReadFile(file)
+	if err != nil {
+		return
+	}
+	str := string(raw)
+	parts := strings.Split(str, "|")
+	if len(parts) != 2 {
+		err = errors.NewErrorf("invalid checksum format, should be [type]|[checksum], but got %s", str)
+		return
+	}
+	typePart, sumPart := parts[0], parts[1]
+	if !hashfactory.Exist(typePart) {
+		err = errors.NewErrorf("unknown checksum type %s", typePart)
+		return
+	}
+	if sum, err = strToChecksum(sumPart); err != nil {
+		return
+	}
+	typ = typePart
+	return
+}

--- a/metanode/const.go
+++ b/metanode/const.go
@@ -137,16 +137,18 @@ const (
 
 // Configuration keys
 const (
-	cfgLocalIP           = "localIP"
-	cfgListen            = "listen"
-	cfgMetadataDir       = "metadataDir"
-	cfgRaftDir           = "raftDir"
-	cfgMasterAddrs       = "masterAddrs" // will be deprecated
-	cfgRaftHeartbeatPort = "raftHeartbeatPort"
-	cfgRaftReplicaPort   = "raftReplicaPort"
-	cfgDeleteBatchCount  = "deleteBatchCount"
-	cfgTotalMem          = "totalMem"
-	cfgZoneName          = "zoneName"
+	cfgLocalIP             = "localIP"
+	cfgListen              = "listen"
+	cfgMetadataDir         = "metadataDir"
+	cfgRaftDir             = "raftDir"
+	cfgIgnoreChecksumError = "ignoreChecksumError"
+	cfgChecksumFn          = "checksumFunc"
+	cfgMasterAddrs         = "masterAddrs" // will be deprecated
+	cfgRaftHeartbeatPort   = "raftHeartbeatPort"
+	cfgRaftReplicaPort     = "raftReplicaPort"
+	cfgDeleteBatchCount    = "deleteBatchCount"
+	cfgTotalMem            = "totalMem"
+	cfgZoneName            = "zoneName"
 
 	metaNodeDeleteBatchCountKey = "batchCount"
 )

--- a/util/hashfactory/hashfactory.go
+++ b/util/hashfactory/hashfactory.go
@@ -1,0 +1,53 @@
+package hashfactory
+
+import (
+	"crypto/md5"
+	"crypto/sha1"
+	"crypto/sha256"
+	"crypto/sha512"
+	"hash"
+	"hash/crc32"
+	"hash/crc64"
+	"strings"
+)
+
+type Hash = hash.Hash
+
+type FactoryFunc func() Hash
+
+var factoryMap = make(map[string]FactoryFunc)
+
+func AddFactoryFunc(name string, f FactoryFunc) {
+	factoryMap[name] = f
+}
+
+func GetFactoryFunc(name string) FactoryFunc {
+	name = strings.ToLower(name)
+	return factoryMap[name]
+}
+
+func Exist(name string) bool {
+	return GetFactoryFunc(name) != nil
+}
+
+func New(name string) Hash {
+	f := GetFactoryFunc(name)
+	if f != nil {
+		return f()
+	} else {
+		return nil
+	}
+}
+
+func init() {
+	AddFactoryFunc("crc32", func() Hash {
+		return crc32.NewIEEE()
+	})
+	AddFactoryFunc("crc64", func() Hash {
+		return crc64.New(crc64.MakeTable(crc64.ISO))
+	})
+	AddFactoryFunc("md5", md5.New)
+	AddFactoryFunc("sha1", sha1.New)
+	AddFactoryFunc("sha256", sha256.New)
+	AddFactoryFunc("sha512", sha512.New)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
meatanode: add a checksum file for each snapshot file. forward compatible and support fallback

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #993 

**Special notes for your reviewer**:
Taking into account the forward compatibility of the snapshot file, we only create a new "checksum file" for each snapshot, instead of adding a checksum at the end of the snapshot file. For example, the resulting file-tree of snapshot dir will be :
```shell
.
├── .checksum.apply
├── .checksum.dentry
├── .checksum.extend
├── .checksum.inode
├── .checksum.multipart
├── .sign
├── apply
├── dentry
├── extend
├── inode
└── multipart
```
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
add configure "checksumFunc" for meta node：the value could be crc32|crc64|md5|sha1|sha256|sha512 (No case limit)
add configure "ignoreChecksumError" to neglect checksum not match error. (Once if the data is abnormal)
```
