### PR TITLE
fix: when kill metanode(mean while mp stoped firstly) and if apply sn…

### DIFF
--- a/metanode/partition_fsm.go
+++ b/metanode/partition_fsm.go
@@ -280,9 +280,14 @@ func (mp *metaPartition) ApplySnapshot(peers []raftproto.Peer, iter raftproto.Sn
 				extendTree:    mp.extendTree,
 				multipartTree: mp.multipartTree,
 			}
-			mp.extReset <- struct{}{}
-			log.LogDebugf("ApplySnapshot: finish with EOF: partitionID(%v) applyID(%v)", mp.config.PartitionId, mp.applyID)
-			return
+			select {
+			case mp.extReset <- struct{}{}:
+				log.LogDebugf("ApplySnapshot: finish with EOF: partitionID(%v) applyID(%v)", mp.config.PartitionId, mp.applyID)
+				return
+			case <-mp.stopC:
+				log.LogWarnf("ApplySnapshot: revice stop signal, exit now, partition(%d), applyId(%d)", mp.config.PartitionId, mp.applyID)
+				return
+			}
 		}
 		log.LogErrorf("ApplySnapshot: stop with error: partitionID(%v) err(%v)", mp.config.PartitionId, err)
 	}()


### PR DESCRIPTION
…apshot happen at the same time, snapshot will be block, causeing metanode can't be killed

Signed-off-by: Victor1319 <834863182@qq.com>

**What this PR does / why we need it**:
when mp apply snapshot and metanode kill operation happen at the same time, metanode will be killed failed, which can only `kill -9`