### PR TITLE
metanode: fix meta not use warn when consulMeta not set

### DIFF
--- a/util/exporter/consul_register.go
+++ b/util/exporter/consul_register.go
@@ -178,6 +178,10 @@ func makeRegisterReq(host, addr, app, role, cluster, meta string, port int64) (r
 
 // parse k1=v1;k2=v2 as a map
 func parseMetaStr(meta string) (bool, map[string]string) {
+	if len(meta) == 0 {
+		return false, nil
+	}
+
 	m := map[string]string{}
 
 	kvs := strings.Split(meta, ";")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
when consulMeta not set, there has warn log "meta no use"

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
