### PR TITLE
Enhancement: shutdown process of DataNode

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -265,6 +265,7 @@ func main() {
 
 	// Block main goroutine until server shutdown.
 	server.Sync()
+	log.LogFlush()
 	os.Exit(0)
 }
 

--- a/datanode/partition.go
+++ b/datanode/partition.go
@@ -24,6 +24,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"hash/crc32"
@@ -104,9 +105,11 @@ type DataPartition struct {
 	lastTruncateID  uint64 // truncate id used in Raft
 	minAppliedID    uint64
 	maxAppliedID    uint64
-	stopRaftC       chan uint64
-	storeC          chan uint64
-	stopC           chan bool
+
+	stopOnce  sync.Once
+	stopRaftC chan uint64
+	storeC    chan uint64
+	stopC     chan bool
 
 	intervalToUpdateReplicas      int64 // interval to ask the master for updating the replica information
 	snapshot                      []*proto.File
@@ -354,12 +357,16 @@ func (dp *DataPartition) SnapShot() (files []*proto.File) {
 
 // Stop close the store and the raft store.
 func (dp *DataPartition) Stop() {
-	if dp.stopC != nil {
-		close(dp.stopC)
-	}
-	// Close the store and raftstore.
-	dp.extentStore.Close()
-	dp.stopRaft()
+	dp.stopOnce.Do(func() {
+		if dp.stopC != nil {
+			close(dp.stopC)
+		}
+		// Close the store and raftstore.
+		dp.extentStore.Close()
+		dp.stopRaft()
+		_ = dp.storeAppliedID(atomic.LoadUint64(&dp.appliedID))
+	})
+	return
 }
 
 // Disk returns the disk instance.

--- a/datanode/partition_raft.go
+++ b/datanode/partition_raft.go
@@ -24,6 +24,7 @@ import (
 	"path"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/chubaofs/chubaofs/proto"
@@ -203,7 +204,7 @@ func (dp *DataPartition) StartRaftLoggingSchedule() {
 			truncateRaftLogTimer.Reset(time.Minute)
 
 		case <-storeAppliedIDTimer.C:
-			if err := dp.storeAppliedID(dp.appliedID); err != nil {
+			if err := dp.storeAppliedID(atomic.LoadUint64(&dp.appliedID)); err != nil {
 				err = errors.NewErrorf("[startSchedule]: dump partition=%d: %v", dp.config.PartitionID, err.Error())
 				log.LogErrorf(err.Error())
 			}

--- a/datanode/server.go
+++ b/datanode/server.go
@@ -165,7 +165,7 @@ func doShutdown(server common.Server) {
 		return
 	}
 	close(s.stopC)
-
+	s.space.Stop()
 	s.stopUpdateNodeInfo()
 	s.stopTCPService()
 	s.stopRaftServer()

--- a/datanode/space_manager.go
+++ b/datanode/space_manager.go
@@ -19,12 +19,13 @@ import (
 	"sync"
 	"time"
 
+	"math"
+	"os"
+
 	"github.com/chubaofs/chubaofs/proto"
 	"github.com/chubaofs/chubaofs/raftstore"
 	"github.com/chubaofs/chubaofs/util"
 	"github.com/chubaofs/chubaofs/util/log"
-	"math"
-	"os"
 )
 
 // SpaceManager manages the disk space.
@@ -65,6 +66,34 @@ func (manager *SpaceManager) Stop() {
 		recover()
 	}()
 	close(manager.stopC)
+	// Parallel stop data partitions.
+	const maxParallelism = 128
+	var parallelism = int(math.Min(float64(maxParallelism), float64(len(manager.partitions))))
+	wg := sync.WaitGroup{}
+	partitionC := make(chan *DataPartition, parallelism)
+	wg.Add(1)
+	go func(c chan<- *DataPartition) {
+		defer wg.Done()
+		for _, partition := range manager.partitions {
+			c <- partition
+		}
+		close(c)
+	}(partitionC)
+
+	for i := 0; i < parallelism; i++ {
+		wg.Add(1)
+		go func(c <-chan *DataPartition) {
+			defer wg.Done()
+			var partition *DataPartition
+			for {
+				if partition = <-c; partition == nil {
+					return
+				}
+				partition.Stop()
+			}
+		}(partitionC)
+	}
+	wg.Wait()
 }
 
 func (manager *SpaceManager) SetNodeID(nodeID uint64) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Improve the DataNode shutdown process, and make the raft apply ID information of all data partitions persistent after receiving the stop signal.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*:
None.

**Special notes for your reviewer**:
None.

**Release note**:
None.