### PR TITLE
fix: update extent cache no matter whether eh is dirty or not

### DIFF
--- a/sdk/data/stream/extent_handler.go
+++ b/sdk/data/stream/extent_handler.go
@@ -415,7 +415,13 @@ func (eh *ExtentHandler) appendExtentKey() (err error) {
 				eh.stream.extents.RemoveDiscard(discard)
 			}
 		} else {
-			//_ = eh.stream.extents.Append(eh.key, false)
+			/*
+			 * Update extents cache using the ek stored in the eh. This is
+			 * indispensable because the ek in the extent cache might be
+			 * a temp one with dpid 0, especially when current eh failed and
+			 * create a new eh to do recovery.
+			 */
+			_ = eh.stream.extents.Append(eh.key, false)
 		}
 	}
 	if err == nil {


### PR DESCRIPTION
The ek stored in the extent cache may be inaccurate with dpid 0,
especially when eh failed and is doing a recovery.

Reported-by: bboyCH4 <hechi1014@126.com>
Signed-off-by: bboyCH4 <hechi1014@126.com>
Signed-off-by: Shuoran Liu <shuoranliu@gmail.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
