### PR TITLE
enhance: return response cache directly, not copy again

### DIFF
--- a/master/data_partition_map.go
+++ b/master/data_partition_map.go
@@ -17,11 +17,12 @@ package master
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/chubaofs/chubaofs/proto"
-	"github.com/chubaofs/chubaofs/util/log"
 	"runtime"
 	"sync"
 	"time"
+
+	"github.com/chubaofs/chubaofs/proto"
+	"github.com/chubaofs/chubaofs/util/log"
 )
 
 // DataPartitionMap stores all the data partitionMap
@@ -119,9 +120,8 @@ func (dpMap *DataPartitionMap) updateResponseCache(needsUpdate bool, minPartitio
 		dpMap.setDataPartitionResponseCache(body)
 		return
 	}
-	body = make([]byte, len(responseCache))
-	copy(body, responseCache)
 
+	body = responseCache
 	return
 }
 


### PR DESCRIPTION
Signed-off-by: Victor1319 <834863182@qq.com>

**What this PR does / why we need it**:
when dp's count is bigger, copy dpResponseCache frequently may produce too much garbage data, casue gc busy