### PR TITLE
Fix: logic issue when read persisted prealloc space extent ID

### DIFF
--- a/storage/persistence_crc.go
+++ b/storage/persistence_crc.go
@@ -67,7 +67,7 @@ func (s *ExtentStore) PersistenceBaseExtentID(extentID uint64) (err error) {
 
 func (s *ExtentStore) GetPreAllocSpaceExtentIDOnVerfiyFile() (extentID uint64) {
 	value := make([]byte, 8)
-	_, err := s.metadataFp.WriteAt(value, 8)
+	_, err := s.metadataFp.ReadAt(value, 8)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

It has been clear that the following code has a logical problem. 
https://github.com/chubaofs/chubaofs/blob/5fa1f6995d8c0b5268ed61361ac9b95b01c3a90f/storage/persistence_crc.go#L68-L76
The logic here should be read, not write.
This logical problem will not affect system functions and data integrity.

**Which issue this PR fixes**: 
fixes #1046

**Special notes for your reviewer**:
None.

**Release note**:
None.