### PR TITLE
Bugfix/fix raft monitor panic error#1069

### DIFF
--- a/raftstore/monitor.go
+++ b/raftstore/monitor.go
@@ -1,0 +1,74 @@
+package raftstore
+
+import (
+	"fmt"
+	"github.com/chubaofs/chubaofs/util/exporter"
+	"github.com/chubaofs/chubaofs/util/log"
+	"github.com/tiglabs/raft/proto"
+	"time"
+)
+
+const (
+	reportDuration          = time.Minute * 3
+	zombieThreshold         = time.Minute * 3
+	raftNotHealthyThreshold = time.Second * 30
+)
+
+type zombiePeer struct {
+	partitionID uint64
+	peer        proto.Peer
+}
+
+type monitor struct {
+	zombieDurations   map[zombiePeer]time.Duration
+	noLeaderDurations map[uint64]time.Duration
+}
+
+func newMonitor() *monitor {
+	return &monitor{
+		zombieDurations:   make(map[zombiePeer]time.Duration),
+		noLeaderDurations: make(map[uint64]time.Duration),
+	}
+}
+
+func (d *monitor) MonitorZombie(id uint64, peer proto.Peer, replicasMsg string, du time.Duration) {
+	if du < zombieThreshold {
+		return
+	}
+	needReport := false
+	zombiePeer := zombiePeer{
+		partitionID: id,
+		peer:        peer,
+	}
+	oldDu := d.zombieDurations[zombiePeer]
+	if oldDu == 0 || du < oldDu || du-oldDu > reportDuration {
+		d.zombieDurations[zombiePeer] = du
+		needReport = true
+	}
+	if !needReport {
+		return
+	}
+	errMsg := fmt.Sprintf("[MonitorZombie] raft partitionID[%d] replicaID[%v] replicasMsg[%s] zombiePeer[%v] zombieDuration[%v]",
+		id, peer.PeerID, replicasMsg, peer, du)
+	log.LogError(errMsg)
+	exporter.Warning(errMsg)
+}
+
+func (d *monitor) MonitorElection(id uint64, replicaMsg string, du time.Duration) {
+	if du < raftNotHealthyThreshold {
+		return
+	}
+	needReport := false
+	oldDu := d.noLeaderDurations[id]
+	if oldDu == 0 || du < oldDu || du-oldDu > reportDuration {
+		d.noLeaderDurations[id] = du
+		needReport = true
+	}
+	if !needReport {
+		return
+	}
+	errMsg := fmt.Sprintf("[MonitorElection] raft status not health partitionID[%d]_replicas[%v]_noLeaderDuration[%v]",
+		id, replicaMsg, du)
+	log.LogError(errMsg)
+	exporter.Warning(errMsg)
+}

--- a/raftstore/raftstore.go
+++ b/raftstore/raftstore.go
@@ -178,6 +178,7 @@ func (s *raftStore) CreatePartition(cfg *PartitionConfig) (p Partition, err erro
 		Storage:      ws,
 		StateMachine: cfg.SM,
 		Applied:      cfg.Applied,
+		Monitor:      newMonitor(),
 	}
 	if err = s.raftServer.CreateRaft(rc); err != nil {
 		return

--- a/vendor/github.com/tiglabs/raft/config.go
+++ b/vendor/github.com/tiglabs/raft/config.go
@@ -133,6 +133,7 @@ type RaftConfig struct {
 	Peers        []proto.Peer
 	Storage      storage.Storage
 	StateMachine StateMachine
+	Monitor      Monitor
 }
 
 // DefaultConfig returns a Config with usable defaults.

--- a/vendor/github.com/tiglabs/raft/monitor.go
+++ b/vendor/github.com/tiglabs/raft/monitor.go
@@ -1,0 +1,14 @@
+package raft
+
+import (
+	"github.com/tiglabs/raft/proto"
+	"time"
+)
+
+//The Monitor interface is used to monitor the health status of the raft.
+type Monitor interface {
+	//If a peer in replica has no respond for long time (2*TickInterval), MonitorZombie will be called.
+	MonitorZombie(id uint64, peer proto.Peer, replicasMsg string, du time.Duration)
+	//If raft election failed continuously. MonitorElection will be called
+	MonitorElection(id uint64, replicaMsg string, du time.Duration)
+}

--- a/vendor/github.com/tiglabs/raft/raft_fsm_candidate.go
+++ b/vendor/github.com/tiglabs/raft/raft_fsm_candidate.go
@@ -27,12 +27,12 @@ func (r *raftFsm) becomeCandidate() {
 		panic(AppPanicError(fmt.Sprintf("[raft->becomeCandidate][%v] invalid transition [leader -> candidate].", r.id)))
 	}
 
+	r.monitorElection()
 	r.step = stepCandidate
 	r.reset(r.term+1, 0, false)
 	r.tick = r.tickElection
 	r.vote = r.config.NodeID
 	r.state = stateCandidate
-
 	if logger.IsEnableDebug() {
 		logger.Debug("raft[%v] became candidate at term %d.", r.id, r.term)
 	}
@@ -114,8 +114,8 @@ func (r *raftFsm) campaign(force bool) {
 		}
 		li, lt := r.raftLog.lastIndexAndTerm()
 		if logger.IsEnableDebug() {
-			logger.Debug("[raft->campaign][%v logterm: %d, index: %d] sent " +
-				"vote request to %v at term %d.   raftFSM[%p]", r.id, lt, li, id, r.term,r)
+			logger.Debug("[raft->campaign][%v logterm: %d, index: %d] sent "+
+				"vote request to %v at term %d.   raftFSM[%p]", r.id, lt, li, id, r.term, r)
 		}
 
 		m := proto.GetMessage()

--- a/vendor/github.com/tiglabs/raft/raft_fsm_leader.go
+++ b/vendor/github.com/tiglabs/raft/raft_fsm_leader.go
@@ -342,16 +342,18 @@ func (r *raftFsm) tickElectionAck() {
 
 func (r *raftFsm) checkLeaderLease() bool {
 	var act int
-	for id := range r.replicas {
-		if id == r.config.NodeID || r.replicas[id].state == replicaStateSnapshot {
+	for id, peer := range r.replicas {
+		if id == r.config.NodeID || peer.state == replicaStateSnapshot {
 			act++
 			continue
 		}
 
-		if r.replicas[id].active {
+		if peer.active {
+			peer.active = false
 			act++
+		} else {
+			r.monitorZombie(peer)
 		}
-		r.replicas[id].active = false
 	}
 
 	return act >= r.quorum()

--- a/vendor/github.com/tiglabs/raft/raft_replica.go
+++ b/vendor/github.com/tiglabs/raft/raft_replica.go
@@ -33,6 +33,7 @@ type replica struct {
 	match, next, committed, pendingSnap uint64
 
 	lastActive time.Time
+	lastZombie time.Time
 }
 
 func newReplica(peer proto.Peer, maxInflight int) *replica {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
`raft.monitor` and `raft.run` will compete for variables such as `raft.raftFsm.replicas`, `raft.raftFsm.leader`, and concurrent access to the non-reentrant function `raft.raftFsm.peers()`

`raft.monitor` does not belong to the native raft library, it is an additional function, mainly used to monitor:
1. Whether a peer in the raft group is disconnected for a long time.
2. Whether the raft group has been unable to elect the leader for a long time.

To fix this problem, we introduce the interface `Monitor`. The functions of `Monitor` are:

1. `Monitor.MonitorZombie` monitors peers that cannot be dialed for a long time  (3min).
2. `Monitor.MonitorElection` monitors the long-term failure of election (30s) .

The above two correspond to the two functions of the original `raft.monitor`.

`Monitor` will not cause concurrency problems because it is just as `StateMachine`. The external app injects its dependencies, implements their own monitoring functions, and called by `raft.run`.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1069 

