### PR TITLE
fix: add mutex lock to avoid to invoke dp.stop() method twice on data…

### DIFF
--- a/datanode/space_manager.go
+++ b/datanode/space_manager.go
@@ -288,13 +288,18 @@ func (manager *SpaceManager) CreatePartition(request *proto.CreateDataPartitionR
 
 // DeletePartition deletes a partition based on the partition id.
 func (manager *SpaceManager) DeletePartition(dpID uint64) {
-	dp := manager.Partition(dpID)
+
+	manager.partitionMutex.Lock()
+
+	dp := manager.partitions[dpID]
 	if dp == nil {
+		manager.partitionMutex.Unlock()
 		return
 	}
-	manager.partitionMutex.Lock()
+
 	delete(manager.partitions, dpID)
 	manager.partitionMutex.Unlock()
+
 	dp.Stop()
 	dp.Disk().DetachDataPartition(dp)
 	os.RemoveAll(dp.Path())


### PR DESCRIPTION
… node

Signed-off-by: Victor1319 <834863182@qq.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
