### PR TITLE
fix:support returning usedRatio in searching volstat

### DIFF
--- a/master/api_service.go
+++ b/master/api_service.go
@@ -2000,8 +2000,9 @@ func volStat(vol *Vol) (stat *proto.VolStatInfo) {
 	if stat.UsedSize > stat.TotalSize {
 		stat.UsedSize = stat.TotalSize
 	}
+	stat.UsedRatio = fmt.Sprintf("%.2f", float64(stat.UsedSize)/float64(stat.TotalSize))
 	stat.EnableToken = vol.enableToken
-	log.LogDebugf("total[%v],usedSize[%v]", stat.TotalSize, stat.UsedSize)
+	log.LogDebugf("total[%v],usedSize[%v],usedRatio[%v]", stat.TotalSize, stat.UsedSize, stat.UsedRatio)
 	return
 }
 


### PR DESCRIPTION
Signed-off-by: zhangxiangping <240133996@qq.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:when search volstat successfully,it should return the usedRatio of this vol

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
