### PR TITLE
fuse: Tell parent error message if error occurs in child

### DIFF
--- a/client/fuse.go
+++ b/client/fuse.go
@@ -355,6 +355,7 @@ func main() {
 			log.LogErrorf("Failed to tell old cfs-client to suspend: %v\n", err)
 			syslog.Printf("Error: Failed to tell old cfs-client to suspend: %v\n", err)
 			log.LogFlush()
+			_ = daemonize.SignalOutcome(err)
 			os.Exit(1)
 		}
 	}


### PR DESCRIPTION
daemonize uses `SignalOutcome' to pass child's error to parent.

Signed-off-by: Sheng Yong <shengyong2021@gmail.com>