### PR TITLE
fix: start tcp listen before starting raft

### DIFF
--- a/metanode/metanode.go
+++ b/metanode/metanode.go
@@ -125,6 +125,15 @@ func doStart(s common.Server, cfg *config.Config) (err error) {
 	if err = m.startRaftServer(); err != nil {
 		return
 	}
+	if err = m.newMetaManager(); err != nil {
+		return
+	}
+	if err = m.startServer(); err != nil {
+		return
+	}
+	if err = m.startSmuxServer(); err != nil {
+		return
+	}
 	if err = m.startMetaManager(); err != nil {
 		return
 	}
@@ -141,14 +150,6 @@ func doStart(s common.Server, cfg *config.Config) (err error) {
 	if err = m.checkLocalPartitionMatchWithMaster(); err != nil {
 		syslog.Println(err)
 		exporter.Warning(err.Error())
-		return
-	}
-
-	if err = m.startServer(); err != nil {
-		return
-	}
-
-	if err = m.startSmuxServer(); err != nil {
 		return
 	}
 
@@ -314,7 +315,7 @@ func (m *MetaNode) validConfig() (err error) {
 	return
 }
 
-func (m *MetaNode) startMetaManager() (err error) {
+func (m *MetaNode) newMetaManager() (err error) {
 	if _, err = os.Stat(m.metadataDir); err != nil {
 		if err = os.MkdirAll(m.metadataDir, 0755); err != nil {
 			return
@@ -328,6 +329,10 @@ func (m *MetaNode) startMetaManager() (err error) {
 		ZoneName:  m.zoneName,
 	}
 	m.metadataManager = NewMetadataManager(conf, m)
+	return
+}
+
+func (m *MetaNode) startMetaManager() (err error) {
 	if err = m.metadataManager.Start(); err == nil {
 		log.LogInfof("[startMetaManager] manager start finish.")
 	}


### PR DESCRIPTION
This commit starts the TCP listen port before starting raft. Because
otherwise there is a gap between raft started and TCP port listened. If
current node is selected as raft leader but TCP port listening is not
up, the whole partition will be unavailable due to "connnection reset
error".

Signed-off-by: Shuoran Liu <shuoranliu@gmail.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
