### PR TITLE
fix: broken test case ftest01

### DIFF
--- a/sdk/data/stream/extent_cache.go
+++ b/sdk/data/stream/extent_cache.go
@@ -129,8 +129,10 @@ func (cache *ExtentCache) Append(ek *proto.ExtentKey, sync bool) (discardExtents
 	for _, key := range discard {
 		cache.root.Delete(key)
 		if key.PartitionId != 0 && key.ExtentId != 0 && (key.PartitionId != ek.PartitionId || key.ExtentId != ek.ExtentId || ek.ExtentOffset != key.ExtentOffset) {
-			cache.discard.ReplaceOrInsert(key)
-			//log.LogDebugf("ExtentCache Append add to discard: ino(%v) ek(%v) discard(%v)", cache.inode, ek, key)
+			if sync || (ek.PartitionId == 0 && ek.ExtentId == 0) {
+				cache.discard.ReplaceOrInsert(key)
+				//log.LogDebugf("ExtentCache Append add to discard: ino(%v) ek(%v) discard(%v)", cache.inode, ek, key)
+			}
 		}
 	}
 
@@ -150,7 +152,7 @@ func (cache *ExtentCache) Append(ek *proto.ExtentKey, sync bool) (discardExtents
 		cache.size = ekEnd
 	}
 
-	log.LogDebugf("ExtentCache Append: ino(%v) sync(%v) ek(%v) discard(%v)", cache.inode, sync, ek, discard)
+	log.LogDebugf("ExtentCache Append: ino(%v) sync(%v) ek(%v) local discard(%v) discardExtents(%v)", cache.inode, sync, ek, discard, discardExtents)
 	return
 }
 

--- a/sdk/meta/api.go
+++ b/sdk/meta/api.go
@@ -504,7 +504,7 @@ func (mw *MetaWrapper) AppendExtentKey(inode uint64, ek proto.ExtentKey, discard
 
 	status, err := mw.appendExtentKey(mp, inode, ek, discard)
 	if err != nil || status != statusOK {
-		log.LogErrorf("AppendExtentKey: inode(%v) ek(%v) discard(%v) err(%v) status(%v)", inode, ek, discard, err, status)
+		log.LogErrorf("AppendExtentKey: inode(%v) ek(%v) local discard(%v) err(%v) status(%v)", inode, ek, discard, err, status)
 		return statusToErrno(status)
 	}
 	log.LogDebugf("AppendExtentKey: ino(%v) ek(%v) discard(%v)", inode, ek, discard)


### PR DESCRIPTION
There might be stale discard extents records left in the stream writer.

When a file is truncated less than the discard extents, those discard
extents records are not removed from the stream writer's extent cache.
So next time, when you write to this file range, the client will get a
"conflict extents error", because the client is expecting to overwrite
and discard these extent keys, but actually they are no such extent keys
in meta node since they were already truncated.

Signed-off-by: Shuoran Liu <shuoranliu@gmail.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
