### PR TITLE
add config comment support and fix bug of GetInt

### DIFF
--- a/util/config/config_test.go
+++ b/util/config/config_test.go
@@ -1,0 +1,54 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+const configTxt = `
+{
+  "GetInt": 1234, # English Comment test
+  "GetInt64": 5678, # 中文注释测试
+  "GetFloat": 1234.5678, # Prueba de comentarios en español
+  "GetString": "test string", # Deutscher Kommentartest
+  "GetBool": true, 
+  "GetBoolStr": "true",
+  "GetStringSlice": [
+    "test string in slice 1",
+    "test string in slice 2" # in [ comment test
+  ],
+  "Quote": "in quote # test"
+}
+`
+
+func TestLoadConfigString(t *testing.T) {
+	conf := LoadConfigString(configTxt)
+	if conf.GetInt("GetInt") != 1234 {
+		t.Fatal()
+	}
+	if conf.GetInt64("GetInt64") != 5678 {
+		t.Fatal()
+	}
+	if conf.GetFloat("GetFloat") != 1234.5678 {
+		t.Fatal()
+	}
+	if conf.GetString("GetString") != "test string" {
+		t.Fatal()
+	}
+	if conf.GetBool("GetBool") != true {
+		t.Fatal()
+	}
+	if conf.GetBool("GetBoolStr") != true {
+		t.Fatal()
+	}
+	if !reflect.DeepEqual(conf.GetStringSlice("GetStringSlice"),
+		[]string{
+			"test string in slice 1",
+			"test string in slice 2"}) {
+		t.Fatal()
+	}
+	if conf.GetString("Quote") != "in quote # test" {
+		t.Fatal()
+	}
+	t.Log("conf check success")
+}


### PR DESCRIPTION
Signed-off-by: xrefft <cserxiao@qq.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Make chubaofs configuration file support comments, which might be useful in some ops scenario.
BTW, fixed the bug that "Config.GetInt()" cannot get the int value correctly. 
(Config.GetInt() have 0 usage in code. I believe this function will be deprecated in future).

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes 

**Special notes for your reviewer**:
The form of the comment is as follows:
```conf
{
  "GetInt": 1234, # English Comment test
  "GetInt64": 5678, # 中文注释测试
  "GetFloat": 1234.5678, # Prueba de comentarios en español
  "GetString": "test string", # Deutscher Kommentartest
  "GetBool": true, 
  "GetBoolStr": "true",
  "GetStringSlice": [
    "test string in slice 1",
    "test string in slice 2" # in [ comment test
  ],
  "Quote": "in quote # test"
}
```
see [util/config/config_test.go](1024/files#diff-8b90b2f0721a5b73ad051692803f434171c14ee28b56aaf2c22aa12684e76d63)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
