### PR TITLE
feature: support multiple subdir permissions

### DIFF
--- a/proto/perm_action.go
+++ b/proto/perm_action.go
@@ -301,19 +301,24 @@ func (p Permission) MatchSubdir(subdir string) bool {
 	}
 
 	s := strings.TrimPrefix(string(p), string(BuiltinPermissionPrefix))
-	var toCompare string
 
-	if subdirRegexp.MatchString(s) {
-		toCompare = strings.Split(s, ":")[0]
-	} else {
-		toCompare = ""
+	if !subdirRegexp.MatchString(s) {
+		if subdir == "" || subdir == "/" {
+			return true
+		} else {
+			return false
+		}
 	}
 
-	if (subdir == "" || subdir == "/") && (toCompare == "" || toCompare == "/") {
-		return true
+	toCompare := strings.Split(s, ":")
+	for i := 0; i < len(toCompare); i++ {
+		if (subdir == "" || subdir == "/") && (toCompare[i] == "" || toCompare[i] == "/") ||
+			subdir == toCompare[i] {
+			return true
+		}
 	}
 
-	return subdir == toCompare
+	return false
 }
 
 func (p Permission) IsCustom() bool {


### PR DESCRIPTION
Multiple subdirs are separated by colons. For example:

perm:builtin:/a/b:/a:Writable

Signed-off-by: Shuoran Liu <shuoranliu@gmail.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
