### PR TITLE
fix: fix block crc calc err when concurrent update case

### DIFF
--- a/datanode/server.go
+++ b/datanode/server.go
@@ -394,6 +394,7 @@ func (s *DataNode) registerHandler() {
 	http.HandleFunc("/partition", s.getPartitionAPI)
 	http.HandleFunc("/extent", s.getExtentAPI)
 	http.HandleFunc("/block", s.getBlockCrcAPI)
+	http.HandleFunc("/resetCrc", s.resetExtentCrcApi)
 	http.HandleFunc("/stats", s.getStatAPI)
 	http.HandleFunc("/raftStatus", s.getRaftStatus)
 	http.HandleFunc("/setAutoRepairStatus", s.setAutoRepairStatus)

--- a/datanode/server_handler.go
+++ b/datanode/server_handler.go
@@ -265,6 +265,43 @@ func (s *DataNode) getBlockCrcAPI(w http.ResponseWriter, r *http.Request) {
 	return
 }
 
+func (s *DataNode) resetExtentCrcApi(w http.ResponseWriter, r *http.Request) {
+	var (
+		partitionID uint64
+		extentID    int
+		err         error
+	)
+
+	if err = r.ParseForm(); err != nil {
+		s.buildFailureResp(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	if partitionID, err = strconv.ParseUint(r.FormValue("partitionID"), 10, 64); err != nil {
+		s.buildFailureResp(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	if extentID, err = strconv.Atoi(r.FormValue("extentID")); err != nil {
+		s.buildFailureResp(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	partition := s.space.Partition(partitionID)
+	if partition == nil {
+		s.buildFailureResp(w, http.StatusNotFound, "partition not exist")
+		return
+	}
+
+	if err = partition.ExtentStore().ResetCrc(uint64(extentID)); err != nil {
+		s.buildFailureResp(w, 500, err.Error())
+		return
+	}
+
+	s.buildSuccessResp(w, fmt.Sprintf("reset extent crc success %d", extentID))
+	return
+}
+
 func (s *DataNode) getTinyDeleted(w http.ResponseWriter, r *http.Request) {
 	var (
 		partitionID uint64

--- a/storage/extent.go
+++ b/storage/extent.go
@@ -245,11 +245,6 @@ func (e *Extent) Write(data []byte, offset, size int64, crc uint32, writeType in
 		}
 	}
 
-	if offsetInBlock == 0 && size == util.BlockSize {
-		err = crcFunc(e, int(blockNo), crc)
-		return
-	}
-
 	if offsetInBlock+size <= util.BlockSize {
 		err = crcFunc(e, int(blockNo), 0)
 		return

--- a/storage/extent.go
+++ b/storage/extent.go
@@ -67,7 +67,7 @@ type Extent struct {
 	filePath   string
 	extentID   uint64
 	modifyTime int64
-	changeTime int64 // change when append write or random write, same as file os's modifyTime
+	changeTime int64 // change whenever append write or random write happens, same as file os's modifyTime
 	dataSize   int64
 	hasClose   int32
 	header     []byte

--- a/storage/extent_store.go
+++ b/storage/extent_store.go
@@ -183,16 +183,10 @@ func (ei *ExtentInfo) UpdateExtentInfo(extent *Extent, crc uint32) {
 	extent.Lock()
 	defer extent.Unlock()
 
-	// check if file is modified according to os.ModTime
+	// check if file is modified according to changeTime
 	if crc != 0 {
-		stat, err := extent.file.Stat()
-		if err != nil {
-			log.LogErrorf("[UpdateExtentInfo] stat file error, set crc default, %v", err)
-			crc = 0
-		}
-
-		if time.Now().Unix()-stat.ModTime().Unix() <= UpdateCrcInterval {
-			log.LogWarn("[UpdateExtentInfo] file has been modified when update extent compute crc, so set crc default")
+		if time.Now().Unix()- extent.changeTime <= UpdateCrcInterval {
+			log.LogInfof("[UpdateExtentInfo] file has been modified when update extent compute crc, so set crc default", extent.filePath)
 			crc = 0
 		}
 	}

--- a/storage/extent_store.go
+++ b/storage/extent_store.go
@@ -186,7 +186,7 @@ func (ei *ExtentInfo) UpdateExtentInfo(extent *Extent, crc uint32) {
 	// check if file is modified according to changeTime
 	if crc != 0 {
 		if time.Now().Unix()- extent.changeTime <= UpdateCrcInterval {
-			log.LogInfof("[UpdateExtentInfo] file has been modified when update extent compute crc, so set crc default", extent.filePath)
+			log.LogWarnf("[UpdateExtentInfo] file has been modified when update extent compute crc, so set crc default", extent.filePath)
 			crc = 0
 		}
 	}
@@ -985,6 +985,11 @@ func (s *ExtentStore) autoComputeExtentCrc() {
 			e, err := s.extentWithHeader(ei)
 			if err != nil {
 				log.LogError("[autoComputeExtentCrc] get extent error", err)
+				continue
+			}
+
+			// change time check
+			if time.Now().Unix() - e.changeTime < UpdateCrcInterval {
 				continue
 			}
 

--- a/storage/extent_store.go
+++ b/storage/extent_store.go
@@ -186,7 +186,7 @@ func (ei *ExtentInfo) UpdateExtentInfo(extent *Extent, crc uint32) {
 	// check if file is modified according to changeTime
 	if crc != 0 {
 		if time.Now().Unix()- extent.changeTime <= UpdateCrcInterval {
-			log.LogWarnf("[UpdateExtentInfo] file has been modified when update extent compute crc, so set crc default", extent.filePath)
+			log.LogWarnf("[UpdateExtentInfo] file has been modified when update extent [%s] compute crc, so set crc default", extent.filePath)
 			crc = 0
 		}
 	}

--- a/storage/persistence_crc.go
+++ b/storage/persistence_crc.go
@@ -48,7 +48,7 @@ func (s *ExtentStore) PersistenceBlockCrc(e *Extent, blockNo int, blockCrc uint3
 
 	if blockCrc != 0 {
 		if time.Now().Unix()- e.changeTime <= UpdateCrcInterval {
-			log.LogInfof("[UpdateExtentInfo] file %s has been modified when updating block crc, not update", e.filePath)
+			log.LogWarnf("[UpdateExtentInfo] file %s has been modified when updating block crc, not update", e.filePath)
 			return
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
1. the case, update block crc after write, maybe conflict with the case, calculate block crc in backgroud task, which will cause extent crc is error. so, by use a changeTime, which stand for os's file modTime, to avoid update block crc or extent crc at the same time.
2. add a http api **resetCrc** to re-calculate block and extent crc again, make it easy to recover error crc before


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1183