### PR TITLE
fix: handle `bytes=0-` correctly in objectnode

### DIFF
--- a/objectnode/api_handler_object.go
+++ b/objectnode/api_handler_object.go
@@ -206,7 +206,7 @@ func (o *ObjectNode) getObjectHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// validate and fix range
-	if isRangeRead && rangeUpper > uint64(fileInfo.Size)-1 {
+	if isRangeRead && rangeUpper > uint64(fileInfo.Size)-1 || rangeUpper == 0 {
 		rangeUpper = uint64(fileInfo.Size) - 1
 	}
 
@@ -308,11 +308,7 @@ func (o *ObjectNode) getObjectHandler(w http.ResponseWriter, r *http.Request) {
 	var offset = rangeLower
 	var size = uint64(fileInfo.Size)
 	if isRangeRead || len(partNumber) > 0 {
-		if rangeUpper == 0 {
-			size = uint64(fileInfo.Size) - rangeLower
-		} else {
-			size = rangeUpper - rangeLower + 1
-		}
+		size = rangeUpper - rangeLower + 1
 	}
 	err = vol.ReadFile(param.Object(), w, offset, size)
 	if err == syscall.ENOENT {


### PR DESCRIPTION
Some clients (e.g. docker registry) send a get to fetch the whole file
by specifying `bytes=0-` as the range. In this case, ChubaoFS will set
the range to 0-0 and the `Content-Length` to 1 (upper - lower + 1). It
will then error out when writing the object, since it will write more
than the specified `Content-Length`.

As a simple fix, we can treat a rangeUpper of 0 the same as max, which
should result in correct behavior.

**Special notes for your reviewer**: I'm not able to build chubaofs locally (errors while building rocksdb), so I haven't been able to test this change.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
objectnode: handle `Range: bytes=0-` correctly
```
