### PR TITLE
fix: it's no need to multiply DefaultHeadRatio when calculate availab…

### DIFF
--- a/vendor/github.com/tiglabs/raft/util/log/log.go
+++ b/vendor/github.com/tiglabs/raft/util/log/log.go
@@ -357,7 +357,7 @@ func (l *Log) SetRotate(logDir string) error {
 	}
 	var minRatio float64
 	if float64(fs.Bavail * uint64(fs.Bsize)) < float64(fs.Blocks*uint64(fs.Bsize)) * DefaultHeadRatio {
-		minRatio = float64(fs.Bavail*uint64(fs.Bsize)) * DefaultHeadRatio / 1024 /1024
+		minRatio = float64(fs.Bavail*uint64(fs.Bsize)) / 1024 /1024
 	} else {
 		minRatio = float64(fs.Blocks*uint64(fs.Bsize)) * DefaultHeadRatio / 1024 / 1024
 	}


### PR DESCRIPTION
…le space for minRatio

Signed-off-by: Victor1319 <834863182@qq.com>
