### PR TITLE
client: Flush streamer's handler instead of marking it closed

### DIFF
--- a/sdk/data/stream/extent_handler.go
+++ b/sdk/data/stream/extent_handler.go
@@ -131,7 +131,8 @@ func NewExtentHandler(stream *Streamer, offset int, storeMode int, size int) *Ex
 
 // String returns the string format of the extent handler.
 func (eh *ExtentHandler) String() string {
-	return fmt.Sprintf("ExtentHandler{ID(%v)Inode(%v)FileOffset(%v)StoreMode(%v)}", eh.id, eh.inode, eh.fileOffset, eh.storeMode)
+	return fmt.Sprintf("ExtentHandler{ID(%v)Inode(%v)FileOffset(%v)StoreMode(%v)Status(%v)}",
+		eh.id, eh.inode, eh.fileOffset, eh.storeMode, eh.status)
 }
 
 func (eh *ExtentHandler) write(data []byte, offset, size int, direct bool) (ek *proto.ExtentKey, err error) {
@@ -139,7 +140,7 @@ func (eh *ExtentHandler) write(data []byte, offset, size int, direct bool) (ek *
 
 	status := eh.getStatus()
 	if status >= ExtentStatusClosed {
-		err = errors.New(fmt.Sprintf("ExtentHandler Write: Full or Recover, status(%v)", status))
+		err = errors.NewErrorf("ExtentHandler Write: Full or Recover eh(%v) key(%v)", eh, eh.key)
 		return
 	}
 
@@ -155,8 +156,7 @@ func (eh *ExtentHandler) write(data []byte, offset, size int, direct bool) (ek *
 	// In this case, the caller should try to create a new extent handler.
 	if eh.fileOffset+eh.size != offset || eh.size+size > util.ExtentSize ||
 		(eh.storeMode == proto.TinyExtentType && eh.size+size > blksize) {
-
-		err = errors.New("ExtentHandler: full or incontinuous")
+		err = errors.NewErrorf("ExtentHandler Write: full or incontinuous eh(%v) key(%v)", eh, eh.key)
 		return
 	}
 

--- a/sdk/data/stream/stream_writer.go
+++ b/sdk/data/stream/stream_writer.go
@@ -444,7 +444,8 @@ func (s *Streamer) doWrite(data []byte, offset, size int, direct bool) (total in
 			break
 		}
 
-		log.LogDebugf("doWrite handler write failed so close open handler: ino(%v) offset(%v) size(%v) storeMode(%v)", s.inode, offset, size, storeMode)
+		log.LogDebugf("doWrite handler write failed so close open handler: ino(%v) offset(%v) size(%v) storeMode(%v) err(%v)",
+			s.inode, offset, size, storeMode, err)
 		s.closeOpenHandler()
 	}
 
@@ -524,7 +525,9 @@ func (s *Streamer) traverse() (err error) {
 				log.LogDebugf("Streamer traverse skipped: traversed(%v) eh(%v)", s.traversed, eh)
 				continue
 			}
-			eh.setClosed()
+			if err = eh.flush(); err != nil {
+				log.LogWarnf("Streamer traverse flush: eh(%v) err(%v)", eh, err)
+			}
 		}
 		log.LogDebugf("Streamer traverse end: eh(%v)", eh)
 	}


### PR DESCRIPTION
traverse() marks streamer's ExtentHandler as closed periodically to
write cached data back. However, if the current handler is closed,
new write request has to create a new one and that prevents writing
data to the previous extent continously if possible.

Instead of marking ExtentHandler closed, this patch flush handler
directly.

Signed-off-by: Sheng Yong <shengyong2021@gmail.com>