### PR TITLE
check size when read data from heartbeat port

### DIFF
--- a/vendor/github.com/tiglabs/raft/proto/codec.go
+++ b/vendor/github.com/tiglabs/raft/proto/codec.go
@@ -15,6 +15,7 @@ package proto
 
 import (
 	"encoding/binary"
+	"fmt"
 	"io"
 	"sort"
 
@@ -230,7 +231,13 @@ func (m *Message) Decode(r *util.BufferReader) error {
 	if datas, err = r.ReadFull(4); err != nil {
 		return err
 	}
-	if datas, err = r.ReadFull(int(binary.BigEndian.Uint32(datas))); err != nil {
+
+	cnt := int(binary.BigEndian.Uint32(datas))
+	if cnt > 256*1024*1024 {
+		return fmt.Errorf("msg len is too big, please check, %d", cnt)
+	}
+
+	if datas, err = r.ReadFull(cnt); err != nil {
 		return err
 	}
 

--- a/vendor/github.com/tiglabs/raft/transport_heartbeat.go
+++ b/vendor/github.com/tiglabs/raft/transport_heartbeat.go
@@ -20,6 +20,7 @@ import (
 
 	//"fmt"
 	//"github.com/tiglabs/raft/logger"
+	"github.com/tiglabs/raft/logger"
 	"github.com/tiglabs/raft/proto"
 	"github.com/tiglabs/raft/util"
 )
@@ -96,6 +97,7 @@ func (t *heartbeatTransport) handleConn(conn *util.ConnTimeout) {
 				return
 			default:
 				if msg, err := reciveMessage(bufRd); err != nil {
+					logger.Error("[heartbeatTransport] recive message from conn error", err.Error())
 					return
 				} else {
 					//logger.Debug(fmt.Sprintf("Recive %v from (%v)", msg.ToString(), conn.RemoteAddr()))


### PR DESCRIPTION
Signed-off-by: Victor1319 <834863182@qq.com>
**What this PR does / why we need it**:
add check for msg size when decode raft msg

**Which issue this PR fixes** : fixes #1168


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
