### PR TITLE
fix: use dp.Hosts if NearHosts is empty

### DIFF
--- a/sdk/data/stream/stream_conn.go
+++ b/sdk/data/stream/stream_conn.go
@@ -193,6 +193,9 @@ func sortByStatus(dp *wrapper.DataPartition, selectAll bool) (hosts []string) {
 	var dpHosts []string
 	if dp.ClientWrapper.FollowerRead() && dp.ClientWrapper.NearRead() {
 		dpHosts = dp.NearHosts
+		if len(dpHosts) == 0 {
+			dpHosts = dp.Hosts
+		}
 	} else {
 		dpHosts = dp.Hosts
 	}


### PR DESCRIPTION
This commit uses dp.Hosts if NearHosts is empty so all the hosts get a
chance to be retried to avoid client IO error.

Signed-off-by: Shuoran Liu <shuoranliu@gmail.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
