### PR TITLE
fix: overlapping extents lost due to concurrent client appending keys

### DIFF
--- a/metanode/const.go
+++ b/metanode/const.go
@@ -117,6 +117,8 @@ const (
 	opFSMDeleteDentryBatch
 	opFSMUnlinkInodeBatch
 	opFSMEvictInodeBatch
+
+	opFSMExtentsAddWithCheck
 )
 
 var (

--- a/metanode/manager.go
+++ b/metanode/manager.go
@@ -18,8 +18,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"net"
 	syslog "log"
+	"net"
 	_ "net/http/pprof"
 	"os"
 	"path"
@@ -111,6 +111,8 @@ func (m *metadataManager) HandleMetadataOperation(conn net.Conn, p *Packet,
 		err = m.opMasterHeartbeat(conn, p, remoteAddr)
 	case proto.OpMetaExtentsAdd:
 		err = m.opMetaExtentsAdd(conn, p, remoteAddr)
+	case proto.OpMetaExtentAddWithCheck:
+		err = m.opMetaExtentAddWithCheck(conn, p, remoteAddr)
 	case proto.OpMetaExtentsList:
 		err = m.opMetaExtentsList(conn, p, remoteAddr)
 	case proto.OpMetaExtentsDel:

--- a/metanode/partition.go
+++ b/metanode/partition.go
@@ -143,6 +143,7 @@ type OpDentry interface {
 // OpExtent defines the interface for the extent operations.
 type OpExtent interface {
 	ExtentAppend(req *proto.AppendExtentKeyRequest, p *Packet) (err error)
+	ExtentAppendWithCheck(req *proto.AppendExtentKeyWithCheckRequest, p *Packet) (err error)
 	ExtentsList(req *proto.GetExtentsRequest, p *Packet) (err error)
 	ExtentsTruncate(req *ExtentsTruncateReq, p *Packet) (err error)
 	BatchExtentAppend(req *proto.AppendExtentKeysRequest, p *Packet) (err error)
@@ -668,6 +669,7 @@ func (mp *metaPartition) Reset() (err error) {
 
 	return
 }
+
 //
 func (mp *metaPartition) canRemoveSelf() (canRemove bool, err error) {
 	var partition *proto.MetaPartitionInfo

--- a/metanode/partition_fsm.go
+++ b/metanode/partition_fsm.go
@@ -135,6 +135,12 @@ func (mp *metaPartition) Apply(command []byte, index uint64) (resp interface{}, 
 			return
 		}
 		resp = mp.fsmAppendExtents(ino)
+	case opFSMExtentsAddWithCheck:
+		ino := NewInode(0, 0)
+		if err = ino.Unmarshal(msg.V); err != nil {
+			return
+		}
+		resp = mp.fsmAppendExtentsWithCheck(ino)
 	case opFSMStoreTick:
 		inodeTree := mp.getInodeTree()
 		dentryTree := mp.getDentryTree()

--- a/metanode/sorted_extents_test.go
+++ b/metanode/sorted_extents_test.go
@@ -8,10 +8,10 @@ import (
 
 func TestAppend01(t *testing.T) {
 	se := NewSortedExtents()
-	se.Append(proto.ExtentKey{FileOffset: 0, Size: 1000, ExtentId: 1})
-	se.Append(proto.ExtentKey{FileOffset: 2000, Size: 1000, ExtentId: 2})
-	se.Append(proto.ExtentKey{FileOffset: 4000, Size: 1000, ExtentId: 3})
-	se.Append(proto.ExtentKey{FileOffset: 3000, Size: 500, ExtentId: 4})
+	se.Append(proto.ExtentKey{FileOffset: 0, Size: 1000, ExtentId: 1}, nil)
+	se.Append(proto.ExtentKey{FileOffset: 2000, Size: 1000, ExtentId: 2}, nil)
+	se.Append(proto.ExtentKey{FileOffset: 4000, Size: 1000, ExtentId: 3}, nil)
+	se.Append(proto.ExtentKey{FileOffset: 3000, Size: 500, ExtentId: 4}, nil)
 	t.Logf("\neks: %v\n", se.eks)
 	if se.Size() != 5000 || len(se.eks) != 4 || se.eks[2].ExtentId != 4 {
 		t.Fail()
@@ -22,15 +22,21 @@ func TestAppend01(t *testing.T) {
 // The same extent file is extended
 func TestAppend02(t *testing.T) {
 	se := NewSortedExtents()
-	delExtents := se.Append(proto.ExtentKey{FileOffset: 0, Size: 1000, ExtentId: 1})
-	delExtents = se.Append(proto.ExtentKey{FileOffset: 0, Size: 2000, ExtentId: 1})
-	t.Logf("\ndel: %v\neks: %v", delExtents, se.eks)
-	if len(delExtents) != 0 || se.Size() != 2000 {
+	delExtents, status := se.Append(proto.ExtentKey{FileOffset: 0, Size: 1000, ExtentId: 1}, nil)
+	t.Logf("\ndel: %v\nstatus: %v\neks: %v", delExtents, status, se.eks)
+	if status != proto.OpOk || len(delExtents) != 0 {
 		t.Fail()
 	}
-	delExtents = se.Append(proto.ExtentKey{FileOffset: 0, Size: 2000, ExtentId: 2})
-	t.Logf("\ndel: %v\neks: %v", delExtents, se.eks)
-	if len(delExtents) != 1 || delExtents[0].ExtentId != 1 || se.eks[0].ExtentId != 2 {
+	delExtents, status = se.Append(proto.ExtentKey{FileOffset: 0, Size: 2000, ExtentId: 1}, nil)
+	t.Logf("\ndel: %v\nstatus: %v\neks: %v", delExtents, status, se.eks)
+	if status != proto.OpOk || len(delExtents) != 0 || se.Size() != 2000 {
+		t.Fail()
+	}
+	discard := make([]proto.ExtentKey, 0)
+	discard = append(discard, proto.ExtentKey{FileOffset: 0, Size: 2000, ExtentId: 1})
+	delExtents, status = se.Append(proto.ExtentKey{FileOffset: 0, Size: 2000, ExtentId: 2}, discard)
+	t.Logf("\ndel: %v\nstatus: %v\neks: %v", delExtents, status, se.eks)
+	if status != proto.OpOk || len(delExtents) != 1 || delExtents[0].ExtentId != 1 || se.eks[0].ExtentId != 2 {
 		t.Fail()
 	}
 	t.Logf("%v\n", se.Size())
@@ -38,11 +44,13 @@ func TestAppend02(t *testing.T) {
 
 func TestAppend03(t *testing.T) {
 	se := NewSortedExtents()
-	delExtents := se.Append(proto.ExtentKey{FileOffset: 0, Size: 1000, ExtentId: 1})
-	t.Logf("\ndel: %v\neks: %v", delExtents, se.eks)
-	delExtents = se.Append(proto.ExtentKey{FileOffset: 0, Size: 1000, ExtentId: 2})
-	t.Logf("\ndel: %v\neks: %v", delExtents, se.eks)
-	if len(delExtents) != 1 || delExtents[0].ExtentId != 1 ||
+	delExtents, status := se.Append(proto.ExtentKey{FileOffset: 0, Size: 1000, ExtentId: 1}, nil)
+	t.Logf("\ndel: %v\nstatus: %v\neks: %v", delExtents, status, se.eks)
+	discard := make([]proto.ExtentKey, 0)
+	discard = append(discard, proto.ExtentKey{FileOffset: 0, Size: 1000, ExtentId: 1})
+	delExtents, status = se.Append(proto.ExtentKey{FileOffset: 0, Size: 1000, ExtentId: 2}, discard)
+	t.Logf("\ndel: %v\nstatus: %v\neks: %v", delExtents, status, se.eks)
+	if status != proto.OpOk || len(delExtents) != 1 || delExtents[0].ExtentId != 1 ||
 		se.eks[0].ExtentId != 2 || se.Size() != 1000 {
 		t.Fail()
 	}
@@ -53,14 +61,16 @@ func TestAppend03(t *testing.T) {
 // for such case, but we should be aware of what the extents look like.
 func TestAppend04(t *testing.T) {
 	se := NewSortedExtents()
-	delExtents := se.Append(proto.ExtentKey{FileOffset: 0, Size: 1000, ExtentId: 1})
-	t.Logf("\ndel: %v\neks: %v", delExtents, se.eks)
-	delExtents = se.Append(proto.ExtentKey{FileOffset: 1000, Size: 1000, ExtentId: 2})
-	t.Logf("\ndel: %v\neks: %v", delExtents, se.eks)
-	delExtents = se.Append(proto.ExtentKey{FileOffset: 1500, Size: 4000, ExtentId: 3})
-	t.Logf("\ndel: %v\neks: %v", delExtents, se.eks)
-	delExtents = se.Append(proto.ExtentKey{FileOffset: 500, Size: 4000, ExtentId: 4})
-	t.Logf("\ndel: %v\neks: %v", delExtents, se.eks)
+	delExtents, status := se.Append(proto.ExtentKey{FileOffset: 0, Size: 1000, ExtentId: 1}, nil)
+	t.Logf("\nstatus: %v\ndel: %v\neks: %v", status, delExtents, se.eks)
+	delExtents, status = se.Append(proto.ExtentKey{FileOffset: 1000, Size: 1000, ExtentId: 2}, nil)
+	t.Logf("\nstatus: %v\ndel: %v\neks: %v", status, delExtents, se.eks)
+	delExtents, status = se.Append(proto.ExtentKey{FileOffset: 1500, Size: 4000, ExtentId: 3}, nil)
+	t.Logf("\nstatus: %v\ndel: %v\neks: %v", status, delExtents, se.eks)
+	discard := make([]proto.ExtentKey, 0)
+	discard = append(discard, proto.ExtentKey{FileOffset: 1000, Size: 1000, ExtentId: 2})
+	delExtents, status = se.Append(proto.ExtentKey{FileOffset: 500, Size: 4000, ExtentId: 4}, discard)
+	t.Logf("\nstatus: %v\ndel: %v\neks: %v", status, delExtents, se.eks)
 	if len(delExtents) != 1 || delExtents[0].ExtentId != 2 ||
 		len(se.eks) != 3 || se.Size() != 5500 ||
 		se.eks[0].ExtentId != 1 || se.eks[1].ExtentId != 4 ||
@@ -72,9 +82,9 @@ func TestAppend04(t *testing.T) {
 
 func TestTruncate01(t *testing.T) {
 	se := NewSortedExtents()
-	delExtents := se.Append(proto.ExtentKey{FileOffset: 0, Size: 1000, ExtentId: 1})
+	delExtents, _ := se.Append(proto.ExtentKey{FileOffset: 0, Size: 1000, ExtentId: 1}, nil)
 	t.Logf("\ndel: %v\neks: %v", delExtents, se.eks)
-	delExtents = se.Append(proto.ExtentKey{FileOffset: 2000, Size: 1000, ExtentId: 2})
+	delExtents, _ = se.Append(proto.ExtentKey{FileOffset: 2000, Size: 1000, ExtentId: 2}, nil)
 	t.Logf("\ndel: %v\neks: %v", delExtents, se.eks)
 	delExtents = se.Truncate(500)
 	t.Logf("\ndel: %v\neks: %v", delExtents, se.eks)

--- a/proto/fs_proto.go
+++ b/proto/fs_proto.go
@@ -300,12 +300,20 @@ type ReadDirResponse struct {
 	Children []Dentry `json:"children"`
 }
 
-// BatchAppendExtentKeyRequest defines the request to append an extent key.
+// AppendExtentKeyRequest defines the request to append an extent key.
 type AppendExtentKeyRequest struct {
 	VolName     string    `json:"vol"`
 	PartitionID uint64    `json:"pid"`
 	Inode       uint64    `json:"ino"`
 	Extent      ExtentKey `json:"ek"`
+}
+
+type AppendExtentKeyWithCheckRequest struct {
+	VolName        string      `json:"vol"`
+	PartitionID    uint64      `json:"pid"`
+	Inode          uint64      `json:"ino"`
+	Extent         ExtentKey   `json:"ek"`
+	DiscardExtents []ExtentKey `json:"dek"`
 }
 
 // GetExtentsRequest defines the reques to get extents.

--- a/proto/packet.go
+++ b/proto/packet.go
@@ -91,13 +91,14 @@ const (
 	//Operations: MetaNode Leader -> MetaNode Follower
 	OpMetaFreeInodesOnRaftFollower uint8 = 0x32
 
-	OpMetaDeleteInode     uint8 = 0x33 // delete specified inode immediately and do not remove data.
-	OpMetaBatchExtentsAdd uint8 = 0x34 // for extents batch attachment
-	OpMetaSetXAttr        uint8 = 0x35
-	OpMetaGetXAttr        uint8 = 0x36
-	OpMetaRemoveXAttr     uint8 = 0x37
-	OpMetaListXAttr       uint8 = 0x38
-	OpMetaBatchGetXAttr   uint8 = 0x39
+	OpMetaDeleteInode        uint8 = 0x33 // delete specified inode immediately and do not remove data.
+	OpMetaBatchExtentsAdd    uint8 = 0x34 // for extents batch attachment
+	OpMetaSetXAttr           uint8 = 0x35
+	OpMetaGetXAttr           uint8 = 0x36
+	OpMetaRemoveXAttr        uint8 = 0x37
+	OpMetaListXAttr          uint8 = 0x38
+	OpMetaBatchGetXAttr      uint8 = 0x39
+	OpMetaExtentAddWithCheck uint8 = 0x3A // Append extent key with discard extents check
 
 	// Operations: Master -> MetaNode
 	OpCreateMetaPartition           uint8 = 0x40
@@ -138,19 +139,20 @@ const (
 	OpMetaBatchEvictInode   uint8 = 0x93
 
 	// Commons
-	OpIntraGroupNetErr uint8 = 0xF3
-	OpArgMismatchErr   uint8 = 0xF4
-	OpNotExistErr      uint8 = 0xF5
-	OpDiskNoSpaceErr   uint8 = 0xF6
-	OpDiskErr          uint8 = 0xF7
-	OpErr              uint8 = 0xF8
-	OpAgain            uint8 = 0xF9
-	OpExistErr         uint8 = 0xFA
-	OpInodeFullErr     uint8 = 0xFB
-	OpTryOtherAddr     uint8 = 0xFC
-	OpNotPerm          uint8 = 0xFD
-	OpNotEmtpy         uint8 = 0xFE
-	OpOk               uint8 = 0xF0
+	OpConflictExtentsErr uint8 = 0xF2
+	OpIntraGroupNetErr   uint8 = 0xF3
+	OpArgMismatchErr     uint8 = 0xF4
+	OpNotExistErr        uint8 = 0xF5
+	OpDiskNoSpaceErr     uint8 = 0xF6
+	OpDiskErr            uint8 = 0xF7
+	OpErr                uint8 = 0xF8
+	OpAgain              uint8 = 0xF9
+	OpExistErr           uint8 = 0xFA
+	OpInodeFullErr       uint8 = 0xFB
+	OpTryOtherAddr       uint8 = 0xFC
+	OpNotPerm            uint8 = 0xFD
+	OpNotEmtpy           uint8 = 0xFE
+	OpOk                 uint8 = 0xF0
 
 	OpPing uint8 = 0xFF
 )
@@ -255,6 +257,8 @@ func (p *Packet) GetOpMsg() (m string) {
 		m = "OpNotifyReplicasToRepair"
 	case OpExtentRepairRead:
 		m = "OpExtentRepairRead"
+	case OpConflictExtentsErr:
+		m = "ConflictExtentsErr"
 	case OpIntraGroupNetErr:
 		m = "IntraGroupNetErr"
 	case OpMetaCreateInode:
@@ -281,6 +285,8 @@ func (p *Packet) GetOpMsg() (m string) {
 		m = "OpMetaBatchInodeGet"
 	case OpMetaExtentsAdd:
 		m = "OpMetaExtentsAdd"
+	case OpMetaExtentAddWithCheck:
+		m = "OpMetaExtentAddWithCheck"
 	case OpMetaExtentsDel:
 		m = "OpMetaExtentsDel"
 	case OpMetaExtentsList:
@@ -392,6 +398,8 @@ func (p *Packet) GetResultMsg() (m string) {
 	}
 
 	switch p.ResultCode {
+	case OpConflictExtentsErr:
+		m = "ConflictExtentsErr"
 	case OpIntraGroupNetErr:
 		m = "IntraGroupNetErr"
 	case OpDiskNoSpaceErr:

--- a/sdk/data/stream/extent_client.go
+++ b/sdk/data/stream/extent_client.go
@@ -28,7 +28,7 @@ import (
 	"github.com/chubaofs/chubaofs/util/log"
 )
 
-type AppendExtentKeyFunc func(inode uint64, key proto.ExtentKey) error
+type AppendExtentKeyFunc func(inode uint64, key proto.ExtentKey, discard []proto.ExtentKey) error
 type GetExtentsFunc func(inode uint64) (uint64, uint64, []proto.ExtentKey, error)
 type TruncateFunc func(inode, size uint64) error
 type EvictIcacheFunc func(inode uint64)

--- a/sdk/data/stream/extent_handler.go
+++ b/sdk/data/stream/extent_handler.go
@@ -408,10 +408,14 @@ func (eh *ExtentHandler) appendExtentKey() (err error) {
 	//log.LogDebugf("appendExtentKey enter: eh(%v)", eh)
 	if eh.key != nil {
 		if eh.dirty {
-			eh.stream.extents.Append(eh.key, true)
-			err = eh.stream.client.appendExtentKey(eh.inode, *eh.key)
+			var discard []proto.ExtentKey
+			discard = eh.stream.extents.Append(eh.key, true)
+			err = eh.stream.client.appendExtentKey(eh.inode, *eh.key, discard)
+			if err == nil && len(discard) > 0 {
+				eh.stream.extents.RemoveDiscard(discard)
+			}
 		} else {
-			eh.stream.extents.Append(eh.key, false)
+			//_ = eh.stream.extents.Append(eh.key, false)
 		}
 	}
 	if err == nil {

--- a/sdk/data/stream/stream_reader.go
+++ b/sdk/data/stream/stream_reader.go
@@ -131,9 +131,9 @@ func (s *Streamer) read(data []byte, offset int, size int) (total int, err error
 				req.Size = filesize - req.FileOffset
 				total += req.Size
 				err = io.EOF
-				if total == 0 {
-					log.LogErrorf("read: ino(%v) req(%v) filesize(%v)", s.inode, req, filesize)
-				}
+				//if total == 0 {
+				//	log.LogErrorf("read: ino(%v) req(%v) filesize(%v)", s.inode, req, filesize)
+				//}
 				return
 			}
 

--- a/sdk/data/stream/stream_writer.go
+++ b/sdk/data/stream/stream_writer.go
@@ -429,7 +429,8 @@ func (s *Streamer) doWrite(data []byte, offset, size int, direct bool) (total in
 		return
 	}
 
-	s.extents.Append(ek, false)
+	// This ek is just a local cache for PrepareWriteRequest, so ignore discard eks here.
+	_ = s.extents.Append(ek, false)
 	total = size
 
 	log.LogDebugf("doWrite exit: ino(%v) offset(%v) size(%v) ek(%v)", s.inode, offset, size, ek)

--- a/sdk/meta/api.go
+++ b/sdk/meta/api.go
@@ -483,18 +483,18 @@ func (mw *MetaWrapper) DentryUpdate_ll(parentID uint64, name string, inode uint6
 }
 
 // Used as a callback by stream sdk
-func (mw *MetaWrapper) AppendExtentKey(inode uint64, ek proto.ExtentKey) error {
+func (mw *MetaWrapper) AppendExtentKey(inode uint64, ek proto.ExtentKey, discard []proto.ExtentKey) error {
 	mp := mw.getPartitionByInode(inode)
 	if mp == nil {
 		return syscall.ENOENT
 	}
 
-	status, err := mw.appendExtentKey(mp, inode, ek)
+	status, err := mw.appendExtentKey(mp, inode, ek, discard)
 	if err != nil || status != statusOK {
-		log.LogErrorf("AppendExtentKey: inode(%v) ek(%v) err(%v) status(%v)", inode, ek, err, status)
+		log.LogErrorf("AppendExtentKey: inode(%v) ek(%v) discard(%v) err(%v) status(%v)", inode, ek, discard, err, status)
 		return statusToErrno(status)
 	}
-	log.LogDebugf("AppendExtentKey: ino(%v) ek(%v)", inode, ek)
+	log.LogDebugf("AppendExtentKey: ino(%v) ek(%v) discard(%v)", inode, ek, discard)
 	return nil
 }
 
@@ -525,7 +525,7 @@ func (mw *MetaWrapper) GetExtents(inode uint64) (gen uint64, size uint64, extent
 		log.LogErrorf("GetExtents: ino(%v) err(%v) status(%v)", inode, err, status)
 		return 0, 0, nil, statusToErrno(status)
 	}
-	log.LogDebugf("GetExtents: ino(%v) gen(%v) size(%v)", inode, gen, size)
+	log.LogDebugf("GetExtents: ino(%v) gen(%v) size(%v) extents(%v)", inode, gen, size, extents)
 	return gen, size, extents, nil
 }
 

--- a/sdk/meta/operation.go
+++ b/sdk/meta/operation.go
@@ -455,16 +455,17 @@ func (mw *MetaWrapper) readdir(mp *MetaPartition, parentID uint64) (status int, 
 	return statusOK, resp.Children, nil
 }
 
-func (mw *MetaWrapper) appendExtentKey(mp *MetaPartition, inode uint64, extent proto.ExtentKey) (status int, err error) {
-	req := &proto.AppendExtentKeyRequest{
-		VolName:     mw.volname,
-		PartitionID: mp.PartitionID,
-		Inode:       inode,
-		Extent:      extent,
+func (mw *MetaWrapper) appendExtentKey(mp *MetaPartition, inode uint64, extent proto.ExtentKey, discard []proto.ExtentKey) (status int, err error) {
+	req := &proto.AppendExtentKeyWithCheckRequest{
+		VolName:        mw.volname,
+		PartitionID:    mp.PartitionID,
+		Inode:          inode,
+		Extent:         extent,
+		DiscardExtents: discard,
 	}
 
 	packet := proto.NewPacketReqID()
-	packet.Opcode = proto.OpMetaExtentsAdd
+	packet.Opcode = proto.OpMetaExtentAddWithCheck
 	err = packet.MarshalData(req)
 	if err != nil {
 		log.LogErrorf("appendExtentKey: req(%v) err(%v)", *req, err)


### PR DESCRIPTION
Two clients writing to an overlapping file range concurrently may cause
the file unreadable. The scenario is like this:

    clientA                                 clientB
        |                                       |
    write [0,100) to extent 25                  |
        |                                       |
    send AppendExtentKey to metanode            |
    (offset: 0, size: 100, extentID:25)         |
        |                                       |
        |                                    write [0,200) to extent 30
        |                                       |
        |                                   send AppendExtentKey to metanode
        |                                   (offset: 0, size: 200, extentID: 30)
        |                                   which will delete extentID 25 asynchronously.
        |
    write [100,200) to extent 25
        |
    send AppendExtentKey to metanode
    (offset: 0, size: 200, extentID: 25)

The file range [0,200) is pointing to extentID 25 which is deleted due
to the AppendExtentKey request from clientB. So reading this file will
cause an "extent not exist error".

This commit introduces a new AppendExtentKeyWithCheck request which
will prevent from two clients writing to overlapping file range
concurrently.

Signed-off-by: Shuoran Liu <shuoranliu@gmail.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
