### PR TITLE
feat: subdir mount such as perm:builtin:/a/:Writable will allow /a/b/…

### DIFF
--- a/proto/perm_action.go
+++ b/proto/perm_action.go
@@ -15,6 +15,7 @@
 package proto
 
 import (
+	"path"
 	"regexp"
 	"strings"
 )
@@ -303,18 +304,32 @@ func (p Permission) MatchSubdir(subdir string) bool {
 	s := strings.TrimPrefix(string(p), string(BuiltinPermissionPrefix))
 
 	if !subdirRegexp.MatchString(s) {
-		if subdir == "" || subdir == "/" {
-			return true
-		} else {
-			return false
-		}
+		return true
 	}
 
-	toCompare := strings.Split(s, ":")
-	for i := 0; i < len(toCompare); i++ {
-		if (subdir == "" || subdir == "/") && (toCompare[i] == "" || toCompare[i] == "/") ||
-			subdir == toCompare[i] {
+	pars := strings.Split(s, ":")
+	pars = pars[:len(pars)-1] //trim (Writable|ReadOnly) at the end
+	for _, toCmp := range pars {
+		if toCmp == "/" || toCmp == "" {
 			return true
+		}
+		subdir = path.Clean("/" + subdir)
+		toCmp = path.Clean("/" + toCmp)
+		if strings.HasPrefix(subdir, toCmp) {
+			tail := strings.TrimPrefix(subdir, toCmp)
+			//match case 1:
+			//subdir = "/a/b/c"
+			//toCmp  = "/a/b/c"
+			//tail   =       ""
+
+			//match case 2:
+			//subdir = "/a/b/c"
+			//toCmp  = "/a/b"
+			//tail   =     "/c"
+
+			if tail == "" || strings.HasPrefix(tail, "/") {
+				return true
+			}
 		}
 	}
 


### PR DESCRIPTION
… mount and so on

perm:builtin:[dir]:(Readonly|Writable) will allow subdir of [dir] (like [dir]/a/b/c [dir]/a/b/c/d) to mount.

Signed-off-by: xrefft <cserxiao@qq.com>


**What this PR does / why we need it**:
In the old subdir mount authentication, `perm:builtin:[dir]:(Readonly|Writable)` only allows a single directory `[dir]` to be mounted.

This PR will make `perm:builtin:[dir]:(Readonly|Writable)` allow `[dir]` and all dir under it (`[dir]/a`, `[dir]/b`...)to be mounted 
