### PR TITLE
add feature.del replica with force if decommission hang 

### DIFF
--- a/master/api_service.go
+++ b/master/api_service.go
@@ -469,14 +469,11 @@ func (m *Server) deleteMetaReplica(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	validate := true
 	var value string
 	if value = r.FormValue(forceKey); value != "" {
-		if force, err = strconv.ParseBool(value); err==nil && force {
-			validate = false
-		}
+		force, _ = strconv.ParseBool(value)
 	}
-	if err = m.cluster.deleteMetaReplica(mp, addr, validate); err != nil {
+	if err = m.cluster.deleteMetaReplica(mp, addr, true, force); err != nil {
 		sendErrReply(w, r, newErrHTTPReply(err))
 		return
 	}

--- a/master/api_service.go
+++ b/master/api_service.go
@@ -456,6 +456,7 @@ func (m *Server) deleteMetaReplica(w http.ResponseWriter, r *http.Request) {
 		mp          *MetaPartition
 		partitionID uint64
 		err         error
+		force       bool
 	)
 
 	if partitionID, addr, err = parseRequestToRemoveMetaReplica(r); err != nil {
@@ -468,7 +469,14 @@ func (m *Server) deleteMetaReplica(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err = m.cluster.deleteMetaReplica(mp, addr, true); err != nil {
+	validate := true
+	var value string
+	if value = r.FormValue(forceKey); value != "" {
+		if force, err = strconv.ParseBool(value); err==nil && force {
+			validate = false
+		}
+	}
+	if err = m.cluster.deleteMetaReplica(mp, addr, validate); err != nil {
 		sendErrReply(w, r, newErrHTTPReply(err))
 		return
 	}

--- a/master/const.go
+++ b/master/const.go
@@ -58,6 +58,7 @@ const (
 	rdOnlyKey               = "rdOnly"
 	srcAddrKey              = "srcAddr"
 	targetAddrKey           = "targetAddr"
+	forceKey                = "force"
 )
 
 const (

--- a/sdk/data/wrapper/wrapper.go
+++ b/sdk/data/wrapper/wrapper.go
@@ -137,7 +137,7 @@ func (w *Wrapper) getSimpleVolView() (err error) {
 }
 
 func (w *Wrapper) update() {
-	ticker := time.NewTicker(5 * time.Second)
+	ticker := time.NewTicker(time.Minute)
 	for {
 		select {
 		case <-ticker.C:


### PR DESCRIPTION
1. update.interval for client fetch data partition need enlarged because client count
2.enhance. meta replica force delete take effect and ignore status of missing and recovery
3.fix. meta node migration be recorded in badmetapartitions concurrently without lock which lead to mp id miss
4.add feature.del replica with force if decommission hang