### PR TITLE
fix: remove 5 GB left limit for disk to create datapartition

### DIFF
--- a/datanode/server.go
+++ b/datanode/server.go
@@ -58,8 +58,7 @@ const (
 	DefaultRaftDir          = "raft"
 	DefaultRaftLogsToRetain = 10 // Count of raft logs per data partition
 	DefaultDiskMaxErr       = 1
-	DefaultDiskRetainMin    = 5 * util.GB  // GB
-	DefaultDiskRetainMax    = 30 * util.GB // GB
+	DefaultDiskRetainMin    = 5 * util.GB // GB
 )
 
 const (

--- a/datanode/space_manager.go
+++ b/datanode/space_manager.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/chubaofs/chubaofs/proto"
 	"github.com/chubaofs/chubaofs/raftstore"
-	"github.com/chubaofs/chubaofs/util"
 	"github.com/chubaofs/chubaofs/util/log"
 )
 
@@ -229,7 +228,7 @@ func (manager *SpaceManager) minPartitionCnt() (d *Disk) {
 	)
 	minWeight = math.MaxFloat64
 	for _, disk := range manager.disks {
-		if disk.Available <= 5*util.GB || disk.Status != proto.ReadWrite {
+		if disk.Status != proto.ReadWrite {
 			continue
 		}
 		diskWeight := disk.getSelectWeight()
@@ -241,7 +240,7 @@ func (manager *SpaceManager) minPartitionCnt() (d *Disk) {
 	if minWeightDisk == nil {
 		return
 	}
-	if minWeightDisk.Available <= 5*util.GB || minWeightDisk.Status != proto.ReadWrite {
+	if minWeightDisk.Status != proto.ReadWrite {
 		return
 	}
 	d = minWeightDisk


### PR DESCRIPTION
Signed-off-by: Victor1319 <834863182@qq.com>

**What this PR does / why we need it**:

Avoide failure of creation of datapartition when disk's left size less than 5G