### PR TITLE
fix: remove redundant memcopy when reading raft snapshot

### DIFF
--- a/vendor/github.com/tiglabs/raft/raft_snapshot.go
+++ b/vendor/github.com/tiglabs/raft/raft_snapshot.go
@@ -68,7 +68,6 @@ func (r *snapshotReader) Next() ([]byte, error) {
 	}
 
 	// read size header
-	r.reader.Reset()
 	var buf []byte
 	if buf, r.err = r.reader.ReadFull(4); r.err != nil {
 		return nil, r.err
@@ -80,7 +79,6 @@ func (r *snapshotReader) Next() ([]byte, error) {
 	}
 
 	// read data
-	r.reader.Reset()
 	if buf, r.err = r.reader.ReadFull(int(size)); r.err != nil {
 		return nil, r.err
 	}


### PR DESCRIPTION
This commit removes the redundant memcopy when reading raft snapshot.
The redundant memcopy makes reading snapshot very slow which leads to
snapshot send failure.

Signed-off-by: leonrayang <chl696@sina.com>
Reviewd-by: Shuoran Liu <shuoranliu@gmail.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
