### PR TITLE
fix: makes AppendExtentKeyWithCheck request idempotent

### DIFF
--- a/metanode/partition_fsmop_inode.go
+++ b/metanode/partition_fsmop_inode.go
@@ -17,6 +17,7 @@ package metanode
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
 	"io"
 	"time"
 
@@ -242,10 +243,14 @@ func (mp *metaPartition) fsmAppendExtentsWithCheck(ino *Inode) (status uint8) {
 		discardExtentKey = eks[1:]
 	}
 	delExtents, status := ino2.AppendExtentWithCheck(eks[0], ino.ModifyTime, discardExtentKey)
-	if status == proto.OpOk {
+	if status == proto.OpOk && delExtents != nil && len(delExtents) > 0 {
 		mp.extDelCh <- delExtents
 	}
-	log.LogInfof("fsmAppendExtentWithCheck inode(%v) ek(%v) deleteExtents(%v) discardExtents(%v) status(%v)", ino2.Inode, eks[0], delExtents, discardExtentKey, status)
+	msg := fmt.Sprintf("fsmAppendExtentWithCheck inode(%v) ek(%v) server deleteExtents(%v) request discardExtents(%v) status(%v)", ino2.Inode, eks[0], delExtents, discardExtentKey, status)
+	if status != proto.OpOk {
+		log.LogError(msg)
+	}
+	log.LogInfo(msg)
 	return
 }
 

--- a/metanode/sorted_extents.go
+++ b/metanode/sorted_extents.go
@@ -160,6 +160,11 @@ func (se *SortedExtents) AppendWithCheck(ek proto.ExtentKey, discard []proto.Ext
 		break
 	}
 
+	// Makes the request idempotent, just in case client retries.
+	if len(invalidExtents) == 1 && invalidExtents[0] == ek {
+		return
+	}
+
 	// check if ek and key are the same extent file with size extented
 	deleteExtents = make([]proto.ExtentKey, 0, len(invalidExtents))
 	for _, key := range invalidExtents {


### PR DESCRIPTION
This commit makes AppendExtentKeyWithCheck request idempotent to avoid
conflict extents error when client retries.

For example,
    -> client writes [0, 100) to extent 25,
    -> send AppendExtentKeyWithCheck to metanode (offset: 0, size: 100, extentID:
25, discard extent: nil),
    -> client overwrites [0, 100) to extent 30,
    -> send AppendExtentKeyWithCheck to metanode (offset: 0, size:
100, extentID: 30, discard extent: 25),

Think about the following scenario: metanode managed to deal with the request,
but failed to respond to the client, and client retries with the same request.
Since AppendExtentKeyWithCheck is not idempotent, this will lead to
conflict extents error.

    -> client send AppendExtentKeyWithCheck to metanode (offset: 0,
size: 100, extentID: 30, discard extent: 25),
    -> when metanode is dealing with such request again, it expects no
discard extent, so it will respond a conflict extent error.

Reported-by: zcola <zhangrui90@163.com>
Signed-off-by: Shuoran Liu <shuoranliu@gmail.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
