### PR TITLE
Modify user.rst

### DIFF
--- a/docs/source/admin-api/master/user.rst
+++ b/docs/source/admin-api/master/user.rst
@@ -164,7 +164,7 @@ Transfer Volume
 
 .. code-block:: bash
 
-   curl -H "Content-Type:application/json" -X POST --data '{"volume":"vol","user_src":"user1","user_dst":"user2","force":"true"}' "http://10.196.59.198:17010/user/transferVol"
+   curl -H "Content-Type:application/json" -X POST --data '{"volume":"vol","user_src":"user1","user_dst":"user2","force":true}' "http://10.196.59.198:17010/user/transferVol"
 
 Transfer the ownership of the specified volume. This operation removes the specified volume from the ``owner_vols`` of source user name and adds it to the ``owner_vols`` of target user name; At the same time, the value of the field ``Owner`` in the volume structure will also be updated to the target user ID.
 


### PR DESCRIPTION
“There is an error in the transfer volume”

Signed-off-by: zhangxiangping <240133996@qq.com>

<!-- Thanks for sending a pull request! -->
Error in the transfer volume command in the user command management section.
When unmarshal, "true" will be thought as astring instead of a bool
**What this PR does / why we need it**:


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
