### PR TITLE
change: docker pull to docker build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
     - docker
 
 before_install:
-    - docker pull chubaofs/cfs-base:1.0
+    - docker build -t chubaofs/cfs-base:1.2 -f docker/Dockerfile docker
 
 script:
     - docker/run_docker.sh -t

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,17 +1,17 @@
-FROM golang:1.12
+FROM golang:1.15
 
 # intall rocksdb
 RUN     apt-get update && \
         apt-get -y install libz-dev libbz2-dev libsnappy-dev && \
         apt-get -y install librocksdb-dev
 
-ENV LTP_VERSION=20180926
+ENV LTP_VERSION=20200515
 ENV LTP_SOURCE=https://github.com/linux-test-project/ltp/archive/${LTP_VERSION}.tar.gz
 
 # install ltptest
 RUN apt-get install -y xz-utils make gcc flex bison automake autoconf
 RUN  mkdir -p /tmp/ltp /opt/ltp && cd /tmp/ltp \
-        && wget ${LTP_SOURCE} && tar xf ${LTP_VERSION}.tar.gz && cd ltp-${LTP_VERSION} \
+        && wget --no-check-certificate ${LTP_SOURCE} && tar xf ${LTP_VERSION}.tar.gz && cd ltp-${LTP_VERSION} \
         && make autotools && ./configure \
         && make -j "$(getconf _NPROCESSORS_ONLN)" all && make install \
         && rm -rf /tmp/ltp

--- a/docker/build_docker.sh
+++ b/docker/build_docker.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
 RootPath=$(cd $(dirname $0) ; pwd)
-CfsBase="chubaofs/cfs-base:1.0"
+CfsBase="chubaofs/cfs-base:1.2"
 
 docker build -t ${CfsBase} -f ${RootPath}/Dockerfile ${RootPath}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,7 +9,7 @@ networks:
 
 services:
     monitor:
-        image: chubaofs/cfs-base:1.1
+        image: chubaofs/cfs-base:1.2
         depends_on:
             - consul
             - prometheus
@@ -18,7 +18,7 @@ services:
             extnetwork:
 
     servers:
-        image: chubaofs/cfs-base:1.1
+        image: chubaofs/cfs-base:1.2
         depends_on:
             - master1
             - master2
@@ -40,7 +40,7 @@ services:
             extnetwork:
 
     master1:
-        image: chubaofs/cfs-base:1.1
+        image: chubaofs/cfs-base:1.2
         ports:
             - "5901"
             - "5902"
@@ -61,7 +61,7 @@ services:
                 ipv4_address: 192.168.0.11
 
     master2:
-        image: chubaofs/cfs-base:1.1
+        image: chubaofs/cfs-base:1.2
         ports:
             - "5901"
             - "5902"
@@ -81,7 +81,7 @@ services:
             extnetwork:
                 ipv4_address: 192.168.0.12
     master3:
-        image: chubaofs/cfs-base:1.1
+        image: chubaofs/cfs-base:1.2
         ports:
             - "5901"
             - "5902"
@@ -102,7 +102,7 @@ services:
                 ipv4_address: 192.168.0.13
 
     metanode1:
-        image: chubaofs/cfs-base:1.1
+        image: chubaofs/cfs-base:1.2
         ports:
             - "17210"
             - "17220"
@@ -123,7 +123,7 @@ services:
                 ipv4_address: 192.168.0.21
 
     metanode2:
-        image: chubaofs/cfs-base:1.1
+        image: chubaofs/cfs-base:1.2
         ports:
             - "17210"
             - "17220"
@@ -144,7 +144,7 @@ services:
                 ipv4_address: 192.168.0.22
 
     metanode3:
-        image: chubaofs/cfs-base:1.1
+        image: chubaofs/cfs-base:1.2
         ports:
             - "17210"
             - "17220"
@@ -165,7 +165,7 @@ services:
                 ipv4_address: 192.168.0.23
 
     metanode4:
-        image: chubaofs/cfs-base:1.1
+        image: chubaofs/cfs-base:1.2
         ports:
             - "17210"
             - "17220"
@@ -186,7 +186,7 @@ services:
                 ipv4_address: 192.168.0.24
 
     datanode1:
-        image: chubaofs/cfs-base:1.1
+        image: chubaofs/cfs-base:1.2
         ports:
             - "17310"
             - "17320"
@@ -207,7 +207,7 @@ services:
                 ipv4_address: 192.168.0.31
 
     datanode2:
-        image: chubaofs/cfs-base:1.1
+        image: chubaofs/cfs-base:1.2
         ports:
             - "17310"
             - "17320"
@@ -228,7 +228,7 @@ services:
                 ipv4_address: 192.168.0.32
 
     datanode3:
-        image: chubaofs/cfs-base:1.1
+        image: chubaofs/cfs-base:1.2
         ports:
             - "17310"
             - "17320"
@@ -249,7 +249,7 @@ services:
                 ipv4_address: 192.168.0.33
 
     datanode4:
-        image: chubaofs/cfs-base:1.1
+        image: chubaofs/cfs-base:1.2
         ports:
             - "17310"
             - "17320"
@@ -270,7 +270,7 @@ services:
                 ipv4_address: 192.168.0.34
 
     objectnode1:
-        image: chubaofs/cfs-base:1.1
+        image: chubaofs/cfs-base:1.2
         ports:
             - "80"
             - 9500
@@ -289,7 +289,7 @@ services:
                 ipv4_address: 192.168.0.41
 
     objectnode2:
-        image: chubaofs/cfs-base:1.1
+        image: chubaofs/cfs-base:1.2
         ports:
             - "80"
             - 9500
@@ -308,7 +308,7 @@ services:
                 ipv4_address: 192.168.0.42
 
     objectnode3:
-        image: chubaofs/cfs-base:1.1
+        image: chubaofs/cfs-base:1.2
         ports:
             - "80"
             - 9500
@@ -328,7 +328,7 @@ services:
 
 
     console1:
-        image: chubaofs/cfs-base:1.1
+        image: chubaofs/cfs-base:1.2
         ports:
           - "80"
         volumes:
@@ -344,7 +344,7 @@ services:
             ipv4_address: 192.168.0.50
 
     client:
-        image: chubaofs/cfs-base:1.1
+        image: chubaofs/cfs-base:1.2
         ports:
             - 9500
         volumes:
@@ -417,7 +417,7 @@ services:
                 ipv4_address: 192.168.0.104
 
     build:
-        image: chubaofs/cfs-base:1.1
+        image: chubaofs/cfs-base:1.2
         volumes:
             - ../:/go/src/github.com/chubaofs/chubaofs
         command:
@@ -426,7 +426,7 @@ services:
             extnetwork:
 
     unit_test:
-        image: chubaofs/cfs-base:1.1
+        image: chubaofs/cfs-base:1.2
         volumes:
             - ../:/go/src/github.com/chubaofs/chubaofs
         command:


### PR DESCRIPTION
This commit changes the ci process from docker pull to docker build
since docker hub limits the image pulling rate. Also change the base
image from golang:1.12 to golang:1.15

Signed-off-by: Shuoran Liu <shuoranliu@gmail.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
