### PR TITLE
fix: update user secret key failed without rolling back access key

### DIFF
--- a/master/user.go
+++ b/master/user.go
@@ -181,6 +181,7 @@ func (u *User) updateKey(param *proto.UserUpdateParam) (userInfo *proto.UserInfo
 	}
 	if param.SecretKey != "" {
 		if !proto.IsValidSK(param.SecretKey) {
+			userInfo.AccessKey = formerAK
 			err = proto.ErrInvalidSecretKey
 			return
 		}


### PR DESCRIPTION
"fix: update user secret key failed without rolling back access key"

Signed-off-by: zhangxiangping <240133996@qq.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
In the process of updating users, once the wrong sk value to be updated is detected, the updated ak value should be rolled back

**Which issue this PR fixes** *(optional, in `fixes #<1061>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1061

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
