### PR TITLE
change: append volume to client log path

### DIFF
--- a/client/fuse.go
+++ b/client/fuse.go
@@ -79,6 +79,8 @@ const (
 	DefaultIP            = "127.0.0.1"
 	DynamicUDSNameFormat = "/tmp/ChubaoFS-fdstore-%v.sock"
 	DefaultUDSName       = "/tmp/ChubaoFS-fdstore.sock"
+
+	DefaultLogPath = "/var/log/chubaofs"
 )
 
 var (
@@ -284,7 +286,7 @@ func main() {
 	}
 
 	level := parseLogLevel(opt.Loglvl)
-	_, err = log.InitLog(opt.Logpath, LoggerPrefix, level, nil)
+	_, err = log.InitLog(opt.Logpath, opt.Volname, level, nil)
 	if err != nil {
 		err = errors.NewErrorf("Init log dir fail: %v\n", err)
 		fmt.Println(err)
@@ -293,7 +295,7 @@ func main() {
 	}
 	defer log.LogFlush()
 
-	outputFilePath := path.Join(opt.Logpath, LoggerPrefix, LoggerOutput)
+	outputFilePath := path.Join(opt.Logpath, opt.Volname, LoggerOutput)
 	outputFile, err := os.OpenFile(outputFilePath, os.O_CREATE|os.O_RDWR|os.O_APPEND, 0666)
 	if err != nil {
 		err = errors.NewErrorf("Open output file failed: %v\n", err)
@@ -591,7 +593,11 @@ func parseMountOption(cfg *config.Config) (*proto.MountOptions, error) {
 	opt.Volname = GlobalMountOptions[proto.VolName].GetString()
 	opt.Owner = GlobalMountOptions[proto.Owner].GetString()
 	opt.Master = GlobalMountOptions[proto.Master].GetString()
-	opt.Logpath = GlobalMountOptions[proto.LogDir].GetString()
+	logPath := GlobalMountOptions[proto.LogDir].GetString()
+	if len(logPath) == 0 {
+		logPath = DefaultLogPath
+	}
+	opt.Logpath = path.Join(logPath, LoggerPrefix)
 	opt.Loglvl = GlobalMountOptions[proto.LogLevel].GetString()
 	opt.Profport = GlobalMountOptions[proto.ProfPort].GetString()
 	opt.IcacheTimeout = GlobalMountOptions[proto.IcacheTimeout].GetInt64()


### PR DESCRIPTION
When multi client mount on one machine, one client log will be
overwritten by another. To avoid this, we should separate the log path
of each client. To implement this, i attach volume name to the logDir in
the config file.

Besides, previous default logDir is root. I set the default logDir to
/var/log

Signed-off-by: wanglei469 <wanglei469@ke.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
