### PR TITLE
enhance: support disk, datanode, metanode decommission limit cnt partition

### DIFF
--- a/master/admin_task_manager.go
+++ b/master/admin_task_manager.go
@@ -20,11 +20,12 @@ import (
 	"time"
 
 	"fmt"
+	"net"
+
 	"github.com/chubaofs/chubaofs/proto"
 	"github.com/chubaofs/chubaofs/util"
 	"github.com/chubaofs/chubaofs/util/errors"
 	"github.com/chubaofs/chubaofs/util/log"
-	"net"
 )
 
 //const
@@ -195,11 +196,11 @@ func (sender *AdminTaskManager) sendAdminTask(task *proto.AdminTask, conn net.Co
 }
 
 func (sender *AdminTaskManager) syncSendAdminTask(task *proto.AdminTask) (packet *proto.Packet, err error) {
-	log.LogInfof("action[syncSendAdminTask],task[%v]", task)
 	packet, err = sender.buildPacket(task)
 	if err != nil {
 		return nil, errors.Trace(err, "action[syncSendAdminTask build packet failed,task:%v]", task.ID)
 	}
+	log.LogInfof("action[syncSendAdminTask],task[%s], op %s, reqId %d", task.ToString(), packet.GetOpMsg(), packet.GetReqID())
 	conn, err := sender.getConn()
 	if err != nil {
 		return nil, errors.Trace(err, "action[syncSendAdminTask get conn failed,task:%v]", task.ID)

--- a/master/cluster.go
+++ b/master/cluster.go
@@ -1192,11 +1192,13 @@ func (c *Cluster) migrateDataNode(srcAddr, targetAddr string, limit int) (err er
 		return fmt.Errorf("migrateDataNode no partition can migrate from [%s] to [%s]", srcAddr, targetAddr)
 	}
 
-	if limit <= 0 {
+	if limit <= 0 && targetAddr == "" {
+		limit = len(toBeOffLinePartitions)
+	} else if limit <= 0 {
 		limit = defaultMigrateDpCnt
 	}
 
-	if targetAddr == "" || limit > len(toBeOffLinePartitions) {
+	if limit > len(toBeOffLinePartitions) {
 		limit = len(toBeOffLinePartitions)
 	}
 
@@ -1735,11 +1737,13 @@ func (c *Cluster) migrateMetaNode(srcAddr, targetAddr string, limit int) (err er
 		return fmt.Errorf("migrateMataNode no partition can migrate from [%s] to [%s]", srcAddr, targetAddr)
 	}
 
-	if limit <= 0 {
+	if limit <= 0 && targetAddr == "" { // default all mps
+		limit = len(toBeOfflineMps)
+	} else if limit <= 0 {
 		limit = defaultMigrateMpCnt
 	}
 
-	if targetAddr == "" || limit > len(toBeOfflineMps) {
+	if limit > len(toBeOfflineMps) {
 		limit = len(toBeOfflineMps)
 	}
 

--- a/master/cluster_task.go
+++ b/master/cluster_task.go
@@ -613,7 +613,7 @@ func (c *Cluster) handleMetaNodeTaskResponse(nodeAddr string, task *proto.AdminT
 	if task == nil {
 		return
 	}
-	log.LogDebugf(fmt.Sprintf("action[handleMetaNodeTaskResponse] receive Task response:%v from %v", task.ID, nodeAddr))
+	log.LogDebugf(fmt.Sprintf("action[handleMetaNodeTaskResponse] receive Task response:%v from %v", task.IdString(), nodeAddr))
 	var (
 		metaNode *MetaNode
 	)

--- a/metanode/manager.go
+++ b/metanode/manager.go
@@ -84,7 +84,7 @@ func (m *metadataManager) getPacketLabels(p *Packet) (labels map[string]string) 
 
 	mp, err := m.getPartition(p.PartitionID)
 	if err != nil {
-		log.LogErrorf("[metaManager] getPacketLabels metric packet: %v, err: %v", p, err)
+		log.LogInfof("[metaManager] getPacketLabels metric packet: %v", p)
 		return
 	}
 
@@ -98,6 +98,8 @@ func (m *metadataManager) getPacketLabels(p *Packet) (labels map[string]string) 
 
 // HandleMetadataOperation handles the metadata operations.
 func (m *metadataManager) HandleMetadataOperation(conn net.Conn, p *Packet, remoteAddr string) (err error) {
+	log.LogInfof("HandleMetadataOperation input info op (%s), remote %s", p.String(), remoteAddr)
+
 	metric := exporter.NewTPCnt(p.GetOpMsg())
 	labels := m.getPacketLabels(p)
 	defer func() {

--- a/proto/admin_task.go
+++ b/proto/admin_task.go
@@ -51,6 +51,10 @@ func (t *AdminTask) ToString() (msg string) {
 	return
 }
 
+func (t *AdminTask) IdString() string {
+	return fmt.Sprintf("id:%s_sendTime_%d_createTime_%d", t.ID, t.SendTime, t.CreateTime)
+}
+
 // CheckTaskNeedSend checks if the task needs to be sent out.
 func (t *AdminTask) CheckTaskNeedSend() (needRetry bool) {
 	if (int)(t.SendCount) < MaxSendCount && time.Now().Unix()-t.SendTime > (int64)(ResponseInterval) {

--- a/vendor/github.com/tiglabs/raft/transport_replicate.go
+++ b/vendor/github.com/tiglabs/raft/transport_replicate.go
@@ -112,10 +112,12 @@ func (t *replicateTransport) sendSnapshot(m *proto.Message, rs *snapshotStatus) 
 		} else if logger.IsEnableWarn() {
 			logger.Warn("[Transport] %v send snapshot to %v successful.", m.ID, m.To)
 		}
+
+		logger.Info("[Transport] %v send snapshot to %v succ.", m.ID, m.To)
 	}()
 
 	if atomic.AddInt32(&t.curSnapshot, 1) > int32(t.config.MaxSnapConcurrency) {
-		err = fmt.Errorf("snapshot concurrency exceed the limit %v.", t.config.MaxSnapConcurrency)
+		err = fmt.Errorf("snapshot concurrency exceed the limit %v, now %d", t.config.MaxSnapConcurrency, t.curSnapshot)
 		return
 	}
 	if conn = getConn(m.To, Replicate, t.config.Resolver, 10*time.Minute, 1*time.Minute); conn == nil {


### PR DESCRIPTION
Signed-off-by: Victor1319 <834863182@qq.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
support decommission disk, datanode or metanode target limit cnt once, so it can be used to control decommission speed to avoid cluster too busy
eg:
```
decomMetaNode: curl 'masterIp:17010/metaNode/decommission?addr=meta:17210&count=2'
decomDataNode: curl 'masterIp:17010/dataNode/decommission?addr=dataIp:17310&count=2'
decomDisk: curl 'masterIp:17010/disk/decommission?addr=dataIp:17310&disk=/cfs/disk&count=2'
```
