### PR TITLE
check nil when get leader term info

### DIFF
--- a/raftstore/partition.go
+++ b/raftstore/partition.go
@@ -118,6 +118,10 @@ func (p *partition) Status() (status *PartitionStatus) {
 
 // LeaderTerm returns the current term of leader in the raft group.
 func (p *partition) LeaderTerm() (leaderID, term uint64) {
+	if p.raft == nil {
+		return
+	}
+
 	leaderID, term = p.raft.LeaderTerm(p.id)
 	return
 }


### PR DESCRIPTION
Signed-off-by: Victor1319 <834863182@qq.com>

**What this PR does / why we need it**:
when meta start, maybe raft is still not start, and startFreeList when check raftLeader with `LeaderTerm()`, so, need to add nil pointer check in `leaderTerm()` function
