### PR TITLE
fix: return file nodes for statfs

### DIFF
--- a/client/fs/super.go
+++ b/client/fs/super.go
@@ -140,13 +140,16 @@ func (s *Super) Root() (fs.Node, error) {
 
 // Statfs handles the Statfs request and returns a set of statistics.
 func (s *Super) Statfs(ctx context.Context, req *fuse.StatfsRequest, resp *fuse.StatfsResponse) error {
-	total, used := s.mw.Statfs()
+	const defaultMaxMetaPartitionInodeID uint64 = 1<<63 - 1
+	total, used, inodeCount := s.mw.Statfs()
 	resp.Blocks = total / uint64(DefaultBlksize)
 	resp.Bfree = (total - used) / uint64(DefaultBlksize)
 	resp.Bavail = resp.Bfree
 	resp.Bsize = DefaultBlksize
 	resp.Namelen = DefaultMaxNameLen
 	resp.Frsize = DefaultBlksize
+	resp.Files = inodeCount
+	resp.Ffree = defaultMaxMetaPartitionInodeID - inodeCount
 	return nil
 }
 

--- a/master/api_service.go
+++ b/master/api_service.go
@@ -2471,6 +2471,9 @@ func volStat(vol *Vol) (stat *proto.VolStatInfo) {
 		stat.UsedSize = stat.TotalSize
 	}
 	stat.UsedRatio = strconv.FormatFloat(float64(stat.UsedSize)/float64(stat.TotalSize), 'f', 2, 32)
+	for _, mp := range vol.MetaPartitions {
+		stat.InodeCount += mp.InodeCount
+	}
 	log.LogDebugf("total[%v],usedSize[%v]", stat.TotalSize, stat.UsedSize)
 	return
 }

--- a/proto/model.go
+++ b/proto/model.go
@@ -156,6 +156,7 @@ type VolStatInfo struct {
 	UsedSize    uint64
 	UsedRatio   string
 	EnableToken bool
+	InodeCount  uint64
 }
 
 // DataPartition represents the structure of storing the file contents.

--- a/sdk/meta/api.go
+++ b/sdk/meta/api.go
@@ -78,9 +78,10 @@ func (mw *MetaWrapper) LookupPath(subdir string) (uint64, error) {
 	return ino, nil
 }
 
-func (mw *MetaWrapper) Statfs() (total, used uint64) {
+func (mw *MetaWrapper) Statfs() (total, used, inodeCount uint64) {
 	total = atomic.LoadUint64(&mw.totalSize)
 	used = atomic.LoadUint64(&mw.usedSize)
+	inodeCount = atomic.LoadUint64(&mw.inodeCount)
 	return
 }
 

--- a/sdk/meta/meta.go
+++ b/sdk/meta/meta.go
@@ -107,8 +107,9 @@ type MetaWrapper struct {
 	rwPartitions []*MetaPartition
 	epoch        uint64
 
-	totalSize uint64
-	usedSize  uint64
+	totalSize  uint64
+	usedSize   uint64
+	inodeCount uint64
 
 	authenticate bool
 	Ticket       auth.Ticket

--- a/sdk/meta/view.go
+++ b/sdk/meta/view.go
@@ -136,6 +136,7 @@ func (mw *MetaWrapper) updateVolStatInfo() (err error) {
 	}
 	atomic.StoreUint64(&mw.totalSize, info.TotalSize)
 	atomic.StoreUint64(&mw.usedSize, info.UsedSize)
+	atomic.StoreUint64(&mw.inodeCount, info.InodeCount)
 	log.LogInfof("VolStatInfo: info(%v)", info)
 	return
 }


### PR DESCRIPTION
This patch adds f_files and f_ffree fields for statfs. Since free
file nodes is not limited, so the default max inode ID is used to
calculate free file nodes.

Signed-off-by: Sheng Yong <shengyong2021@gmail.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
