### PR TITLE
Trivial fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ BIN_CLIENT := $(BIN_PATH)/cfs-client
 BIN_CLIENT2 := $(BIN_PATH)/cfs-client2
 BIN_AUTHTOOL := $(BIN_PATH)/cfs-authtool
 BIN_CLI := $(BIN_PATH)/cfs-cli
+BIN_FSCK := $(BIN_PATH)/cfs-fsck
 BIN_LIBSDK := $(BIN_PATH)/libsdk
 
 COMMON_SRC := build/build.sh Makefile
@@ -16,6 +17,7 @@ CLIENT_SRC := $(wildcard client/*.go client/fs/*.go sdk/*.go)
 CLIENT2_SRC := $(wildcard clientv2/*.go clientv2/fs/*.go sdk/*.go)
 AUTHTOOL_SRC := $(wildcard authtool/*.go)
 CLI_SRC := $(wildcard cli/*.go)
+FSCK_SRC := $(wildcard fsck/*.go fsck/cmd/*.go)
 LIBSDK_SRC := $(wildcard libsdk/*.go)
 
 RM := $(shell [ -x /bin/rm ] && echo "/bin/rm" || echo "/usr/bin/rm" )
@@ -25,8 +27,8 @@ default: all
 phony := all
 all: build
 
-phony += build server authtool client client2 cli
-build: server authtool client cli libsdk
+phony += build server authtool client client2 cli fsck
+build: server authtool client cli libsdk fsck
 
 server: $(BIN_SERVER)
 
@@ -37,6 +39,8 @@ client2: $(BIN_CLIENT2)
 authtool: $(BIN_AUTHTOOL)
 
 cli: $(BIN_CLI)
+
+fsck: $(BIN_FSCK)
 
 libsdk: $(BIN_LIBSDK)
 
@@ -54,6 +58,9 @@ $(BIN_AUTHTOOL): $(COMMON_SRC) $(AUTHTOOL_SRC)
 
 $(BIN_CLI): $(COMMON_SRC) $(CLI_SRC)
 	@build/build.sh cli
+
+$(BIN_FSCK): $(COMMON_SRC) $(FSCK_SRC)
+	@build/build.sh fsck
 
 $(BIN_LIBSDK): $(COMMON_SRC) $(LIBSDK_SRC)
 	@build/build.sh libsdk

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ BIN_LIBSDK := $(BIN_PATH)/libsdk
 
 COMMON_SRC := build/build.sh Makefile
 COMMON_SRC += $(wildcard storage/*.go util/*/*.go util/*.go repl/*.go raftstore/*.go proto/*.go)
-SERVER_SRC := $(wildcard cmd/*.go authnode/*.go datanode/*.go master/*.go metanode/*.go)
+SERVER_SRC := $(wildcard cmd/*.go authnode/*.go datanode/*.go master/*.go metanode/*.go objectnode/*.go)
 CLIENT_SRC := $(wildcard client/*.go client/fs/*.go sdk/*.go)
 CLIENT2_SRC := $(wildcard clientv2/*.go clientv2/fs/*.go sdk/*.go)
 AUTHTOOL_SRC := $(wildcard authtool/*.go)

--- a/build/build.sh
+++ b/build/build.sh
@@ -287,6 +287,14 @@ build_cli() {
     popd >/dev/null
 }
 
+build_fsck() {
+    pre_build
+    pushd $SrcPath >/dev/null
+    echo -n "build cfs-fsck      "
+    go build $MODFLAGS -ldflags "${LDFlags}" -o ${BuildBinPath}/cfs-fsck ${SrcPath}/fsck/*.go  && echo "success" || echo "failed"
+    popd >/dev/null
+}
+
 build_libsdk() {
     pre_build_server
     case `uname` in
@@ -348,6 +356,9 @@ case "$cmd" in
         ;;
     "cli")
         build_cli
+        ;;
+    "fsck")
+        build_fsck
         ;;
     "libsdk")
         build_libsdk

--- a/fsck/cmd/root.go
+++ b/fsck/cmd/root.go
@@ -15,17 +15,26 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 	"path"
 
+	"github.com/chubaofs/chubaofs/proto"
 	"github.com/spf13/cobra"
 )
 
 func NewRootCmd() *cobra.Command {
+	var optShowVersion bool
 	var c = &cobra.Command{
 		Use:   path.Base(os.Args[0]),
 		Short: "ChubaoFS fsck tool",
 		Args:  cobra.MinimumNArgs(0),
+		Run: func(cmd *cobra.Command, args []string) {
+			if optShowVersion {
+				_, _ = fmt.Fprintf(os.Stdout, proto.DumpVersion("FSCK"))
+				return
+			}
+		},
 	}
 
 	c.AddCommand(
@@ -34,9 +43,10 @@ func NewRootCmd() *cobra.Command {
 	)
 
 	c.PersistentFlags().StringVarP(&MasterAddr, "master", "m", "", "master addresses")
-	c.PersistentFlags().StringVarP(&VolName, "vol", "v", "", "volume name")
+	c.PersistentFlags().StringVarP(&VolName, "vol", "V", "", "volume name")
 	c.PersistentFlags().StringVarP(&InodesFile, "inode-list", "i", "", "inode list file")
 	c.PersistentFlags().StringVarP(&DensFile, "dentry-list", "d", "", "dentry list file")
 	c.PersistentFlags().StringVarP(&MetaPort, "mport", "", "", "prof port of metanode")
+	c.Flags().BoolVarP(&optShowVersion, "version", "v", false, "Show version information")
 	return c
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->
1. add `-v, --version` for fsck.
    To avoid conflicting with host fsck, the target is named to **cfs-fsck**.
    `-v` conflicts with `--vol`. Because `-v` is used for other cfs tools to show version, the short option of `--vol` is changed to `-V`. 
2. Update Makefile & build/build.sh to build fsck.
3. Update Makefile to track modification of objectnode code.
