### PR TITLE
fix: currAddr of stream conn is empty

### DIFF
--- a/sdk/data/stream/stream_conn.go
+++ b/sdk/data/stream/stream_conn.go
@@ -48,19 +48,36 @@ var (
 )
 
 // NewStreamConn returns a new stream connection.
-func NewStreamConn(dp *wrapper.DataPartition, follower bool) *StreamConn {
+func NewStreamConn(dp *wrapper.DataPartition, follower bool) (sc *StreamConn) {
 	if !follower {
-		return &StreamConn{
+		sc = &StreamConn{
 			dp:       dp,
 			currAddr: dp.LeaderAddr,
 		}
+		return
 	}
 
+	defer func() {
+		if sc.currAddr == "" {
+			/*
+			 * If followerRead is enabled, and there is no preferred choice,
+			 * currAddr can be arbitrarily selected from the hosts.
+			 */
+			for _, h := range dp.Hosts {
+				if h != "" {
+					sc.currAddr = h
+					break
+				}
+			}
+		}
+	}()
+
 	if dp.ClientWrapper.NearRead() {
-		return &StreamConn{
+		sc = &StreamConn{
 			dp:       dp,
 			currAddr: getNearestHost(dp),
 		}
+		return
 	}
 
 	epoch := atomic.AddUint64(&dp.Epoch, 1)
@@ -72,10 +89,11 @@ func NewStreamConn(dp *wrapper.DataPartition, follower bool) *StreamConn {
 		currAddr = hosts[index]
 	}
 
-	return &StreamConn{
+	sc = &StreamConn{
 		dp:       dp,
 		currAddr: currAddr,
 	}
+	return
 }
 
 // String returns the string format of the stream connection.


### PR DESCRIPTION
If followerRead is enabled and there is no preferred currAddr, it can be
picked arbitrarily from one of the dp hosts.

This commit avoids IO error during the period when volume is just created
due to the empty currAddr.

Signed-off-by: Shuoran Liu <shuoranliu@gmail.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
