### PR TITLE
fix: func sortHostsByDistance change dp's hosts

### DIFF
--- a/sdk/data/wrapper/wrapper.go
+++ b/sdk/data/wrapper/wrapper.go
@@ -288,7 +288,10 @@ func (w *Wrapper) NearRead() bool {
 }
 
 // Sort hosts by distance form local
-func (w *Wrapper) sortHostsByDistance(hosts []string) []string {
+func (w *Wrapper) sortHostsByDistance(srcHosts []string) []string {
+	hosts := make([]string, len(srcHosts))
+	copy(hosts, srcHosts)
+
 	for i := 0; i < len(hosts); i++ {
 		for j := i + 1; j < len(hosts); j++ {
 			if distanceFromLocal(hosts[i]) > distanceFromLocal(hosts[j]) {


### PR DESCRIPTION
Signed-off-by: Victor1319 <834863182@qq.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
`to avoid changing hosts of dp by use a copy of hosts`

**Which issue this PR fixes** : fixes #1105

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
