### PR TITLE
use statfs's bfree to caclute used size

### DIFF
--- a/datanode/disk.go
+++ b/datanode/disk.go
@@ -115,7 +115,8 @@ func (d *Disk) computeUsage() (err error) {
 	d.Available = uint64(available)
 
 	//  used := math.Max(0, int64(total - available))
-	used := int64(total - available)
+	free := int64(fs.Bfree*uint64(fs.Bsize) - d.ReservedSpace)
+	used := int64(total - free)
 	if used < 0 {
 		used = 0
 	}


### PR DESCRIPTION
Signed-off-by: Victor1319 <834863182@qq.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
I found it's better to use (total space - free space) to get used space, because I think that may be much better know how much space used by chubaofs sytem. And by this way, the used sapce will be same both ext4 and xfs system

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1029 

