### PR TITLE
enhance: support delete miss replicas

### DIFF
--- a/datanode/partition.go
+++ b/datanode/partition.go
@@ -348,6 +348,24 @@ func (dp *DataPartition) getReplicaLen() int {
 	return len(dp.replicas)
 }
 
+func (dp *DataPartition) needDeleteReplica(addr string) bool {
+	if dp.IsExsitReplica(addr) {
+		return true
+	}
+
+	if dp.config == nil {
+		return false
+	}
+
+	for _, h := range dp.config.Hosts {
+		if addr == h {
+			return true
+		}
+	}
+
+	return false
+}
+
 func (dp *DataPartition) IsExsitReplica(addr string) bool {
 	dp.replicasLock.RLock()
 	defer dp.replicasLock.RUnlock()
@@ -623,7 +641,7 @@ func (dp *DataPartition) updateReplicas(isForce bool) (err error) {
 	dp.isLeader = isLeader
 	dp.replicas = replicas
 	dp.intervalToUpdateReplicas = time.Now().Unix()
-	log.LogInfof(fmt.Sprintf("ActionUpdateReplicationHosts partiton(%v)", dp.partitionID))
+	log.LogInfof(fmt.Sprintf("ActionUpdateReplicationHosts partiton(%v), force(%v)", dp.partitionID, isForce))
 
 	return
 }

--- a/datanode/wrap_operator.go
+++ b/datanode/wrap_operator.go
@@ -997,9 +997,8 @@ func (s *DataNode) handlePacketToRemoveDataPartitionRaftMember(p *repl.Packet) {
 	}
 	p.PartitionID = req.PartitionId
 
-	if !dp.IsExsitReplica(req.RemovePeer.Addr) {
-		log.LogInfof("recive MasterCommand: %v "+
-			"RemoveRaftPeer(%v) has not exsit", string(reqData), req.RemovePeer.Addr)
+	if !dp.needDeleteReplica(req.RemovePeer.Addr) {
+		log.LogWarnf("handlePacketToRemoveDataPartitionRaftMember, req(%s) RemoveRaftPeer(%s) is not exist", string(reqData), req.RemovePeer.Addr)
 		return
 	}
 

--- a/master/data_partition.go
+++ b/master/data_partition.go
@@ -164,9 +164,17 @@ func (partition *DataPartition) resetTaskID(t *proto.AdminTask) {
 }
 
 // Check if there is a replica missing or not.
-func (partition *DataPartition) hasMissingOneReplica(replicaNum int) (err error) {
+func (partition *DataPartition) hasMissingOneReplica(addr string, replicaNum int) (err error) {
 	hostNum := len(partition.Replicas)
-	if hostNum <= replicaNum-1 {
+
+	inReplicas := false
+	for _, rep := range partition.Replicas {
+		if addr == rep.Addr {
+			inReplicas = true
+		}
+	}
+
+	if hostNum <= replicaNum-1 && inReplicas {
 		log.LogError(fmt.Sprintf("action[%v],partitionID:%v,err:%v",
 			"hasMissingOneReplica", partition.PartitionID, proto.ErrHasOneMissingReplica))
 		err = proto.ErrHasOneMissingReplica
@@ -187,7 +195,7 @@ func (partition *DataPartition) canBeOffLine(offlineAddr string) (err error) {
 		}
 	}
 
-	if len(otherLiveReplicas) < int(partition.ReplicaNum/2) {
+	if len(otherLiveReplicas) < int(partition.ReplicaNum/2+1) {
 		msg = fmt.Sprintf(msg+" err:%v  liveReplicas:%v ", proto.ErrCannotBeOffLine, len(liveReplicas))
 		log.LogError(msg)
 		err = fmt.Errorf(msg)
@@ -435,7 +443,7 @@ func (partition *DataPartition) liveReplicas(timeOutSec int64) (replicas []*Data
 	replicas = make([]*DataReplica, 0)
 	for i := 0; i < len(partition.Replicas); i++ {
 		replica := partition.Replicas[i]
-		if replica.isLive(timeOutSec) == true && partition.hasHost(replica.Addr) == true {
+		if replica.isLive(timeOutSec) && partition.hasHost(replica.Addr) {
 			replicas = append(replicas, replica)
 		}
 	}

--- a/master/data_replica.go
+++ b/master/data_replica.go
@@ -47,8 +47,8 @@ func (replica *DataReplica) isMissing(interval int64) (isMissing bool) {
 }
 
 func (replica *DataReplica) isLive(timeOutSec int64) (isAvailable bool) {
-	if replica.dataNode.isActive == true && replica.Status != proto.Unavailable &&
-		replica.isActive(timeOutSec) == true {
+	if replica.dataNode.isActive && replica.Status != proto.Unavailable &&
+		replica.isActive(timeOutSec) {
 		isAvailable = true
 	}
 

--- a/master/meta_partition.go
+++ b/master/meta_partition.go
@@ -370,10 +370,18 @@ func (mp *MetaPartition) canBeOffline(nodeAddr string, replicaNum int) (err erro
 	return
 }
 
-// Check if there is a replica missing or not.
-func (mp *MetaPartition) hasMissingOneReplica(replicaNum int) (err error) {
+// Check if there is a replica missing or not, exclude addr
+func (mp *MetaPartition) hasMissingOneReplica(addr string, replicaNum int) (err error) {
+	inReplicas := false
+	for _, rep := range mp.Replicas {
+		if rep.Addr == addr {
+			inReplicas = true
+			break
+		}
+	}
+
 	hostNum := len(mp.Replicas)
-	if hostNum <= replicaNum-1 {
+	if hostNum <= replicaNum-1 && inReplicas {
 		log.LogError(fmt.Sprintf("action[%v],partitionID:%v,err:%v",
 			"hasMissingOneReplica", mp.PartitionID, proto.ErrHasOneMissingReplica))
 		err = proto.ErrHasOneMissingReplica

--- a/metanode/manager.go
+++ b/metanode/manager.go
@@ -104,6 +104,8 @@ func (m *metadataManager) HandleMetadataOperation(conn net.Conn, p *Packet, remo
 		metric.SetWithLabels(err, labels)
 	}()
 
+	log.LogDebugf("HandleMetadataOperation input info op (%s), remote %s", p.GetOpMsg(), remoteAddr)
+
 	switch p.Opcode {
 	case proto.OpMetaCreateInode:
 		err = m.opCreateInode(conn, p, remoteAddr)


### PR DESCRIPTION
Signed-off-by: Victor1319 <834863182@qq.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
After the metanode & datanode goes down, once the master change leader, it's not ok to decommission replicas in the metanode because of the limit thant, once replicas is less than hosts num, can't decommission replicas again

