### PR TITLE
fix: update user secret key failed without rolling back access key

### DIFF
--- a/master/user.go
+++ b/master/user.go
@@ -168,6 +168,7 @@ func (u *User) updateKey(param *proto.UserUpdateParam) (userInfo *proto.UserInfo
 		return
 	}
 	var formerAK = userInfo.AccessKey
+	var akMark, skMark, typeMark, describeMark int
 	if param.AccessKey != "" {
 		if !proto.IsValidAK(param.AccessKey) {
 			err = proto.ErrInvalidAccessKey
@@ -177,20 +178,20 @@ func (u *User) updateKey(param *proto.UserUpdateParam) (userInfo *proto.UserInfo
 			err = proto.ErrDuplicateAccessKey
 			return
 		}
-		userInfo.AccessKey = param.AccessKey
+		akMark = 1
 	}
 	if param.SecretKey != "" {
 		if !proto.IsValidSK(param.SecretKey) {
 			err = proto.ErrInvalidSecretKey
 			return
 		}
-		userInfo.SecretKey = param.SecretKey
+		skMark = 1
 	}
 	if param.Type.Valid() {
-		userInfo.UserType = param.Type
+		typeMark = 1
 	}
 	if param.Description != "" {
-		userInfo.Description = param.Description
+		describeMark = 1
 	}
 
 	var akUserBef *proto.AKUser
@@ -201,6 +202,18 @@ func (u *User) updateKey(param *proto.UserUpdateParam) (userInfo *proto.UserInfo
 	} else {
 		err = proto.ErrAccessKeyNotExists
 		return
+	}
+	if akMark == 1 {
+		userInfo.AccessKey = param.AccessKey
+	}
+	if skMark == 1 {
+		userInfo.SecretKey = param.SecretKey
+	}
+	if typeMark == 1 {
+		userInfo.UserType = param.Type
+	}
+	if describeMark == 1 {
+		userInfo.Description = param.Description
 	}
 
 	if len(strings.TrimSpace(param.Password)) != 0 {


### PR DESCRIPTION
Signed-off-by: zhangxiangping <240133996@qq.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
In the process of updating users, once the wrong sk value to be updated is detected, the updated ak value should be rolled back


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1061 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
