### PR TITLE
metanode: Export inode's Extents

### DIFF
--- a/metanode/inode.go
+++ b/metanode/inode.go
@@ -149,7 +149,37 @@ func (i *Inode) Copy() BtreeItem {
 func (i *Inode) MarshalToJSON() ([]byte, error) {
 	i.RLock()
 	defer i.RUnlock()
-	return json.Marshal(i)
+	return json.Marshal(struct {
+		Inode      uint64
+		Type       uint32
+		Uid        uint32
+		Gid        uint32
+		Size       uint64
+		Generation uint64
+		CreateTime int64
+		AccessTime int64
+		ModifyTime int64
+		LinkTarget []byte
+		NLink      uint32
+		Flag       int32
+		Reserved   uint64
+		Extents    []proto.ExtentKey
+	}{
+		i.Inode,
+		i.Type,
+		i.Uid,
+		i.Gid,
+		i.Size,
+		i.Generation,
+		i.CreateTime,
+		i.AccessTime,
+		i.ModifyTime,
+		i.LinkTarget[:],
+		i.NLink,
+		i.Flag,
+		i.Reserved,
+		i.Extents.eks[:],
+	})
 }
 
 // Marshal marshals the inode into a byte array.


### PR DESCRIPTION
Export inode's Extents for getAllInodes. In this way, fsck could get
extents information of inodes.

Signed-off-by: Sheng Yong <shengyong2021@gmail.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
