### PR TITLE
fix: if compute crc and random write happen at the same time, crc che…

### DIFF
--- a/storage/extent.go
+++ b/storage/extent.go
@@ -47,7 +47,7 @@ type ExtentInfo struct {
 	Size       uint64 `json:"size"`
 	Crc        uint32 `json:"Crc"`
 	IsDeleted  bool   `json:"deleted"`
-	ModifyTime int64  `json:"modTime"`
+	ModifyTime int64  `json:"modTime"` // random write not update modify time
 	Source     string `json:"src"`
 }
 

--- a/storage/extent_store.go
+++ b/storage/extent_store.go
@@ -182,9 +182,21 @@ func NewExtentStore(dataDir string, partitionID uint64, storeSize int) (s *Exten
 func (ei *ExtentInfo) UpdateExtentInfo(extent *Extent, crc uint32) {
 	extent.Lock()
 	defer extent.Unlock()
-	if time.Now().Unix()-extent.ModifyTime() <= UpdateCrcInterval {
-		crc = 0
+
+	// check if file is modified according to os.ModTime
+	if crc != 0 {
+		stat, err := extent.file.Stat()
+		if err != nil {
+			log.LogErrorf("[UpdateExtentInfo] stat file error, set crc default, %v", err)
+			crc = 0
+		}
+
+		if time.Now().Unix()-stat.ModTime().Unix() <= UpdateCrcInterval {
+			log.LogWarn("[UpdateExtentInfo] file has been modified when update extent compute crc, so set crc default")
+			crc = 0
+		}
 	}
+
 	ei.Size = uint64(extent.dataSize)
 	if !IsTinyExtent(ei.FileID) {
 		atomic.StoreUint32(&ei.Crc, crc)
@@ -409,7 +421,7 @@ func (s *ExtentStore) MarkDelete(extentID uint64, offset, size int64) (err error
 	s.PutNormalExtentToDeleteCache(extentID)
 
 	s.eiMutex.Lock()
-	delete(s.extentInfoMap,extentID)
+	delete(s.extentInfoMap, extentID)
 	s.eiMutex.Unlock()
 
 	return
@@ -729,17 +741,17 @@ func (s *ExtentStore) ReadTinyDeleteRecords(offset, size int64, data []byte) (cr
 	return
 }
 
-type ExtentDeleted struct{
-	ExtentID uint64   `json:"extentID"`
-	Offset   uint64	  `json:"offset"`
-	Size 	 uint64	  `json:"size"`
+type ExtentDeleted struct {
+	ExtentID uint64 `json:"extentID"`
+	Offset   uint64 `json:"offset"`
+	Size     uint64 `json:"size"`
 }
 
 func (s *ExtentStore) GetHasDeleteTinyRecords() (extentDes []ExtentDeleted, err error) {
 	data := make([]byte, DeleteTinyRecordSize)
 	offset := int64(0)
 
-	for ;; {
+	for {
 		_, err = s.tinyExtentDeleteFp.ReadAt(data, offset)
 		if err != nil {
 			if err == io.EOF {
@@ -935,24 +947,33 @@ func (s *ExtentStore) autoComputeExtentCrc() {
 	sort.Sort(ExtentInfoArr(extentInfos))
 
 	for _, ei := range extentInfos {
+
 		if ei == nil {
 			continue
 		}
+
 		if !IsTinyExtent(ei.FileID) && time.Now().Unix()-ei.ModifyTime > UpdateCrcInterval &&
-			ei.IsDeleted == false && ei.Size > 0 && ei.Crc == 0 {
+			!ei.IsDeleted && ei.Size > 0 && ei.Crc == 0 {
+
 			e, err := s.extentWithHeader(ei)
 			if err != nil {
+				log.LogError("[autoComputeExtentCrc] get extent error", err)
 				continue
 			}
+
 			extentCrc, err := e.autoComputeExtentCrc(s.PersistenceBlockCrc)
 			if err != nil {
+				log.LogError("[autoComputeExtentCrc] compute crc fail", err)
 				continue
 			}
+
 			ei.UpdateExtentInfo(e, extentCrc)
+
+			time.Sleep(time.Millisecond * 100)
 		}
-		time.Sleep(time.Millisecond * 100)
 	}
 
+	time.Sleep(time.Second)
 }
 
 func (s *ExtentStore) TinyExtentRecover(extentID uint64, offset, size int64, data []byte, crc uint32, isEmptyPacket bool) (err error) {


### PR DESCRIPTION
…ck maybe error; so here check os.modTime to judge whether file is modified when update computed crc.
fix #1146

this problem is caused by update calculated crc and set crc 0 after overwrite data occour at the same time,  look the `UpdateExtentInfo` function, although trying to use `extent.modifyTime` to judge whether to update calculated crc, but because `extent.modifyTime`  don't change when overwrite operation happens, so this check is not valid and may cause concurrent problem in overwrite op happens frequently
```go
func (ei *ExtentInfo) UpdateExtentInfo(extent *Extent, crc uint32) {
	extent.Lock()
	defer extent.Unlock()

	if time.Now().Unix()-extent.ModifyTime() <= UpdateCrcInterval {
		crc = 0
	}
	ei.Size = uint64(extent.dataSize)
	if !IsTinyExtent(ei.FileID) {
		atomic.StoreUint32(&ei.Crc, crc)
		ei.ModifyTime = extent.ModifyTime()
	}
}
```


Signed-off-by: Victor1319 <834863182@qq.com>
