### PR TITLE
fix data node raftstatus's active value #1054

### DIFF
--- a/vendor/github.com/tiglabs/raft/raft_fsm_leader.go
+++ b/vendor/github.com/tiglabs/raft/raft_fsm_leader.go
@@ -37,6 +37,9 @@ func (r *raftFsm) becomeLeader() {
 	r.leader = r.config.NodeID
 	r.state = stateLeader
 	r.acks = nil
+	if pr, ok := r.replicas[r.config.NodeID]; ok {
+		pr.active = true
+	}
 
 	ents, err := r.raftLog.entries(r.raftLog.committed+1, noLimit)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Victor1319 <834863182@qq.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
before, replica's status is not initate when replica change to raft leader, so when raft replica change to leader, set  it's status ``active=true``

**Which issue this PR fixes: fixes #1054

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
